### PR TITLE
feat: add reusable UI components (TextInput, Avatar, Badge, Card)

### DIFF
--- a/mobile/components/ui/Avatar.tsx
+++ b/mobile/components/ui/Avatar.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { View, Text, Image, StyleSheet } from 'react-native';
+
+const SIZES = { sm: 32, md: 40, lg: 56 };
+const COLORS = ['#6366F1','#8B5CF6','#EC4899','#F59E0B','#10B981','#3B82F6','#EF4444'];
+
+function getInitials(name: string) {
+  const words = name.trim().split(/\s+/);
+  return (words[0]?.[0] ?? '') + (words[1]?.[0] ?? '');
+}
+
+function getBgColor(name: string) {
+  const hash = [...name].reduce((acc, c) => acc + c.charCodeAt(0), 0);
+  return COLORS[hash % COLORS.length];
+}
+
+interface Props {
+  uri?: string;
+  name: string;
+  size?: 'sm' | 'md' | 'lg';
+}
+
+export function Avatar({ uri, name, size = 'md' }: Props) {
+  const px = SIZES[size];
+  const style = { width: px, height: px, borderRadius: px / 2 };
+
+  if (uri) {
+    return <Image source={{ uri }} style={style} />;
+  }
+
+  return (
+    <View style={[style, styles.fallback, { backgroundColor: getBgColor(name) }]}>
+      <Text style={[styles.initials, { fontSize: px * 0.35 }]}>{getInitials(name).toUpperCase()}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  fallback: { alignItems: 'center', justifyContent: 'center' },
+  initials: { color: '#fff', fontWeight: '600' },
+});

--- a/mobile/components/ui/Badge.tsx
+++ b/mobile/components/ui/Badge.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+type Variant = 'success' | 'warning' | 'error' | 'info' | 'neutral';
+
+const VARIANT_COLORS: Record<Variant, { bg: string; text: string }> = {
+  success: { bg: '#14532D', text: '#4ADE80' },
+  warning: { bg: '#78350F', text: '#FCD34D' },
+  error:   { bg: '#7F1D1D', text: '#FCA5A5' },
+  info:    { bg: '#1E3A5F', text: '#60A5FA' },
+  neutral: { bg: '#1E293B', text: '#94A3B8' },
+};
+
+interface Props {
+  label: string;
+  variant: Variant;
+}
+
+export function Badge({ label, variant }: Props) {
+  const { bg, text } = VARIANT_COLORS[variant];
+  return (
+    <View style={[styles.badge, { backgroundColor: bg }]}>
+      <Text style={[styles.text, { color: text }]}>{label}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  badge: {
+    alignSelf: 'flex-start',
+    borderRadius: 999,
+    paddingHorizontal: 10,
+    paddingVertical: 3,
+  },
+  text: { fontSize: 12, fontWeight: '600' },
+});

--- a/mobile/components/ui/Card.tsx
+++ b/mobile/components/ui/Card.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { View, Pressable, StyleSheet, ViewStyle } from 'react-native';
+
+interface Props {
+  children: React.ReactNode;
+  style?: ViewStyle;
+  onPress?: () => void;
+}
+
+export function Card({ children, style, onPress }: Props) {
+  const content = <View style={[styles.card, style]}>{children}</View>;
+
+  if (onPress) {
+    return (
+      <Pressable onPress={onPress} style={({ pressed }) => [{ opacity: pressed ? 0.75 : 1 }]}>
+        {content}
+      </Pressable>
+    );
+  }
+
+  return content;
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: '#1E293B',
+    borderWidth: 1,
+    borderColor: '#334155',
+    borderRadius: 12,
+    padding: 16,
+  },
+});

--- a/mobile/components/ui/TextInput.tsx
+++ b/mobile/components/ui/TextInput.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { View, Text, TextInput as RNTextInput, TextInputProps, StyleSheet } from 'react-native';
+
+interface Props extends TextInputProps {
+  label?: string;
+  error?: string;
+}
+
+export function TextInput({ label, error, style, ...props }: Props) {
+  return (
+    <View style={styles.container}>
+      {label && <Text style={styles.label}>{label}</Text>}
+      <RNTextInput
+        style={[styles.input, error ? styles.inputError : null, style]}
+        placeholderTextColor="#64748B"
+        {...props}
+      />
+      {error && <Text style={styles.error}>{error}</Text>}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { marginBottom: 12 },
+  label: { color: '#fff', marginBottom: 4, fontSize: 14 },
+  input: {
+    backgroundColor: '#1E293B',
+    color: '#fff',
+    borderWidth: 1,
+    borderColor: '#334155',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 14,
+  },
+  inputError: { borderColor: '#EF4444' },
+  error: { color: '#EF4444', fontSize: 12, marginTop: 4 },
+});

--- a/mobile/components/ui/index.ts
+++ b/mobile/components/ui/index.ts
@@ -1,0 +1,4 @@
+export { TextInput } from './TextInput';
+export { Avatar } from './Avatar';
+export { Badge } from './Badge';
+export { Card } from './Card';


### PR DESCRIPTION
## Summary

This PR implements 4 reusable UI components for the mobile app, resolving all assigned issues.

## Changes

### TextInput (`#71`)
- Wraps RN `TextInput` with a label above and error message below
- Red border + error text when `error` prop is set
- Dark theme: bg `#1E293B`, text white, border `#334155`
- Supports all native `TextInput` props via spread

### Avatar (`#72`)
- Shows image when `uri` is provided (circular)
- Falls back to initials (first letters of first two words of `name`)
- Deterministic background color derived from `name`
- Three sizes: `sm` (32px), `md` (40px), `lg` (56px)

### Badge (`#73`)
- Pill-shaped badge with 5 variants: `success`, `warning`, `error`, `info`, `neutral`
- Each variant has distinct background + text color for contrast

### Card (`#74`)
- Default styles: bg `#1E293B`, border `#334155`, radius 12, padding 16
- When `onPress` provided, wraps in `Pressable` with pressed opacity effect
- `style` prop overrides defaults

All components exported from `mobile/components/ui/index.ts`.

## Closes

Closes #71
Closes #72
Closes #73
Closes #74