### PR TITLE
Fix Incorrect Payment Due Status in MyGroups

### DIFF
--- a/apps/web/components/my-groups.tsx
+++ b/apps/web/components/my-groups.tsx
@@ -149,7 +149,7 @@ export function MyGroups() {
               <div className="space-y-1 flex-1">
                 <div className="flex items-center gap-2">
                   <h4 className="font-medium text-foreground">{group.name}</h4>
-                  <StatusBadge status={group.status} />
+                  <StatusBadge status={group.status} label={group.statusLabel} />
                 </div>
                 <p className="text-sm text-muted-foreground">
                   {typeof group.contribution === "number" &&
@@ -168,6 +168,12 @@ export function MyGroups() {
                     : "-"}{" "}
                   • Position #{group.myPosition >= 1 ? group.myPosition : "-"}
                 </p>
+                {typeof group.roundDeadlineTimestamp === "number" &&
+                group.roundDeadlineTimestamp > 0 ? (
+                  <p className="text-xs text-muted-foreground">
+                    Next payment due: {new Date(group.roundDeadlineTimestamp * 1000).toLocaleDateString()}
+                  </p>
+                ) : null}
                 <div className="flex items-center gap-2 pt-1">
                   <Progress value={group.progress} className="h-1.5 flex-1" />
                   <span className="text-xs text-muted-foreground">
@@ -194,22 +200,28 @@ export function MyGroups() {
   );
 }
 
-function StatusBadge({ status }: { status: string }) {
+function StatusBadge({ status, label }: { status: string; label?: string }) {
   const variants = {
     paid: "bg-primary/10 text-primary border-primary/20",
-    pending: "bg-warning/10 text-warning-dark border-warning/20",
-    received: "bg-stellar/10 text-stellar border-stellar/20",
-    defaulted: "bg-destructive/10 text-destructive border-destructive/20",
+    dueSoon: "bg-warning/10 text-warning-dark border-warning/20",
     overdue: "bg-destructive/10 text-destructive border-destructive/20",
+    defaulted: "bg-destructive/10 text-destructive border-destructive/20",
+    waiting: "bg-muted/10 text-muted-foreground border-muted/20",
+    active: "bg-muted/10 text-muted-foreground border-muted/20",
+    received: "bg-stellar/10 text-stellar border-stellar/20",
+    paused: "bg-muted/10 text-muted-foreground border-muted/20",
     completed: "bg-muted/10 text-muted-foreground border-muted/20",
   };
 
   const labels = {
     paid: "✅ Paid",
-    pending: "⏳ Payment Due",
-    received: "🎉 Received",
-    defaulted: "❌ Defaulted",
+    dueSoon: "⏳ Payment Due Soon",
     overdue: "⚠️ Overdue",
+    defaulted: "❌ Defaulted",
+    waiting: "⏳ Waiting to Start",
+    active: "Active",
+    received: "🎉 Received",
+    paused: "⏸ Paused",
     completed: "✓ Completed",
   };
 
@@ -218,7 +230,7 @@ function StatusBadge({ status }: { status: string }) {
       variant="outline"
       className={variants[status as keyof typeof variants]}
     >
-      {labels[status as keyof typeof labels]}
+      {label || labels[status as keyof typeof labels]}
     </Badge>
   );
 }

--- a/apps/web/hooks/useUserGroups.ts
+++ b/apps/web/hooks/useUserGroups.ts
@@ -1,9 +1,8 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useWallet } from '@/hooks/use-wallet'
-import { useRegistryContract } from '@/context/registryContract'
-import { useSavingsContract } from '@/context/savingsContract'
-import { GroupInfo } from '@/context/registryContract'
-import { Group, Member, MemberStatus } from '@/context/savingsContract'
+import { useRegistryContract, GroupInfo } from '@/context/registryContract'
+import { useSavingsContract, MemberStatus} from '@/context/savingsContract'
+
 
 export interface GroupDisplayData {
   id: string
@@ -12,7 +11,10 @@ export interface GroupDisplayData {
   totalMembers: number
   currentRound: number
   myPosition: number
-  status: 'paid' | 'pending' | 'received' | 'defaulted' | 'overdue' | 'completed'
+  status: 'paid' | 'active' | 'dueSoon' | 'waiting' | 'received' | 'defaulted' | 'overdue' | 'completed' | 'paused'
+  statusLabel: string
+  roundDeadlineTimestamp?: number
+  daysUntilDeadline?: number
   progress: number
   groupId: string
   contractAddress: string
@@ -26,25 +28,88 @@ export function useUserGroups() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const mapMemberStatus = (memberStatus: MemberStatus, groupStatus: string): 'paid' | 'pending' | 'received' | 'defaulted' | 'overdue' | 'completed' => {
+  const getRoundDeadlineSeconds = async (groupId: string, currentRound: number): Promise<number | null> => {
+    if (typeof currentRound !== 'number' || isNaN(currentRound) || currentRound < 0) return null
+    try {
+      const deadline = await savings.getRoundDeadlineByGroup(groupId, currentRound)
+      const deadlineNum = Number(deadline)
+      if (Number.isFinite(deadlineNum) && deadlineNum > 0) return deadlineNum
+      return null
+    } catch (e) {
+      console.warn('Failed to fetch round deadline', { groupId, currentRound, e })
+      return null
+    }
+  }
+
+  const deriveStatus = async (p: {
+    memberStatus: MemberStatus
+    groupStatus: string
+    groupId: string
+    currentRound: number
+  }): Promise<Pick<GroupDisplayData, 'status' | 'statusLabel' | 'roundDeadlineTimestamp' | 'daysUntilDeadline'>> => {
+    const { memberStatus, groupStatus, groupId, currentRound } = p
+
+    if (memberStatus === 'PaidCurrentRound') {
+      return { status: 'paid', statusLabel: '✅ Paid' }
+    }
+    if (memberStatus === 'ReceivedPayout') {
+      return { status: 'received', statusLabel: '🎉 Received Payout' }
+    }
+    if (memberStatus === 'Defaulted') {
+      return { status: 'defaulted', statusLabel: '❌ Defaulted' }
+    }
+
     if (groupStatus === 'Completed') {
-      return 'completed'
+      return { status: 'completed', statusLabel: '✓ Completed' }
     }
-    
-    switch (memberStatus) {
-      case 'PaidCurrentRound':
-        return 'paid'
-      case 'Active':
-        return 'pending'
-      case 'ReceivedPayout':
-        return 'received'
-      case 'Defaulted':
-        return 'defaulted'
-      case 'Overdue':
-        return 'overdue'
-      default:
-        return 'pending'
+    if (groupStatus === 'Paused') {
+      return { status: 'paused', statusLabel: '⏸ Paused' }
     }
+    if (groupStatus === 'Open') {
+      return { status: 'waiting', statusLabel: '⏳ Waiting to Start' }
+    }
+
+    if (memberStatus === 'Overdue') {
+      return { status: 'overdue', statusLabel: '⚠️ Overdue' }
+    }
+
+    if (groupStatus === 'Active' && memberStatus === 'Active') {
+      const deadlineSec = await getRoundDeadlineSeconds(groupId, currentRound)
+      if (!deadlineSec) {
+        return { status: 'active', statusLabel: 'Active' }
+      }
+
+      const nowSec = Math.floor(Date.now() / 1000)
+      const diffSec = deadlineSec - nowSec
+      const daysUntilDeadline = Math.ceil(diffSec / (24 * 60 * 60))
+
+      if (daysUntilDeadline < 0) {
+        return {
+          status: 'overdue',
+          statusLabel: '⚠️ Overdue',
+          roundDeadlineTimestamp: deadlineSec,
+          daysUntilDeadline,
+        }
+      }
+
+      if (daysUntilDeadline <= 3) {
+        return {
+          status: 'dueSoon',
+          statusLabel: daysUntilDeadline === 0 ? '⏳ Due today' : '⏳ Payment Due Soon',
+          roundDeadlineTimestamp: deadlineSec,
+          daysUntilDeadline,
+        }
+      }
+
+      return {
+        status: 'active',
+        statusLabel: `⏳ Due in ${daysUntilDeadline} days`,
+        roundDeadlineTimestamp: deadlineSec,
+        daysUntilDeadline,
+      }
+    }
+
+    return { status: 'active', statusLabel: 'Active' }
   }
 
   const calculateProgress = (currentRound: number, totalMembers: number): number => {
@@ -94,6 +159,13 @@ export function useUserGroups() {
 
           const member = await savings.getMemberByGroup(publicKey, groupInfo.group_id)
 
+          const derived = await deriveStatus({
+            memberStatus: member.status,
+            groupStatus: savingsGroup.status,
+            groupId: groupInfo.group_id,
+            currentRound: savingsGroup.currentRound,
+          })
+
           const rawPosition = member.joinOrder + 1
           const rawProgress = calculateProgress(savingsGroup.currentRound, savingsGroup.totalMembers)
 
@@ -104,7 +176,10 @@ export function useUserGroups() {
             totalMembers: savingsGroup.totalMembers,
             currentRound: savingsGroup.currentRound,
             myPosition: safePosition(rawPosition) ?? 0,
-            status: mapMemberStatus(member.status, savingsGroup.status),
+            status: derived.status,
+            statusLabel: derived.statusLabel,
+            roundDeadlineTimestamp: derived.roundDeadlineTimestamp,
+            daysUntilDeadline: derived.daysUntilDeadline,
             progress: safeProgress(rawProgress),
             groupId: groupInfo.group_id,
             contractAddress: contractAddress
@@ -120,12 +195,15 @@ export function useUserGroups() {
 
       const sortedGroups = validGroups.sort((a, b) => {
         const statusPriority = {
+          'dueSoon': 1,
           'overdue': 1,
           'defaulted': 1,
-          'pending': 2,
-          'paid': 3,
-          'received': 4,
-          'completed': 5
+          'waiting': 2,
+          'active': 3,
+          'paid': 4,
+          'received': 5,
+          'paused': 6,
+          'completed': 7
         }
         return (statusPriority[a.status] || 6) - (statusPriority[b.status] || 6)
       })


### PR DESCRIPTION
closes #31 
1) useUserGroups now derives status correctly
File: apps/web/hooks/useUserGroups.ts

Uses both group + member state instead of mapping Active -> Payment Due.
Fetches the current round deadline via savings.getRoundDeadlineByGroup(groupId, currentRound).
Computes daysUntilDeadline and sets:
Open group -> waiting / ⏳ Waiting to Start
Active group + Active member
deadline passed -> overdue / ⚠️ Overdue
deadline in <= 3 days -> dueSoon / ⏳ Payment Due Soon (or ⏳ Due today)
deadline in > 3 days -> active / ⏳ Due in X days
Paid/Received/Defaulted take priority as you specified
Completed / Paused handled as well
It also now returns:

statusLabel
roundDeadlineTimestamp
daysUntilDeadline
So the UI can show accurate wording and the actual deadline date.

2) MyGroups badge now uses the derived label + supports new variants
File: apps/web/components/my-groups.tsx

StatusBadge now accepts label and renders label || fallbackLabel.
Added/updated variants for:
dueSoon, waiting, active, paused, etc.
The list item now displays:
Next payment due: <date> when roundDeadlineTimestamp is available
This directly addresses the “false urgency” problem.