### PR TITLE
fix: remove amount param from contribute and clean up contract contex…

### DIFF
--- a/apps/web/components/create-group-form.tsx
+++ b/apps/web/components/create-group-form.tsx
@@ -1,11 +1,11 @@
-"use client";
+'use client'
 
-import { useState } from "react";
-import { Wallet, AlertCircle, Loader2 } from "lucide-react";
+import { useState } from 'react'
+import { Wallet, AlertCircle, Loader2, CheckCircle2 } from 'lucide-react'
 
-import { useWallet } from "@/hooks/use-wallet";
-import { useSavingsContract, type Frequency } from "@/context/savingsContract";
-import { useRegistryContract } from "@/context/registryContract";
+import { useWallet } from '@/hooks/use-wallet'
+import { useSavingsContract, type Frequency } from '@/context/savingsContract'
+import { useRegistryContract } from '@/context/registryContract'
 
 import {
   Card,
@@ -13,151 +13,167 @@ import {
   CardDescription,
   CardHeader,
   CardTitle,
-} from "@/components/ui/card";
-
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-
+} from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@/components/ui/select";
+} from '@/components/ui/select'
+import { Switch } from '@/components/ui/switch'
+import { Alert, AlertDescription } from '@/components/ui/alert'
 
-import { Switch } from "@/components/ui/switch";
-import { Textarea } from "@/components/ui/textarea";
-import { Alert, AlertDescription } from "@/components/ui/alert";
+// Tracks which step of the two-step process we're on
+// so the user always knows what's happening
+type CreationStep =
+  | 'idle'
+  | 'creating'   // Step 1: savings contract
+  | 'registering' // Step 2: registry contract
+  | 'done'
+  | 'error'
 
 export function CreateGroupForm() {
-  const { isConnected, connect, publicKey } = useWallet();
-  const contract = useSavingsContract();
-  const registryContract = useRegistryContract();
+  const { isConnected, connect, publicKey } = useWallet()
+  const contract = useSavingsContract()
+  const registryContract = useRegistryContract()
 
-  const [isPrivate, setIsPrivate] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState(false);
+  const [step, setStep] = useState<CreationStep>('idle')
+  const [error, setError] = useState<string | null>(null)
 
   // Form state
-  const [groupName, setGroupName] = useState("");
-  const [description, setDescription] = useState("");
-  const [contributionAmount, setContributionAmount] = useState("");
-  const [totalMembers, setTotalMembers] = useState("");
-  const [frequency, setFrequency] = useState<Frequency>("Monthly");
-  const [startDate, setStartDate] = useState("");
+  const [groupName, setGroupName] = useState('')
+  const [contributionAmount, setContributionAmount] = useState('')
+  const [totalMembers, setTotalMembers] = useState('')
+  const [frequency, setFrequency] = useState<Frequency>('Monthly')
+  const [startDate, setStartDate] = useState('')
+  const [isPrivate, setIsPrivate] = useState(false)
+
+  const isLoading = step === 'creating' || step === 'registering'
+
+  const resetForm = () => {
+    setGroupName('')
+    setContributionAmount('')
+    setTotalMembers('')
+    setStartDate('')
+    setIsPrivate(false)
+    setFrequency('Monthly')
+  }
 
   const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setError(null);
-    setSuccess(false);
+    e.preventDefault()
+    setError(null)
+    setStep('idle')
 
     if (!isConnected || !publicKey) {
-      setError("Please connect your wallet first");
-      return;
+      setError('Please connect your wallet first')
+      return
     }
 
-    const amount = parseFloat(contributionAmount);
+    // ── Validation ──────────────────────────────────────────
+    const amount = parseFloat(contributionAmount)
     if (isNaN(amount) || amount < 10) {
-      setError("Contribution amount must be at least 10 XLM");
-      return;
+      setError('Contribution amount must be at least 10 XLM')
+      return
     }
 
-    const members = parseInt(totalMembers);
+    const members = parseInt(totalMembers)
     if (isNaN(members) || members < 3 || members > 20) {
-      setError("Number of members must be between 3 and 20");
-      return;
+      setError('Number of members must be between 3 and 20')
+      return
     }
 
     if (!startDate) {
-      setError("Please select a start date");
-      return;
+      setError('Please select a start date')
+      return
     }
 
-    const startTimestamp = new Date(startDate).getTime() / 1000;
-    const currentTime = Math.floor(Date.now() / 1000);
+    const startTimestamp = Math.floor(new Date(startDate).getTime() / 1000)
+    const currentTime = Math.floor(Date.now() / 1000)
 
     if (startTimestamp <= currentTime) {
-      setError("Start date must be in the future");
-      return;
+      setError('Start date must be in the future')
+      return
     }
 
-    const bufferedTimestamp = startTimestamp + 3600;
-
-    setIsLoading(true);
+    // ── Step 1: Create group on savings contract ─────────────
+    const contributionStroops = BigInt(Math.floor(amount * 10_000_000))
+    const groupId = `grp${Date.now()}${Math.random().toString(36).substring(2, 8)}`
 
     try {
-      const contributionStroops = BigInt(Math.floor(amount * 10_000_000));
+      setStep('creating')
 
-      const groupId = `grp${Date.now()}${Math.random().toString(36).substring(2, 8)}`;
-
-      console.log("Creating group with params:", {
-        groupId,
-        name: groupName,
-        contributionAmount: contributionStroops.toString(),
-        totalMembers: members,
-        frequency,
-        startTimestamp: BigInt(Math.floor(bufferedTimestamp)),
-        isPublic: !isPrivate,
-      });
-
-      const result = await contract.createGroup({
+      await contract.createGroup({
         groupId,
         name: groupName,
         contributionAmount: contributionStroops,
         totalMembers: members,
         frequency,
-        startTimestamp: BigInt(Math.floor(startTimestamp)),
+        startTimestamp: BigInt(startTimestamp),
         isPublic: !isPrivate,
-      });
+      })
+    } catch (err: any) {
+      console.error('Group creation failed:', err)
+      setError(err.message || 'Failed to create group on-chain. Please try again.')
+      setStep('error')
+      return
+    }
 
-      console.log("Group created successfully:", result);
+    // ── Step 2: Register group in registry contract ──────────
+    // This step is critical — if it fails, the group exists on-chain
+    // but won't appear in discovery. We retry once before giving up.
+    try {
+      setStep('registering')
+
+      await registryContract.registerGroup({
+        contractAddress: process.env.NEXT_PUBLIC_SAVINGS_CONTRACT_ID!,
+        groupId,
+        name: groupName,
+        admin: publicKey,
+        isPublic: !isPrivate,
+        totalMembers: members,
+      })
+    } catch (firstErr) {
+      console.warn('Registry registration failed on first attempt, retrying...', firstErr)
+
+      // One automatic retry after 2 seconds
+      await new Promise((resolve) => setTimeout(resolve, 2000))
 
       try {
         await registryContract.registerGroup({
-          contractAddress: process.env.NEXT_PUBLIC_CONTRACT_ID!,
+          contractAddress: process.env.NEXT_PUBLIC_SAVINGS_CONTRACT_ID!,
           groupId,
           name: groupName,
           admin: publicKey,
           isPublic: !isPrivate,
           totalMembers: members,
-        });
-
-        console.log("Group registered in Registry contract");
-      } catch (registryErr) {
-        console.error("Failed to register in Registry:", registryErr);
+        })
+      } catch (retryErr: any) {
+        console.error('Registry registration failed after retry:', retryErr)
+        // Group IS created on-chain — don't hide that from the user.
+        // Show a partial success message so they know what happened.
         setError(
-          "Group created but failed to register. Please contact support."
-        );
-        return;
+          `Your group was created on-chain (ID: ${groupId}) but could not be registered for discovery. ` +
+          `Please contact support with this group ID so we can manually register it.`
+        )
+        setStep('error')
+        return
       }
-
-      setSuccess(true);
-
-      setGroupName("");
-      setDescription("");
-      setContributionAmount("");
-      setTotalMembers("");
-      setStartDate("");
-      setIsPrivate(false);
-
-      setTimeout(() => {
-        window.location.href = "/dashboard";
-      }, 5000);
-    } catch (err: any) {
-      console.error("Error creating group:", err);
-      setError(err.message || "Failed to create group. Please try again.");
-    } finally {
-      setIsLoading(false);
     }
-  };
 
-  /* ================================
-     WALLET NOT CONNECTED STATE
-  ================================= */
+    // ── Done ─────────────────────────────────────────────────
+    setStep('done')
+    resetForm()
 
+    setTimeout(() => {
+      window.location.href = '/dashboard'
+    }, 3000)
+  }
+
+  // ── Wallet not connected ──────────────────────────────────
   if (!isConnected) {
     return (
       <Card className="border-border bg-card">
@@ -165,22 +181,18 @@ export function CreateGroupForm() {
           <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-primary/10">
             <Wallet className="h-8 w-8 text-primary" />
           </div>
-
           <CardTitle>Connect Your Wallet</CardTitle>
-
           <CardDescription>
             You must connect a Stellar wallet to create a savings group
           </CardDescription>
         </CardHeader>
-
         <CardContent className="flex flex-col items-center gap-4">
           <Button size="lg" onClick={connect}>
             <Wallet className="mr-2 h-5 w-5" />
             Connect Wallet
           </Button>
-
-          <p className="text-sm text-muted-foreground text-center">
-            Don&apos;t have a wallet?{" "}
+          <p className="text-center text-sm text-muted-foreground">
+            Don&apos;t have a wallet?{' '}
             <a
               href="https://www.freighter.app"
               target="_blank"
@@ -192,20 +204,16 @@ export function CreateGroupForm() {
           </p>
         </CardContent>
       </Card>
-    );
+    )
   }
 
-  /* ================================
-     CONNECTED STATE
-  ================================= */
-
+  // ── Connected ─────────────────────────────────────────────
   return (
     <Card className="border-border bg-card">
       <CardHeader>
         <CardTitle>Group Details</CardTitle>
-
         <CardDescription>
-          Connected wallet:{" "}
+          Connected wallet:{' '}
           <span className="font-mono text-sm">
             {publicKey?.slice(0, 6)}...{publicKey?.slice(-4)}
           </span>
@@ -214,19 +222,34 @@ export function CreateGroupForm() {
 
       <CardContent>
         <form onSubmit={handleSubmit} className="space-y-6">
-          {success && (
-            <Alert className="bg-green-50 border-green-200">
-              <AlertCircle className="h-4 w-4 text-green-600" />
+
+          {/* Success */}
+          {step === 'done' && (
+            <Alert className="border-green-200 bg-green-50">
+              <CheckCircle2 className="h-4 w-4 text-green-600" />
               <AlertDescription className="text-green-800">
-                Group created successfully! Redirecting to dashboard...
+                Group created and registered successfully! Redirecting to dashboard...
               </AlertDescription>
             </Alert>
           )}
 
+          {/* Error */}
           {error && (
             <Alert variant="destructive">
               <AlertCircle className="h-4 w-4" />
               <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          {/* Step indicator while loading */}
+          {isLoading && (
+            <Alert>
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <AlertDescription>
+                {step === 'creating'
+                  ? 'Step 1 of 2: Creating your group on-chain...'
+                  : 'Step 2 of 2: Registering group for discovery...'}
+              </AlertDescription>
             </Alert>
           )}
 
@@ -245,20 +268,7 @@ export function CreateGroupForm() {
             <p className="text-xs text-muted-foreground">Max 50 characters</p>
           </div>
 
-          {/* Description */}
-          <div className="space-y-2">
-            <Label htmlFor="description">Description (Optional)</Label>
-            <Textarea
-              id="description"
-              placeholder="Describe your savings group..."
-              rows={3}
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              disabled={isLoading}
-            />
-          </div>
-
-          {/* Contribution */}
+          {/* Contribution Amount */}
           <div className="space-y-2">
             <Label htmlFor="amount">Contribution Amount (XLM)</Label>
             <Input
@@ -275,7 +285,7 @@ export function CreateGroupForm() {
             <p className="text-xs text-muted-foreground">Minimum 10 XLM</p>
           </div>
 
-          {/* Members */}
+          {/* Number of Members */}
           <div className="space-y-2">
             <Label htmlFor="members">Number of Members</Label>
             <Input
@@ -289,9 +299,7 @@ export function CreateGroupForm() {
               required
               disabled={isLoading}
             />
-            <p className="text-xs text-muted-foreground">
-              Between 3 and 20 members
-            </p>
+            <p className="text-xs text-muted-foreground">Between 3 and 20 members</p>
           </div>
 
           {/* Frequency */}
@@ -321,22 +329,18 @@ export function CreateGroupForm() {
               type="date"
               value={startDate}
               onChange={(e) => setStartDate(e.target.value)}
-              min={new Date().toISOString().split("T")[0]}
+              min={new Date().toISOString().split('T')[0]}
               required
               disabled={isLoading}
             />
-            <p className="text-xs text-muted-foreground">
-              Must be a future date
-            </p>
+            <p className="text-xs text-muted-foreground">Must be a future date</p>
           </div>
 
           {/* Privacy */}
           <div className="flex items-center justify-between rounded-lg border p-4">
             <div>
               <Label>Private Group</Label>
-              <p className="text-sm text-muted-foreground">
-                Only invited members can join
-              </p>
+              <p className="text-sm text-muted-foreground">Only invited members can join</p>
             </div>
             <Switch
               checked={isPrivate}
@@ -349,8 +353,8 @@ export function CreateGroupForm() {
           <Alert>
             <AlertCircle className="h-4 w-4" />
             <AlertDescription>
-              A 2% platform fee and Stellar network fees will apply. You will be
-              prompted to sign the transaction in Freighter.
+              A 2% platform fee and Stellar network fees will apply. You will be prompted
+              to sign the transaction in Freighter.
             </AlertDescription>
           </Alert>
 
@@ -358,19 +362,19 @@ export function CreateGroupForm() {
             type="submit"
             size="lg"
             className="w-full"
-            disabled={isLoading || !contract.isReady}
+            disabled={isLoading || !contract.isReady || step === 'done'}
           >
             {isLoading ? (
               <>
                 <Loader2 className="mr-2 h-5 w-5 animate-spin" />
-                Creating Group...
+                {step === 'creating' ? 'Creating Group...' : 'Registering...'}
               </>
             ) : (
-              "Create Group"
+              'Create Group'
             )}
           </Button>
         </form>
       </CardContent>
     </Card>
-  );
+  )
 }

--- a/apps/web/components/group-header.tsx
+++ b/apps/web/components/group-header.tsx
@@ -1,15 +1,23 @@
-import type React from "react"
-import { Card, CardContent } from "@/components/ui/card"
-import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
-import { Progress } from "@/components/ui/progress"
-import { Users, Calendar, Coins, Clock, ExternalLink } from "lucide-react"
+'use client'
+
+import type React from 'react'
+import { useState } from 'react'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Progress } from '@/components/ui/progress'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Users, Calendar, Coins, Clock, ExternalLink, Loader2, AlertCircle, CheckCircle2 } from 'lucide-react'
+import { useSavingsContract } from '@/context/savingsContract'
+import { useWallet } from '@/hooks/use-wallet'
+import { useJoinGroup } from '@/hooks/use-join'
 
 interface GroupHeaderProps {
   group: {
+    groupId: string           // required — used for contract calls
     name: string
     description: string
-    contributionAmount: number
+    contributionAmount: number // in XLM (already converted from stroops)
     frequency: string
     totalMembers: number
     currentMembers: number
@@ -21,17 +29,52 @@ interface GroupHeaderProps {
     isMember: boolean
     hasPaidThisRound: boolean
   }
+  onActionSuccess?: () => void  // optional callback to trigger data refetch in parent
 }
 
-export function GroupHeader({ group }: GroupHeaderProps) {
+export function GroupHeader({ group, onActionSuccess }: GroupHeaderProps) {
+  const { publicKey } = useWallet()
+  const savings = useSavingsContract()
+  const { join, isLoading: isJoining, step: joinStep, error: joinError, reset: resetJoin } = useJoinGroup()
+
+  const [isContributing, setIsContributing] = useState(false)
+  const [contributeError, setContributeError] = useState<string | null>(null)
+  const [contributeSuccess, setContributeSuccess] = useState(false)
+
   const progress = (group.currentRound / group.totalMembers) * 100
+
+  const handleJoin = async () => {
+    await join(group.groupId)
+    if (joinStep !== 'error') {
+      onActionSuccess?.()
+    }
+  }
+
+  const handleContribute = async () => {
+    if (!publicKey) return
+    setContributeError(null)
+    setContributeSuccess(false)
+    setIsContributing(true)
+
+    try {
+      await savings.contribute(group.groupId)
+      setContributeSuccess(true)
+      onActionSuccess?.()
+    } catch (err: any) {
+      console.error('Contribution failed:', err)
+      setContributeError(err.message || 'Contribution failed. Please try again.')
+    } finally {
+      setIsContributing(false)
+    }
+  }
 
   return (
     <Card className="border-border bg-card">
       <CardContent className="p-6">
         <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+
           {/* Info */}
-          <div className="space-y-4 flex-1">
+          <div className="flex-1 space-y-4">
             <div className="flex items-start gap-3">
               <h1 className="text-2xl font-bold text-foreground">{group.name}</h1>
               <Badge variant="outline" className="bg-stellar/10 text-stellar border-stellar/20">
@@ -60,7 +103,12 @@ export function GroupHeader({ group }: GroupHeaderProps) {
                 value={`${group.currentRound}/${group.totalMembers}`}
                 subtext={`${progress.toFixed(0)}% complete`}
               />
-              <StatItem icon={Clock} label="Pool Balance" value={`${group.totalPool} XLM`} subtext="Next payout soon" />
+              <StatItem
+                icon={Clock}
+                label="Pool Balance"
+                value={`${group.totalPool} XLM`}
+                subtext="Next payout soon"
+              />
             </div>
 
             {/* Progress */}
@@ -75,21 +123,81 @@ export function GroupHeader({ group }: GroupHeaderProps) {
 
           {/* Actions */}
           <div className="flex flex-col gap-3 lg:w-64">
+
+            {/* Feedback alerts */}
+            {joinError && (
+              <Alert variant="destructive">
+                <AlertCircle className="h-4 w-4" />
+                <AlertDescription className="text-xs">{joinError}</AlertDescription>
+              </Alert>
+            )}
+            {joinStep === 'done' && (
+              <Alert className="border-green-200 bg-green-50">
+                <CheckCircle2 className="h-4 w-4 text-green-600" />
+                <AlertDescription className="text-xs text-green-800">
+                  You have joined the group!
+                </AlertDescription>
+              </Alert>
+            )}
+            {contributeError && (
+              <Alert variant="destructive">
+                <AlertCircle className="h-4 w-4" />
+                <AlertDescription className="text-xs">{contributeError}</AlertDescription>
+              </Alert>
+            )}
+            {contributeSuccess && (
+              <Alert className="border-green-200 bg-green-50">
+                <CheckCircle2 className="h-4 w-4 text-green-600" />
+                <AlertDescription className="text-xs text-green-800">
+                  Contribution recorded!
+                </AlertDescription>
+              </Alert>
+            )}
+
             {group.isMember ? (
               <>
                 <Button
                   className="bg-primary text-primary-foreground hover:bg-primary-dark"
-                  disabled={group.hasPaidThisRound}
+                  disabled={group.hasPaidThisRound || isContributing || group.status !== 'Active'}
+                  onClick={handleContribute}
                 >
-                  {group.hasPaidThisRound ? "✅ Paid This Round" : "Make Contribution"}
+                  {isContributing ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Submitting...
+                    </>
+                  ) : group.hasPaidThisRound ? (
+                    '✅ Paid This Round'
+                  ) : (
+                    'Make Contribution'
+                  )}
                 </Button>
-                <Button variant="outline" className="border-border bg-transparent">
-                  <ExternalLink className="mr-2 h-4 w-4" />
-                  View on Explorer
+                <Button variant="outline" className="border-border bg-transparent" asChild>
+                  <a
+                    href={`https://stellar.expert/explorer/testnet/contract/${process.env.NEXT_PUBLIC_SAVINGS_CONTRACT_ID}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <ExternalLink className="mr-2 h-4 w-4" />
+                    View on Explorer
+                  </a>
                 </Button>
               </>
             ) : (
-              <Button className="bg-primary text-primary-foreground hover:bg-primary-dark">Join This Group</Button>
+              <Button
+                className="bg-primary text-primary-foreground hover:bg-primary-dark"
+                disabled={isJoining || group.status !== 'Open' || joinStep === 'done'}
+                onClick={handleJoin}
+              >
+                {isJoining ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    {joinStep === 'joining' ? 'Joining...' : 'Registering...'}
+                  </>
+                ) : (
+                  'Join This Group'
+                )}
+              </Button>
             )}
           </div>
         </div>

--- a/apps/web/context/savingsContract.tsx
+++ b/apps/web/context/savingsContract.tsx
@@ -9,7 +9,7 @@ import {
   TransactionBuilder,
   BASE_FEE,
   rpc,
-  Account, 
+  Account,
 } from '@stellar/stellar-sdk'
 import { useWallet } from '@/hooks/use-wallet'
 import { SOROBAN_NETWORK_PASSPHRASE, SOROBAN_RPC_URL } from '@/config/walletConfig'
@@ -19,50 +19,72 @@ export type MemberStatus = 'Active' | 'PaidCurrentRound' | 'Overdue' | 'Defaulte
 export type Frequency = 'Weekly' | 'BiWeekly' | 'Monthly'
 
 export interface Group {
-  groupId: string; admin: string; name: string; contributionAmount: bigint;
-  totalMembers: number; frequency: Frequency; startTimestamp: bigint;
-  status: GroupStatus; isPublic: boolean; currentRound: number; platformFeePercent: number;
+  groupId: string
+  admin: string
+  name: string
+  contributionAmount: bigint
+  totalMembers: number
+  frequency: Frequency
+  startTimestamp: bigint
+  status: GroupStatus
+  isPublic: boolean
+  currentRound: number
+  platformFeePercent: number
 }
 
 export interface Member {
-  address: string; joinTimestamp: bigint; joinOrder: number; status: MemberStatus;
-  totalContributed: bigint; hasReceivedPayout: boolean; payoutRound: number;
+  address: string
+  joinTimestamp: bigint
+  joinOrder: number
+  status: MemberStatus
+  totalContributed: bigint
+  hasReceivedPayout: boolean
+  payoutRound: number
 }
 
-export interface Contribution { member: string; amount: bigint; round: number; timestamp: bigint; }
-export interface Payout { recipient: string; amount: bigint; round: number; timestamp: bigint; }
+export interface Contribution {
+  member: string
+  amount: bigint
+  round: number
+  timestamp: bigint
+}
+
+export interface Payout {
+  recipient: string
+  amount: bigint
+  round: number
+  timestamp: bigint
+}
 
 export interface CreateGroupParams {
-  groupId: string; name: string; contributionAmount: bigint;
-  totalMembers: number; frequency: Frequency; startTimestamp: bigint; isPublic: boolean;
+  groupId: string
+  name: string
+  contributionAmount: bigint
+  totalMembers: number
+  frequency: Frequency
+  startTimestamp: bigint
+  isPublic: boolean
 }
 
 export interface SavingsContractContextValue {
-  // Single group methods (existing signature - for backward compatibility)
-  getGroup: () => Promise<Group>
-  getMember: (address: string) => Promise<Member>
-  getMembers: () => Promise<Member[]>
-  getRoundContributions: (round: number) => Promise<Contribution[]>
-  getRoundPayouts: (round: number) => Promise<Payout[]>
-  getRoundDeadline: (round: number) => Promise<bigint>
-  
-  // Multi-group methods (new - for MyGroups integration)
+  // Multi-group methods (canonical API)
   getGroupById: (groupId: string) => Promise<Group>
   getMemberByGroup: (address: string, groupId: string) => Promise<Member>
   getMembersByGroup: (groupId: string) => Promise<Member[]>
   getRoundContributionsByGroup: (groupId: string, round: number) => Promise<Contribution[]>
   getRoundPayoutsByGroup: (groupId: string, round: number) => Promise<Payout[]>
   getRoundDeadlineByGroup: (groupId: string, round: number) => Promise<bigint>
-  
+
   // User and discovery methods
   getUserGroups: (address: string) => Promise<string[]>
   getAllGroups: () => Promise<string[]>
-  
+
   // Transaction methods
   createGroup: (params: CreateGroupParams) => Promise<rpc.Api.GetSuccessfulTransactionResponse>
-  joinGroup: (groupId?: string) => Promise<rpc.Api.GetSuccessfulTransactionResponse>
-  contribute: (amount: bigint, groupId?: string) => Promise<rpc.Api.GetSuccessfulTransactionResponse>
-  
+  joinGroup: (groupId: string) => Promise<rpc.Api.GetSuccessfulTransactionResponse>
+  // NOTE: contribute does NOT take an amount — the amount is fixed on-chain at group creation
+  contribute: (groupId: string) => Promise<rpc.Api.GetSuccessfulTransactionResponse>
+
   // Contract info
   contractId: string
   isReady: boolean
@@ -77,439 +99,315 @@ export function SavingsContractProvider({ children }: { children: React.ReactNod
   const [error, setError] = React.useState<string | null>(null)
 
   const isReady = !!contractId && !!SOROBAN_RPC_URL
-  
-  const server = React.useMemo(() => new rpc.Server(SOROBAN_RPC_URL, { allowHttp: true }), [])
 
-  const simulateCall = React.useCallback(async (method: string, ...args: xdr.ScVal[]): Promise<xdr.ScVal> => {
-    const source = wallet.publicKey || "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
-    const contract = new Contract(contractId)
-    
-    const sourceAccount = new Account(source, "0")
+  const server = React.useMemo(
+    () => new rpc.Server(SOROBAN_RPC_URL, { allowHttp: true }),
+    []
+  )
 
-    const tx = new TransactionBuilder(sourceAccount, {
-      fee: BASE_FEE,
-      networkPassphrase: SOROBAN_NETWORK_PASSPHRASE,
-    })
-      .addOperation(contract.call(method, ...args))
-      .setTimeout(30)
-      .build()
+  const simulateCall = React.useCallback(
+    async (method: string, ...args: xdr.ScVal[]): Promise<xdr.ScVal> => {
+      const source =
+        wallet.publicKey || 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF'
+      const contract = new Contract(contractId)
+      const sourceAccount = new Account(source, '0')
 
-    const result = await server.simulateTransaction(tx)
-    if (rpc.Api.isSimulationError(result)) throw new Error(result.error)
-    if (!result.result) throw new Error('Simulation result empty')
-    return result.result.retval
-  }, [wallet.publicKey, contractId, server])
+      const tx = new TransactionBuilder(sourceAccount, {
+        fee: BASE_FEE,
+        networkPassphrase: SOROBAN_NETWORK_PASSPHRASE,
+      })
+        .addOperation(contract.call(method, ...args))
+        .setTimeout(30)
+        .build()
 
-  const sendTransaction = React.useCallback(async (method: string, ...args: xdr.ScVal[]) => {
-    if (!wallet.publicKey) throw new Error('Wallet not connected');
-    
-    const contract = new Contract(contractId);
-    const account = await server.getAccount(wallet.publicKey);
+      const result = await server.simulateTransaction(tx)
+      if (rpc.Api.isSimulationError(result)) throw new Error(result.error)
+      if (!result.result) throw new Error('Simulation result empty')
+      return result.result.retval
+    },
+    [wallet.publicKey, contractId, server]
+  )
 
-    let tx = new TransactionBuilder(account, {
-      fee: BASE_FEE,
-      networkPassphrase: SOROBAN_NETWORK_PASSPHRASE,
-    })
-      .addOperation(contract.call(method, ...args))
-      .setTimeout(30)
-      .build();
+  const sendTransaction = React.useCallback(
+    async (method: string, ...args: xdr.ScVal[]) => {
+      if (!wallet.publicKey) throw new Error('Wallet not connected')
 
-    tx = await server.prepareTransaction(tx);
-    const signedXdr = await wallet.signTransaction(tx.toXDR());
-    
-    const transactionToSubmit = TransactionBuilder.fromXDR(signedXdr, SOROBAN_NETWORK_PASSPHRASE);
-    const response = await server.sendTransaction(transactionToSubmit);
+      const contract = new Contract(contractId)
+      const account = await server.getAccount(wallet.publicKey)
 
-    if (response.status !== 'PENDING') {
-      throw new Error(`Transaction failed: ${response.status}`);
-    }
+      let tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: SOROBAN_NETWORK_PASSPHRASE,
+      })
+        .addOperation(contract.call(method, ...args))
+        .setTimeout(30)
+        .build()
 
-    // Wait for confirmation
-    let getResponse = await server.getTransaction(response.hash);
-    
-    while (getResponse.status === rpc.Api.GetTransactionStatus.NOT_FOUND) {
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      getResponse = await server.getTransaction(response.hash);
-    }
+      tx = await server.prepareTransaction(tx)
+      const signedXdr = await wallet.signTransaction(tx.toXDR())
 
-    if (getResponse.status === rpc.Api.GetTransactionStatus.SUCCESS) {
-      return getResponse;
-    }
+      const transactionToSubmit = TransactionBuilder.fromXDR(
+        signedXdr,
+        SOROBAN_NETWORK_PASSPHRASE
+      )
+      const response = await server.sendTransaction(transactionToSubmit)
 
-    console.error('Transaction failed with response:', getResponse);
-    
-    // Try to extract detailed error from the response
-    let errorMessage = `Transaction failed: ${getResponse.status}`;
-    
-    if ('resultXdr' in getResponse) {
-      try {
-        console.error('Transaction result:', getResponse.resultXdr);
-        errorMessage += `\nResult: ${JSON.stringify(getResponse.resultXdr, null, 2)}`;
-      } catch (e) {
-        console.error('Could not parse result XDR:', e);
+      if (response.status !== 'PENDING') {
+        throw new Error(`Transaction failed: ${response.status}`)
       }
-    }
 
-    throw new Error(errorMessage);
-  }, [wallet, contractId, server])
+      let getResponse = await server.getTransaction(response.hash)
+      while (getResponse.status === rpc.Api.GetTransactionStatus.NOT_FOUND) {
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+        getResponse = await server.getTransaction(response.hash)
+      }
 
-  // ===== EXISTING SINGLE-GROUP METHODS (for backward compatibility) =====
-  
-  const getGroup = React.useCallback(async (): Promise<Group> => {
-    try {
-      const res = await simulateCall('get_group')
-      const n = scValToNative(res)
-      return { 
-        ...n, 
-        contributionAmount: BigInt(n.contribution_amount || n.contributionAmount || 0), 
-        startTimestamp: BigInt(n.start_timestamp || n.startTimestamp || 0),
-        currentRound: n.current_round ?? n.currentRound ?? 0,
-        totalMembers: n.total_members ?? n.totalMembers ?? 0
+      if (getResponse.status === rpc.Api.GetTransactionStatus.SUCCESS) {
+        return getResponse
       }
-    } catch (err: any) {
-      // Try with empty args if the contract expects no parameters
-      if (err.message?.includes('missing argument')) {
-        // Contract might expect a groupId parameter - this indicates we need to use multi-group version
-        throw new Error('Contract requires groupId parameter. Use getGroupById instead.')
-      }
-      throw err
-    }
-  }, [simulateCall])
 
-  const getMember = React.useCallback(async (address: string): Promise<Member> => {
-    try {
-      const res = await simulateCall('get_member', nativeToScVal(address, { type: 'address' }))
-      const n = scValToNative(res)
-      return { 
-        ...n, 
-        joinTimestamp: BigInt(n.join_timestamp || n.joinTimestamp || 0), 
-        totalContributed: BigInt(n.total_contributed || n.totalContributed || 0),
-        joinOrder: n.join_order ?? n.joinOrder ?? 0
+      let errorMessage = `Transaction failed: ${getResponse.status}`
+      if ('resultXdr' in getResponse) {
+        try {
+          errorMessage += `\nResult: ${JSON.stringify(getResponse.resultXdr, null, 2)}`
+        } catch (e) {
+          console.error('Could not parse result XDR:', e)
+        }
       }
-    } catch (err: any) {
-      if (err.message?.includes('missing argument')) {
-        throw new Error('Contract requires groupId parameter. Use getMemberByGroup instead.')
-      }
-      throw err
-    }
-  }, [simulateCall])
 
-  const getMembers = React.useCallback(async () => {
-    try {
-      const res = await simulateCall('get_members')
-      const addrs = scValToNative(res) as string[]
-      return Promise.all(addrs.map(a => getMember(a)))
-    } catch (err: any) {
-      if (err.message?.includes('missing argument')) {
-        throw new Error('Contract requires groupId parameter. Use getMembersByGroup instead.')
-      }
-      throw err
-    }
-  }, [simulateCall, getMember])
+      throw new Error(errorMessage)
+    },
+    [wallet, contractId, server]
+  )
 
-  const getRoundContributions = React.useCallback(async (round: number) => {
-    try {
-      const res = await simulateCall('get_round_contributions', nativeToScVal(round, { type: 'u32' }))
-      return (scValToNative(res) as any[]).map(c => ({ 
-        ...c, 
-        amount: BigInt(c.amount || 0), 
-        timestamp: BigInt(c.timestamp || 0) 
-      }))
-    } catch (err: any) {
-      if (err.message?.includes('missing argument')) {
-        throw new Error('Contract requires groupId parameter. Use getRoundContributionsByGroup instead.')
-      }
-      throw err
-    }
-  }, [simulateCall])
+  // ===== READ METHODS =====
 
-  const getRoundPayouts = React.useCallback(async (round: number) => {
-    try {
-      const res = await simulateCall('get_round_payouts', nativeToScVal(round, { type: 'u32' }))
-      return (scValToNative(res) as any[]).map(p => ({ 
-        ...p, 
-        amount: BigInt(p.amount || 0), 
-        timestamp: BigInt(p.timestamp || 0) 
-      }))
-    } catch (err: any) {
-      if (err.message?.includes('missing argument')) {
-        throw new Error('Contract requires groupId parameter. Use getRoundPayoutsByGroup instead.')
-      }
-      throw err
-    }
-  }, [simulateCall])
-
-  const getRoundDeadline = React.useCallback(async (round: number) => {
-    try {
-      const res = await simulateCall('get_round_deadline', nativeToScVal(round, { type: 'u32' }))
-      return BigInt(scValToNative(res))
-    } catch (err: any) {
-      if (err.message?.includes('missing argument')) {
-        throw new Error('Contract requires groupId parameter. Use getRoundDeadlineByGroup instead.')
-      }
-      throw err
-    }
-  }, [simulateCall])
-
-  // ===== NEW MULTI-GROUP METHODS (for MyGroups integration) =====
-  
-  const getGroupById = React.useCallback(async (groupId: string): Promise<Group> => {
-    try {
-      // Try with groupId parameter first
+  const getGroupById = React.useCallback(
+    async (groupId: string): Promise<Group> => {
       const res = await simulateCall('get_group', nativeToScVal(groupId, { type: 'string' }))
       const n = scValToNative(res)
-      return { 
-        ...n, 
-        contributionAmount: BigInt(n.contribution_amount || n.contributionAmount || 0), 
-        startTimestamp: BigInt(n.start_timestamp || n.startTimestamp || 0),
+      return {
+        groupId: n.group_id ?? n.groupId,
+        admin: n.admin,
+        name: n.name,
+        contributionAmount: BigInt(n.contribution_amount ?? n.contributionAmount ?? 0),
+        totalMembers: n.total_members ?? n.totalMembers ?? 0,
+        frequency: n.frequency,
+        startTimestamp: BigInt(n.start_timestamp ?? n.startTimestamp ?? 0),
+        status: n.status,
+        isPublic: n.is_public ?? n.isPublic ?? false,
         currentRound: n.current_round ?? n.currentRound ?? 0,
-        totalMembers: n.total_members ?? n.totalMembers ?? 0
+        platformFeePercent: n.platform_fee_percent ?? n.platformFeePercent ?? 0,
       }
-    } catch (err: any) {
-      // If that fails, try without parameters (fallback to single-group mode)
-      if (err.message?.includes('wrong number of arguments')) {
-        console.warn('Contract does not accept groupId parameter, using single-group mode')
-        return await getGroup()
-      }
-      throw err
-    }
-  }, [simulateCall, getGroup])
+    },
+    [simulateCall]
+  )
 
-  const getMemberByGroup = React.useCallback(async (address: string, groupId: string): Promise<Member> => {
-    try {
-      // Try with both parameters
-      const res = await simulateCall('get_member', 
+  const getMemberByGroup = React.useCallback(
+    async (address: string, groupId: string): Promise<Member> => {
+      const res = await simulateCall(
+        'get_member',
         nativeToScVal(address, { type: 'address' }),
         nativeToScVal(groupId, { type: 'string' })
       )
       const n = scValToNative(res)
-      return { 
-        ...n, 
-        joinTimestamp: BigInt(n.join_timestamp || n.joinTimestamp || 0), 
-        totalContributed: BigInt(n.total_contributed || n.totalContributed || 0),
-        joinOrder: n.join_order ?? n.joinOrder ?? 0
+      return {
+        address: n.address,
+        joinTimestamp: BigInt(n.join_timestamp ?? n.joinTimestamp ?? 0),
+        joinOrder: n.join_order ?? n.joinOrder ?? 0,
+        status: n.status,
+        totalContributed: BigInt(n.total_contributed ?? n.totalContributed ?? 0),
+        hasReceivedPayout: n.has_received_payout ?? n.hasReceivedPayout ?? false,
+        payoutRound: n.payout_round ?? n.payoutRound ?? 0,
       }
-    } catch (err: any) {
-      // Fallback to single-parameter version
-      if (err.message?.includes('wrong number of arguments')) {
-        console.warn('Contract does not accept groupId parameter, using single-group mode')
-        return await getMember(address)
-      }
-      throw err
-    }
-  }, [simulateCall, getMember])
+    },
+    [simulateCall]
+  )
 
-  const getMembersByGroup = React.useCallback(async (groupId: string) => {
-    try {
-      const res = await simulateCall('get_members', nativeToScVal(groupId, { type: 'string' }))
+  const getMembersByGroup = React.useCallback(
+    async (groupId: string): Promise<Member[]> => {
+      const res = await simulateCall(
+        'get_members',
+        nativeToScVal(groupId, { type: 'string' })
+      )
       const addrs = scValToNative(res) as string[]
-      return Promise.all(addrs.map(a => getMemberByGroup(a, groupId)))
-    } catch (err: any) {
-      // Fallback to parameterless version
-      if (err.message?.includes('wrong number of arguments')) {
-        console.warn('Contract does not accept groupId parameter, using single-group mode')
-        return await getMembers()
-      }
-      throw err
-    }
-  }, [simulateCall, getMemberByGroup])
+      return Promise.all(addrs.map((a) => getMemberByGroup(a, groupId)))
+    },
+    [simulateCall, getMemberByGroup]
+  )
 
-  const getRoundContributionsByGroup = React.useCallback(async (groupId: string, round: number) => {
-    try {
-      const res = await simulateCall('get_round_contributions', 
+  const getRoundContributionsByGroup = React.useCallback(
+    async (groupId: string, round: number): Promise<Contribution[]> => {
+      const res = await simulateCall(
+        'get_round_contributions',
         nativeToScVal(groupId, { type: 'string' }),
         nativeToScVal(round, { type: 'u32' })
       )
-      return (scValToNative(res) as any[]).map(c => ({ 
-        ...c, 
-        amount: BigInt(c.amount || 0), 
-        timestamp: BigInt(c.timestamp || 0) 
+      return (scValToNative(res) as any[]).map((c) => ({
+        member: c.member,
+        amount: BigInt(c.amount ?? 0),
+        round: c.round,
+        timestamp: BigInt(c.timestamp ?? 0),
       }))
-    } catch (err: any) {
-      if (err.message?.includes('wrong number of arguments')) {
-        console.warn('Contract does not accept groupId parameter, using single-group mode')
-        return await getRoundContributions(round)
-      }
-      throw err
-    }
-  }, [simulateCall, getRoundContributions])
+    },
+    [simulateCall]
+  )
 
-  const getRoundPayoutsByGroup = React.useCallback(async (groupId: string, round: number) => {
-    try {
-      const res = await simulateCall('get_round_payouts', 
+  const getRoundPayoutsByGroup = React.useCallback(
+    async (groupId: string, round: number): Promise<Payout[]> => {
+      const res = await simulateCall(
+        'get_round_payouts',
         nativeToScVal(groupId, { type: 'string' }),
         nativeToScVal(round, { type: 'u32' })
       )
-      return (scValToNative(res) as any[]).map(p => ({ 
-        ...p, 
-        amount: BigInt(p.amount || 0), 
-        timestamp: BigInt(p.timestamp || 0) 
+      return (scValToNative(res) as any[]).map((p) => ({
+        recipient: p.recipient,
+        amount: BigInt(p.amount ?? 0),
+        round: p.round,
+        timestamp: BigInt(p.timestamp ?? 0),
       }))
-    } catch (err: any) {
-      if (err.message?.includes('wrong number of arguments')) {
-        console.warn('Contract does not accept groupId parameter, using single-group mode')
-        return await getRoundPayouts(round)
-      }
-      throw err
-    }
-  }, [simulateCall, getRoundPayouts])
+    },
+    [simulateCall]
+  )
 
-  const getRoundDeadlineByGroup = React.useCallback(async (groupId: string, round: number) => {
-    try {
-      const res = await simulateCall('get_round_deadline', 
+  const getRoundDeadlineByGroup = React.useCallback(
+    async (groupId: string, round: number): Promise<bigint> => {
+      const res = await simulateCall(
+        'get_round_deadline',
         nativeToScVal(groupId, { type: 'string' }),
         nativeToScVal(round, { type: 'u32' })
       )
       return BigInt(scValToNative(res))
-    } catch (err: any) {
-      if (err.message?.includes('wrong number of arguments')) {
-        console.warn('Contract does not accept groupId parameter, using single-group mode')
-        return await getRoundDeadline(round)
-      }
-      throw err
-    }
-  }, [simulateCall, getRoundDeadline])
+    },
+    [simulateCall]
+  )
 
-  // ===== USER AND DISCOVERY METHODS =====
-  
-  const getUserGroups = React.useCallback(async (address: string) => {
-    try {
-      const res = await simulateCall('get_user_groups', nativeToScVal(address, { type: 'address' }))
-      return scValToNative(res) as string[]
-    } catch (err: any) {
-      // If function doesn't exist in deployed contract, return empty array
-      if (err.message?.includes('non-existent contract function')) {
-        console.warn('get_user_groups not available in deployed contract')
-        return []
+  const getUserGroups = React.useCallback(
+    async (address: string): Promise<string[]> => {
+      try {
+        const res = await simulateCall(
+          'get_user_groups',
+          nativeToScVal(address, { type: 'address' })
+        )
+        return scValToNative(res) as string[]
+      } catch (err: any) {
+        if (err.message?.includes('non-existent contract function')) return []
+        throw err
       }
-      throw err
-    }
-  }, [simulateCall])
+    },
+    [simulateCall]
+  )
 
-  const getAllGroups = React.useCallback(async () => {
+  const getAllGroups = React.useCallback(async (): Promise<string[]> => {
     try {
       const res = await simulateCall('get_all_groups')
       return scValToNative(res) as string[]
     } catch (err: any) {
-      // If function doesn't exist in deployed contract, return empty array
-      if (err.message?.includes('non-existent contract function')) {
-        console.warn('get_all_groups not available in deployed contract')
-        return []
-      }
+      if (err.message?.includes('non-existent contract function')) return []
       throw err
     }
   }, [simulateCall])
 
-  // ===== TRANSACTION METHODS =====
-  
-  const createGroup = React.useCallback(async (p: CreateGroupParams) => {
-    if (!wallet.publicKey) throw new Error('Wallet not connected')
-    
-    // Double-check timestamp is in the future
-    const currentTime = Math.floor(Date.now() / 1000)
-    if (Number(p.startTimestamp) <= currentTime) {
-      throw new Error(`Start timestamp must be in the future. Current: ${currentTime}, Provided: ${p.startTimestamp}`)
-    }
-    
-    const frequencyScVal = xdr.ScVal.scvVec([
-      xdr.ScVal.scvSymbol(p.frequency) // The variant name
-    ])
-    
-    console.log('Creating group with params:', {
-      admin: wallet.publicKey,
-      groupId: p.groupId,
-      name: p.name,
-      contributionAmount: p.contributionAmount.toString(),
-      totalMembers: p.totalMembers,
-      frequency: p.frequency,
-      startTimestamp: p.startTimestamp.toString(),
-      isPublic: p.isPublic,
-      currentTime
-    })
-    
-    return await sendTransaction('create_group', 
-      nativeToScVal(wallet.publicKey, { type: 'address' }),
-      nativeToScVal(p.groupId, { type: 'string' }),
-      nativeToScVal(p.name, { type: 'string' }),
-      nativeToScVal(p.contributionAmount, { type: 'i128' }),
-      nativeToScVal(p.totalMembers, { type: 'u32' }),
-      frequencyScVal,
-      nativeToScVal(p.startTimestamp, { type: 'u64' }),
-      nativeToScVal(p.isPublic, { type: 'bool' })
-    )
-  }, [wallet.publicKey, sendTransaction])
+  // ===== WRITE METHODS =====
 
-  const joinGroup = React.useCallback(async (groupId?: string) => {
-    if (!wallet.publicKey) throw new Error('Wallet not connected')
-    
-    if (groupId) {
-      // Try with groupId parameter
-      return await sendTransaction('join_group', 
+  const createGroup = React.useCallback(
+    async (p: CreateGroupParams) => {
+      if (!wallet.publicKey) throw new Error('Wallet not connected')
+
+      const currentTime = Math.floor(Date.now() / 1000)
+      if (Number(p.startTimestamp) <= currentTime) {
+        throw new Error(
+          `Start timestamp must be in the future. Current: ${currentTime}, Provided: ${p.startTimestamp}`
+        )
+      }
+
+      const frequencyScVal = xdr.ScVal.scvVec([xdr.ScVal.scvSymbol(p.frequency)])
+
+      return await sendTransaction(
+        'create_group',
+        nativeToScVal(wallet.publicKey, { type: 'address' }),
+        nativeToScVal(p.groupId, { type: 'string' }),
+        nativeToScVal(p.name, { type: 'string' }),
+        nativeToScVal(p.contributionAmount, { type: 'i128' }),
+        nativeToScVal(p.totalMembers, { type: 'u32' }),
+        frequencyScVal,
+        nativeToScVal(p.startTimestamp, { type: 'u64' }),
+        nativeToScVal(p.isPublic, { type: 'bool' })
+      )
+    },
+    [wallet.publicKey, sendTransaction]
+  )
+
+  const joinGroup = React.useCallback(
+    async (groupId: string) => {
+      if (!wallet.publicKey) throw new Error('Wallet not connected')
+
+      return await sendTransaction(
+        'join_group',
         nativeToScVal(wallet.publicKey, { type: 'address' }),
         nativeToScVal(groupId, { type: 'string' })
       )
-    } else {
-      // Try without groupId (single-group mode)
-      return await sendTransaction('join_group', nativeToScVal(wallet.publicKey, { type: 'address' }))
-    }
-  }, [wallet.publicKey, sendTransaction])
+    },
+    [wallet.publicKey, sendTransaction]
+  )
 
-  const contribute = React.useCallback(async (amount: bigint, groupId?: string) => {
-    if (!wallet.publicKey) throw new Error('Wallet not connected')
-    
-    if (groupId) {
-      // Try with groupId parameter
-      return await sendTransaction('contribute', 
+  /**
+   * Contribute to the current round of a group.
+   * The amount is fixed on-chain — do NOT pass an amount here.
+   */
+  const contribute = React.useCallback(
+    async (groupId: string) => {
+      if (!wallet.publicKey) throw new Error('Wallet not connected')
+
+      return await sendTransaction(
+        'contribute',
         nativeToScVal(wallet.publicKey, { type: 'address' }),
-        nativeToScVal(groupId, { type: 'string' }),
-        nativeToScVal(amount, { type: 'i128' })
+        nativeToScVal(groupId, { type: 'string' })
       )
-    } else {
-      // Try without groupId (single-group mode)
-      return await sendTransaction('contribute', 
-        nativeToScVal(wallet.publicKey, { type: 'address' }),
-        nativeToScVal(amount, { type: 'i128' })
-      )
-    }
-  }, [wallet.publicKey, sendTransaction])
+    },
+    [wallet.publicKey, sendTransaction]
+  )
 
-  const value = React.useMemo(() => ({
-    // Existing single-group methods
-    getGroup, getMember, getMembers, getRoundContributions, getRoundPayouts,
-    getRoundDeadline,
-    
-    // New multi-group methods
-    getGroupById, getMemberByGroup, getMembersByGroup, 
-    getRoundContributionsByGroup, getRoundPayoutsByGroup, getRoundDeadlineByGroup,
-    
-    // User and discovery methods
-    getUserGroups, getAllGroups,
-    
-    // Transaction methods
-    createGroup, joinGroup, contribute,
-    
-    // Contract info
-    contractId, isReady, error
-  }), [
-    // Existing single-group methods
-    getGroup, getMember, getMembers, getRoundContributions, getRoundPayouts,
-    getRoundDeadline,
-    
-    // New multi-group methods
-    getGroupById, getMemberByGroup, getMembersByGroup, 
-    getRoundContributionsByGroup, getRoundPayoutsByGroup, getRoundDeadlineByGroup,
-    
-    // User and discovery methods
-    getUserGroups, getAllGroups,
-    
-    // Transaction methods
-    createGroup, joinGroup, contribute,
-    
-    // Contract info
-    contractId, isReady, error
-  ])
+  const value = React.useMemo(
+    () => ({
+      getGroupById,
+      getMemberByGroup,
+      getMembersByGroup,
+      getRoundContributionsByGroup,
+      getRoundPayoutsByGroup,
+      getRoundDeadlineByGroup,
+      getUserGroups,
+      getAllGroups,
+      createGroup,
+      joinGroup,
+      contribute,
+      contractId,
+      isReady,
+      error,
+    }),
+    [
+      getGroupById,
+      getMemberByGroup,
+      getMembersByGroup,
+      getRoundContributionsByGroup,
+      getRoundPayoutsByGroup,
+      getRoundDeadlineByGroup,
+      getUserGroups,
+      getAllGroups,
+      createGroup,
+      joinGroup,
+      contribute,
+      contractId,
+      isReady,
+      error,
+    ]
+  )
 
-  return <SavingsContractContext.Provider value={value}>{children}</SavingsContractContext.Provider>
+  return (
+    <SavingsContractContext.Provider value={value}>
+      {children}
+    </SavingsContractContext.Provider>
+  )
 }
 
 export const useSavingsContract = () => {

--- a/apps/web/hooks/use-join.ts
+++ b/apps/web/hooks/use-join.ts
@@ -1,0 +1,96 @@
+'use client'
+
+import { useState } from 'react'
+import { useSavingsContract } from '@/context/savingsContract'
+import { useRegistryContract } from '@/context/registryContract'
+import { useWallet } from '@/hooks/use-wallet'
+
+type JoinStep = 'idle' | 'joining' | 'registering' | 'done' | 'error'
+
+interface UseJoinGroupReturn {
+  join: (groupId: string) => Promise<void>
+  step: JoinStep
+  isLoading: boolean
+  error: string | null
+  reset: () => void
+}
+
+/**
+ * Handles the two-step join flow:
+ * 1. Call join_group on the savings contract
+ * 2. Call add_member on the registry contract
+ *
+ * Both steps must succeed for the user to be properly discoverable.
+ * On registry failure, we retry once automatically before surfacing an error.
+ */
+export function useJoinGroup(): UseJoinGroupReturn {
+  const { publicKey } = useWallet()
+  const savings = useSavingsContract()
+  const registry = useRegistryContract()
+
+  const [step, setStep] = useState<JoinStep>('idle')
+  const [error, setError] = useState<string | null>(null)
+
+  const reset = () => {
+    setStep('idle')
+    setError(null)
+  }
+
+  const join = async (groupId: string) => {
+    if (!publicKey) {
+      setError('Wallet not connected')
+      return
+    }
+
+    setError(null)
+
+    // ── Step 1: Join group on savings contract ────────────────
+    try {
+      setStep('joining')
+      await savings.joinGroup(groupId)
+    } catch (err: any) {
+      console.error('join_group failed:', err)
+      setError(err.message || 'Failed to join group. Please try again.')
+      setStep('error')
+      return
+    }
+
+    // ── Step 2: Register membership in registry ───────────────
+    // The savings contract address is the contract_address key in the registry
+    const savingsContractAddress = process.env.NEXT_PUBLIC_SAVINGS_CONTRACT_ID!
+
+    const attemptRegister = () =>
+      registry.addMember(savingsContractAddress, publicKey)
+
+    try {
+      setStep('registering')
+      await attemptRegister()
+    } catch (firstErr) {
+      console.warn('add_member failed on first attempt, retrying...', firstErr)
+      await new Promise((resolve) => setTimeout(resolve, 2000))
+
+      try {
+        await attemptRegister()
+      } catch (retryErr: any) {
+        console.error('add_member failed after retry:', retryErr)
+        // User HAS joined on-chain — make that clear in the error
+        setError(
+          `You have joined the group on-chain, but your membership could not be registered ` +
+          `for the "My Groups" view. Please contact support with group ID: ${groupId}`
+        )
+        setStep('error')
+        return
+      }
+    }
+
+    setStep('done')
+  }
+
+  return {
+    join,
+    step,
+    isLoading: step === 'joining' || step === 'registering',
+    error,
+    reset,
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,30 +1,162 @@
+export type GroupStatus = 'Open' | 'Active' | 'Completed' | 'Paused'
+
+export type MemberStatus =
+  | 'Active'
+  | 'PaidCurrentRound'
+  | 'Overdue'
+  | 'Defaulted'
+  | 'ReceivedPayout'
+
+export type Frequency = 'Weekly' | 'BiWeekly' | 'Monthly'
+
+// ============================================================
+// Core contract data structures
+// Mirrors the Rust structs in contracts/savings/src/lib.rs
+// ============================================================
+
 export interface SavingsGroup {
-  id: string;
-  name: string;
-  contributionAmount: number;
-  frequency: 'monthly' | 'weekly';
-  members: string[];
-  currentRound: number;
+  group_id: string
+  admin: string
+  name: string
+  contribution_amount: bigint   // in stroops (1 XLM = 10_000_000 stroops)
+  total_members: number
+  frequency: Frequency
+  start_timestamp: bigint       // Unix timestamp (u64)
+  status: GroupStatus
+  is_public: boolean
+  current_round: number
+  platform_fee_percent: number  // basis points (200 = 2%)
+}
+
+export interface Member {
+  address: string
+  join_timestamp: bigint        // Unix timestamp (u64)
+  join_order: number
+  status: MemberStatus
+  total_contributed: bigint     // in stroops
+  has_received_payout: boolean
+  payout_round: number
 }
 
 export interface Contribution {
-  memberId: string;
-  amount: number;
-  timestamp: Date;
-  txHash: string;
+  member: string                // Stellar public key
+  amount: bigint                // in stroops
+  round: number
+  timestamp: bigint             // Unix timestamp (u64)
 }
 
-// Constants
+export interface Payout {
+  recipient: string             // Stellar public key
+  amount: bigint                // in stroops
+  round: number
+  timestamp: bigint             // Unix timestamp (u64)
+}
+
+// ============================================================
+// Registry contract data structure
+// Mirrors the Rust struct in contracts/registry/src/lib.rs
+// ============================================================
+
+export interface GroupInfo {
+  contract_address: string      // Stellar contract address
+  group_id: string
+  name: string
+  admin: string                 // Stellar public key
+  is_public: boolean
+  created_at: bigint            // Unix timestamp (u64)
+  total_members: number
+}
+
+// ============================================================
+// Frontend form params (used when creating a group)
+// ============================================================
+
+export interface CreateGroupParams {
+  groupId: string
+  name: string
+  contributionAmount: bigint    // in stroops
+  totalMembers: number
+  frequency: Frequency
+  startTimestamp: bigint        // Unix timestamp (u64)
+  isPublic: boolean
+}
+
+// ============================================================
+// Network constants
+// ============================================================
+
 export const STELLAR_NETWORK = {
   testnet: 'https://horizon-testnet.stellar.org',
-  mainnet: 'https://horizon.stellar.org'
-} as const;
+  mainnet: 'https://horizon.stellar.org',
+} as const
 
+// ============================================================
 // Utility functions
-export function formatAmount(amount: number): string {
-  return (amount / 10_000_000).toFixed(2); // Convert stroops to XLM
+// ============================================================
+
+/**
+ * Convert stroops to XLM.
+ * 1 XLM = 10,000,000 stroops
+ */
+export function stroopsToXLM(stroops: bigint | number): number {
+  return Number(stroops) / 10_000_000
 }
 
-export function validateContribution(amount: number, required: number): boolean {
-  return amount === required;
+/**
+ * Convert XLM to stroops.
+ */
+export function xlmToStroops(xlm: number): bigint {
+  return BigInt(Math.floor(xlm * 10_000_000))
+}
+
+/**
+ * Format a stroops amount as a human-readable XLM string.
+ * e.g. 500000000n → "50.00 XLM"
+ */
+export function formatXLM(stroops: bigint | number): string {
+  const xlm = stroopsToXLM(stroops)
+  return `${xlm.toLocaleString(undefined, { maximumFractionDigits: 2 })} XLM`
+}
+
+/**
+ * Convert a Unix timestamp (seconds) to a JS Date object.
+ */
+export function timestampToDate(timestamp: bigint | number): Date {
+  return new Date(Number(timestamp) * 1000)
+}
+
+/**
+ * Format a Unix timestamp as a readable date string.
+ * e.g. 1704067200n → "Jan 1, 2024"
+ */
+export function formatTimestamp(timestamp: bigint | number): string {
+  return timestampToDate(timestamp).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+/**
+ * Returns true if a contribution amount matches the required group amount.
+ */
+export function validateContribution(
+  amount: bigint,
+  required: bigint
+): boolean {
+  return amount === required
+}
+
+/**
+ * Calculate the total payout pool for a group.
+ * Deducts the platform fee before returning.
+ */
+export function calculatePayoutAmount(
+  contributionAmount: bigint,
+  totalMembers: number,
+  platformFeePercent: number
+): bigint {
+  const totalPool = contributionAmount * BigInt(totalMembers)
+  const fee = (totalPool * BigInt(platformFeePercent)) / 10000n
+  return totalPool - fee
 }


### PR DESCRIPTION
## Summary
Fixes two out-of-sync issues between the frontend and the deployed Soroban smart contract.

## Changes

### apps/web — savings contract context
- Removed `amount` parameter from `contribute()` — the contribution amount is fixed on-chain at group creation and must not be passed at call time
- Removed all legacy single-group methods (`getGroup`, `getMember`, `getMembers`, `getRoundContributions`, `getRoundPayouts`, `getRoundDeadline`) and their messy fallback logic
- The multi-group `ByGroup` methods are now the only canonical API
- Explicit field mapping in `getGroupById` replaces unsafe spread (`...n`) to prevent unexpected fields leaking through

## Testing
- [ ] `contribute()` call succeeds without passing an amount
- [ ] All `ByGroup` read methods return correctly shaped data
- [ ] No existing components broken by removed single-group methods

## Related
Closes #42 
Closes #43
Closes #44