### PR TITLE
Feat/build

### DIFF
--- a/mobile/app/(tabs)/groups/[groupId].tsx
+++ b/mobile/app/(tabs)/groups/[groupId].tsx
@@ -70,7 +70,7 @@ export default function GroupDetailPage() {
   const router = useRouter();
   const params = useLocalSearchParams<{ groupId?: string }>();
   const groupId = params.groupId ?? '';
-  const group = MOCK_GROUPS.find((item) => item.id === groupId) || MOCK_GROUPS[0];
+  const group = MOCK_GROUPS.find((item) => item.id === groupId) || null;
 
   return (
     <SafeAreaView style={styles.container}>
@@ -82,19 +82,30 @@ export default function GroupDetailPage() {
       </View>
 
       <ScrollView contentContainerStyle={styles.content}>
-        <GroupDetailHeader group={group} />
+        {group ? (
+          <>
+            <GroupDetailHeader group={group} />
 
-        <View style={styles.section}>
-          <Text style={styles.sectionHeading}>Overview</Text>
-          <Text style={styles.sectionText}>
-            This is the group detail screen for “{group.name}”. The group has a contribution amount of {group.contribution} paid {group.frequency.toLowerCase()}, and currently includes {group.memberCount} members.
-          </Text>
-        </View>
+            <View style={styles.section}>
+              <Text style={styles.sectionHeading}>Overview</Text>
+              <Text style={styles.sectionText}>
+                This is the group detail screen for “{group.name}”. The group has a contribution amount of {group.contribution} paid {group.frequency.toLowerCase()}, and currently includes {group.memberCount} members.
+              </Text>
+            </View>
 
-        <View style={styles.section}>
-          <Text style={styles.sectionHeading}>Group ID</Text>
-          <Text style={styles.sectionText}>{groupId || 'Unknown'}</Text>
-        </View>
+            <View style={styles.section}>
+              <Text style={styles.sectionHeading}>Group ID</Text>
+              <Text style={styles.sectionText}>{groupId}</Text>
+            </View>
+          </>
+        ) : (
+          <View style={styles.section}>
+            <Text style={styles.sectionHeading}>Group not found</Text>
+            <Text style={styles.sectionText}>
+              No mock group was found for the requested ID. Use a valid group link to see details.
+            </Text>
+          </View>
+        )}
       </ScrollView>
     </SafeAreaView>
   );

--- a/mobile/app/(tabs)/groups/[groupId].tsx
+++ b/mobile/app/(tabs)/groups/[groupId].tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import React from 'react';
+import { SafeAreaView, ScrollView, View, Text, Pressable, StyleSheet } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { Badge } from '../../../components/ui/Badge';
+
+type Group = {
+  id: string;
+  name: string;
+  status: 'Active' | 'Paused' | 'Closed' | 'Pending';
+  contribution: string;
+  frequency: string;
+  memberCount: number;
+};
+
+const MOCK_GROUPS: Group[] = [
+  {
+    id: '1',
+    name: 'Solar Saver Collective',
+    status: 'Active',
+    contribution: '45 XLM',
+    frequency: 'Monthly',
+    memberCount: 8,
+  },
+  {
+    id: '2',
+    name: 'Lunar Growth Syndicate',
+    status: 'Paused',
+    contribution: '90 XLM',
+    frequency: 'Biweekly',
+    memberCount: 12,
+  },
+  {
+    id: '3',
+    name: 'Horizon Funding Group',
+    status: 'Pending',
+    contribution: '120 XLM',
+    frequency: 'Weekly',
+    memberCount: 5,
+  },
+];
+
+const STATUS_VARIANT_MAP: Record<Group['status'], 'success' | 'warning' | 'error' | 'info' | 'neutral'> = {
+  Active: 'success',
+  Paused: 'warning',
+  Closed: 'error',
+  Pending: 'info',
+};
+
+function GroupDetailHeader({ group }: { group: Group }) {
+  return (
+    <View style={styles.groupHeader}>
+      <View style={styles.titleRow}>
+        <Text style={styles.groupName}>{group.name}</Text>
+        <Badge label={group.status} variant={STATUS_VARIANT_MAP[group.status]} />
+      </View>
+
+      <View style={styles.amountRow}>
+        <Text style={styles.contributionAmount}>{group.contribution}</Text>
+        <Text style={styles.frequencyText}>{group.frequency}</Text>
+      </View>
+
+      <Text style={styles.memberText}>{group.memberCount} members</Text>
+    </View>
+  );
+}
+
+export default function GroupDetailPage() {
+  const router = useRouter();
+  const params = useLocalSearchParams<{ groupId?: string }>();
+  const groupId = params.groupId ?? '';
+  const group = MOCK_GROUPS.find((item) => item.id === groupId) || MOCK_GROUPS[0];
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.navHeader}>
+        <Pressable onPress={() => router.back()} style={styles.backButton}>
+          <Text style={styles.backButtonText}>Back</Text>
+        </Pressable>
+        <Text style={styles.screenTitle}>Group Details</Text>
+      </View>
+
+      <ScrollView contentContainerStyle={styles.content}>
+        <GroupDetailHeader group={group} />
+
+        <View style={styles.section}>
+          <Text style={styles.sectionHeading}>Overview</Text>
+          <Text style={styles.sectionText}>
+            This is the group detail screen for “{group.name}”. The group has a contribution amount of {group.contribution} paid {group.frequency.toLowerCase()}, and currently includes {group.memberCount} members.
+          </Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionHeading}>Group ID</Text>
+          <Text style={styles.sectionText}>{groupId || 'Unknown'}</Text>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#F8FAFC',
+  },
+  navHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingTop: 16,
+    paddingBottom: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#CBD5E1',
+    backgroundColor: '#FFFFFF',
+  },
+  backButton: {
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 8,
+    backgroundColor: '#E2E8F0',
+  },
+  backButtonText: {
+    color: '#0F172A',
+    fontWeight: '600',
+  },
+  screenTitle: {
+    marginLeft: 16,
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#0F172A',
+  },
+  content: {
+    padding: 16,
+  },
+  groupHeader: {
+    marginBottom: 24,
+    padding: 20,
+    borderRadius: 20,
+    backgroundColor: '#FFFFFF',
+    shadowColor: '#000',
+    shadowOpacity: 0.06,
+    shadowRadius: 10,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 2,
+  },
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 16,
+  },
+  groupName: {
+    fontSize: 22,
+    fontWeight: '800',
+    color: '#0F172A',
+    flex: 1,
+    marginRight: 12,
+  },
+  amountRow: {
+    marginBottom: 8,
+  },
+  contributionAmount: {
+    fontSize: 32,
+    fontWeight: '800',
+    color: '#0F172A',
+  },
+  frequencyText: {
+    marginTop: 6,
+    fontSize: 16,
+    color: '#475569',
+  },
+  memberText: {
+    fontSize: 15,
+    color: '#475569',
+    opacity: 0.9,
+  },
+  section: {
+    marginTop: 16,
+    padding: 18,
+    borderRadius: 18,
+    backgroundColor: '#FFFFFF',
+  },
+  sectionHeading: {
+    marginBottom: 10,
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#0F172A',
+  },
+  sectionText: {
+    fontSize: 15,
+    lineHeight: 22,
+    color: '#334155',
+  },
+});

--- a/mobile/app/(tabs)/groups/[groupId].tsx
+++ b/mobile/app/(tabs)/groups/[groupId].tsx
@@ -4,6 +4,12 @@ import React from 'react';
 import { SafeAreaView, ScrollView, View, Text, Pressable, StyleSheet } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { Badge } from '../../../components/ui/Badge';
+import { MemberAvatarStack } from '../../../components/groups/MemberAvatarStack';
+
+type Member = {
+  address: string;
+  name?: string;
+};
 
 type Group = {
   id: string;
@@ -12,6 +18,7 @@ type Group = {
   contribution: string;
   frequency: string;
   memberCount: number;
+  members: Member[];
 };
 
 const MOCK_GROUPS: Group[] = [

--- a/mobile/app/(tabs)/groups/[groupId].tsx
+++ b/mobile/app/(tabs)/groups/[groupId].tsx
@@ -29,6 +29,14 @@ const MOCK_GROUPS: Group[] = [
     contribution: '45 XLM',
     frequency: 'Monthly',
     memberCount: 8,
+    members: [
+      { address: 'GABCD1234', name: 'Amina' },
+      { address: 'GXYZ5678', name: 'Noah' },
+      { address: 'GQWER0987', name: 'Sophia' },
+      { address: 'GJKL4321', name: 'Mia' },
+      { address: 'GMNO2890', name: 'Leo' },
+      { address: 'GPDRT1111', name: 'Aria' },
+    ],
   },
   {
     id: '2',
@@ -37,6 +45,10 @@ const MOCK_GROUPS: Group[] = [
     contribution: '90 XLM',
     frequency: 'Biweekly',
     memberCount: 12,
+    members: [
+      { address: 'GHIJK1234', name: 'Noah' },
+      { address: 'GLMNO5678', name: 'Eli' },
+    ],
   },
   {
     id: '3',
@@ -45,6 +57,7 @@ const MOCK_GROUPS: Group[] = [
     contribution: '120 XLM',
     frequency: 'Weekly',
     memberCount: 5,
+    members: [{ address: 'GPQRZ9876', name: 'Zoe' }],
   },
 ];
 
@@ -92,6 +105,11 @@ export default function GroupDetailPage() {
         {group ? (
           <>
             <GroupDetailHeader group={group} />
+
+            <View style={styles.section}>
+              <Text style={styles.sectionHeading}>Members</Text>
+              <MemberAvatarStack members={group.members} onViewAll={() => {}} />
+            </View>
 
             <View style={styles.section}>
               <Text style={styles.sectionHeading}>Overview</Text>

--- a/mobile/app/(tabs)/groups/page.tsx
+++ b/mobile/app/(tabs)/groups/page.tsx
@@ -81,7 +81,38 @@ function getFilteredGroups(filter: FilterKey) {
 export default function GroupsPage() {
   const router = useRouter();
   const [activeFilter, setActiveFilter] = useState<FilterKey>('All');
+  const [refreshing, setRefreshing] = useState(false);
   const filteredGroups = getFilteredGroups(activeFilter);
+
+  const onRefresh = useCallback(() => {
+    setRefreshing(true);
+    const timeout = setTimeout(() => {
+      setRefreshing(false);
+    }, 1000);
+
+    return () => clearTimeout(timeout);
+  }, []);
+
+  const renderGroup = ({ item }: { item: Group }) => (
+    <Pressable
+      key={item.id}
+      onPress={() => router.push(`/groups/${item.id}`)}
+      style={styles.groupCard}
+    >
+      <View style={styles.cardHeader}>
+        <Text style={styles.groupName}>{item.name}</Text>
+        <Badge label={item.status} variant={STATUS_VARIANT_MAP[item.status]} />
+      </View>
+
+      <View style={styles.cardRow}>
+        <View>
+          <Text style={styles.cardAmount}>{item.contribution}</Text>
+          <Text style={styles.cardMeta}>{item.frequency}</Text>
+        </View>
+        <Text style={styles.cardMeta}>{item.memberCount} members</Text>
+      </View>
+    </Pressable>
+  );
 
   return (
     <SafeAreaView style={styles.container}>
@@ -108,35 +139,25 @@ export default function GroupsPage() {
         })}
       </View>
 
-      <ScrollView contentContainerStyle={styles.content}>
-        {filteredGroups.map((group) => (
-          <Pressable
-            key={group.id}
-            onPress={() => router.push(`/groups/${group.id}`)}
-            style={styles.groupCard}
-          >
-            <View style={styles.cardHeader}>
-              <Text style={styles.groupName}>{group.name}</Text>
-              <Badge label={group.status} variant={STATUS_VARIANT_MAP[group.status]} />
-            </View>
-
-            <View style={styles.cardRow}>
-              <View>
-                <Text style={styles.cardAmount}>{group.contribution}</Text>
-                <Text style={styles.cardMeta}>{group.frequency}</Text>
-              </View>
-              <Text style={styles.cardMeta}>{group.memberCount} members</Text>
-            </View>
-          </Pressable>
-        ))}
-
-        {filteredGroups.length === 0 && (
+      <FlatList
+        data={filteredGroups}
+        keyExtractor={(item) => item.id}
+        renderItem={renderGroup}
+        contentContainerStyle={styles.content}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={onRefresh}
+            tintColor="#0F172A"
+          />
+        }
+        ListEmptyComponent={
           <View style={styles.emptyState}>
             <Text style={styles.emptyTitle}>No groups to show</Text>
             <Text style={styles.emptyMessage}>Try another filter to see matching groups.</Text>
           </View>
-        )}
-      </ScrollView>
+        }
+      />
     </SafeAreaView>
   );
 }

--- a/mobile/app/(tabs)/groups/page.tsx
+++ b/mobile/app/(tabs)/groups/page.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+import React, { useState } from 'react';
+import { SafeAreaView, ScrollView, View, Text, Pressable, StyleSheet } from 'react-native';
+import { useRouter } from 'expo-router';
+import { Badge } from '../../../components/ui/Badge';
+
+type GroupStatus = 'Active' | 'Open' | 'Paused' | 'Closed' | 'Pending';
+type Group = {
+  id: string;
+  name: string;
+  status: GroupStatus;
+  contribution: string;
+  frequency: string;
+  memberCount: number;
+  userJoined: boolean;
+};
+
+type FilterKey = 'All' | 'Joined' | 'Open';
+
+const FILTERS: FilterKey[] = ['All', 'Joined', 'Open'];
+
+const MOCK_GROUPS: Group[] = [
+  {
+    id: '1',
+    name: 'Solar Saver Collective',
+    status: 'Active',
+    contribution: '45 XLM',
+    frequency: 'Monthly',
+    memberCount: 8,
+    userJoined: true,
+  },
+  {
+    id: '2',
+    name: 'Lunar Growth Syndicate',
+    status: 'Open',
+    contribution: '90 XLM',
+    frequency: 'Biweekly',
+    memberCount: 12,
+    userJoined: false,
+  },
+  {
+    id: '3',
+    name: 'Horizon Funding Group',
+    status: 'Open',
+    contribution: '120 XLM',
+    frequency: 'Weekly',
+    memberCount: 5,
+    userJoined: true,
+  },
+  {
+    id: '4',
+    name: 'Orbit Growth Fund',
+    status: 'Paused',
+    contribution: '60 XLM',
+    frequency: 'Monthly',
+    memberCount: 10,
+    userJoined: false,
+  },
+];
+
+const STATUS_VARIANT_MAP: Record<GroupStatus, 'success' | 'warning' | 'error' | 'info' | 'neutral'> = {
+  Active: 'success',
+  Open: 'info',
+  Paused: 'warning',
+  Closed: 'error',
+  Pending: 'neutral',
+};
+
+function getFilteredGroups(filter: FilterKey) {
+  switch (filter) {
+    case 'Joined':
+      return MOCK_GROUPS.filter((group) => group.userJoined);
+    case 'Open':
+      return MOCK_GROUPS.filter((group) => group.status === 'Open');
+    default:
+      return MOCK_GROUPS;
+  }
+}
+
+export default function GroupsPage() {
+  const router = useRouter();
+  const [activeFilter, setActiveFilter] = useState<FilterKey>('All');
+  const filteredGroups = getFilteredGroups(activeFilter);
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.title}>Groups</Text>
+      </View>
+
+      <View style={styles.filterBar}>
+        {FILTERS.map((filter) => {
+          const isActive = filter === activeFilter;
+          return (
+            <Pressable
+              key={filter}
+              onPress={() => setActiveFilter(filter)}
+              style={[
+                styles.filterButton,
+                isActive ? styles.filterButtonActive : styles.filterButtonInactive,
+              ]}
+            >
+              <Text style={[styles.filterLabel, isActive && styles.filterLabelActive]}>{filter}</Text>
+              {isActive && <View style={styles.activeIndicator} />}
+            </Pressable>
+          );
+        })}
+      </View>
+
+      <ScrollView contentContainerStyle={styles.content}>
+        {filteredGroups.map((group) => (
+          <Pressable
+            key={group.id}
+            onPress={() => router.push(`/groups/${group.id}`)}
+            style={styles.groupCard}
+          >
+            <View style={styles.cardHeader}>
+              <Text style={styles.groupName}>{group.name}</Text>
+              <Badge label={group.status} variant={STATUS_VARIANT_MAP[group.status]} />
+            </View>
+
+            <View style={styles.cardRow}>
+              <View>
+                <Text style={styles.cardAmount}>{group.contribution}</Text>
+                <Text style={styles.cardMeta}>{group.frequency}</Text>
+              </View>
+              <Text style={styles.cardMeta}>{group.memberCount} members</Text>
+            </View>
+          </Pressable>
+        ))}
+
+        {filteredGroups.length === 0 && (
+          <View style={styles.emptyState}>
+            <Text style={styles.emptyTitle}>No groups to show</Text>
+            <Text style={styles.emptyMessage}>Try another filter to see matching groups.</Text>
+          </View>
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#F8FAFC',
+  },
+  header: {
+    paddingHorizontal: 16,
+    paddingTop: 16,
+    paddingBottom: 10,
+    backgroundColor: '#FFFFFF',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#CBD5E1',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '800',
+    color: '#0F172A',
+  },
+  filterBar: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    backgroundColor: '#FFFFFF',
+  },
+  filterButton: {
+    flex: 1,
+    alignItems: 'center',
+    paddingVertical: 10,
+    marginHorizontal: 4,
+    borderRadius: 999,
+  },
+  filterButtonActive: {
+    backgroundColor: '#0F172A',
+  },
+  filterButtonInactive: {
+    backgroundColor: '#E2E8F0',
+  },
+  filterLabel: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#334155',
+  },
+  filterLabelActive: {
+    color: '#FFFFFF',
+  },
+  activeIndicator: {
+    marginTop: 6,
+    width: 20,
+    height: 3,
+    borderRadius: 2,
+    backgroundColor: '#FFFFFF',
+  },
+  content: {
+    padding: 16,
+  },
+  groupCard: {
+    marginBottom: 16,
+    padding: 18,
+    borderRadius: 20,
+    backgroundColor: '#FFFFFF',
+    shadowColor: '#000',
+    shadowOpacity: 0.06,
+    shadowRadius: 10,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 2,
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 12,
+  },
+  groupName: {
+    flex: 1,
+    marginRight: 10,
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#0F172A',
+  },
+  cardRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  cardAmount: {
+    fontSize: 20,
+    fontWeight: '800',
+    color: '#0F172A',
+  },
+  cardMeta: {
+    fontSize: 14,
+    color: '#475569',
+    marginTop: 4,
+  },
+  emptyState: {
+    marginTop: 32,
+    alignItems: 'center',
+  },
+  emptyTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#0F172A',
+    marginBottom: 8,
+  },
+  emptyMessage: {
+    fontSize: 15,
+    color: '#64748B',
+    textAlign: 'center',
+    maxWidth: 260,
+  },
+});

--- a/mobile/app/(tabs)/groups/page.tsx
+++ b/mobile/app/(tabs)/groups/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import React, { useState } from 'react';
-import { SafeAreaView, ScrollView, View, Text, Pressable, StyleSheet } from 'react-native';
+import React, { useState, useCallback } from 'react';
+import { FlatList, RefreshControl, SafeAreaView, View, Text, Pressable, StyleSheet } from 'react-native';
 import { useRouter } from 'expo-router';
 import { Badge } from '../../../components/ui/Badge';
 

--- a/mobile/components/groups/MemberAvatarStack.tsx
+++ b/mobile/components/groups/MemberAvatarStack.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import React from 'react';
+import { View, Text, Pressable, StyleSheet } from 'react-native';
+import { Avatar } from '../ui/Avatar';
+
+type Member = {
+  address: string;
+  name?: string;
+};
+
+interface MemberAvatarStackProps {
+  members: Member[];
+  maxVisible?: number;
+  onViewAll?: () => void;
+}
+
+export function MemberAvatarStack({
+  members,
+  maxVisible = 5,
+  onViewAll,
+}: MemberAvatarStackProps) {
+  const visibleMembers = members.slice(0, maxVisible);
+  const extraCount = Math.max(0, members.length - visibleMembers.length);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.avatarRow}>
+        {visibleMembers.map((member, index) => (
+          <View
+            key={member.address}
+            style={[
+              styles.avatarWrapper,
+              index !== 0 && styles.overlap,
+              { zIndex: visibleMembers.length - index },
+            ]}
+          >
+            <Avatar name={member.name ?? member.address} size="md" />
+          </View>
+        ))}
+
+        {extraCount > 0 && (
+          <View style={[styles.extraBadge, { marginLeft: visibleMembers.length ? -12 : 0 }]}> 
+            <Text style={styles.extraText}>+{extraCount}</Text>
+          </View>
+        )}
+      </View>
+
+      <Pressable onPress={onViewAll} style={styles.viewAllPressable}>
+        <Text style={styles.viewAllText}>View All Members</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 16,
+  },
+  avatarRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  avatarWrapper: {
+    borderRadius: 999,
+    overflow: 'hidden',
+  },
+  overlap: {
+    marginLeft: -12,
+  },
+  extraBadge: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: '#0F172A',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 2,
+    borderColor: '#FFFFFF',
+  },
+  extraText: {
+    color: '#FFFFFF',
+    fontWeight: '700',
+  },
+  viewAllPressable: {
+    marginTop: 12,
+  },
+  viewAllText: {
+    color: '#0F172A',
+    fontSize: 15,
+    fontWeight: '700',
+  },
+});

--- a/packages/shared/dist/index.d.ts
+++ b/packages/shared/dist/index.d.ts
@@ -1,20 +1,91 @@
+export type GroupStatus = 'Open' | 'Active' | 'Completed' | 'Paused';
+export type MemberStatus = 'Active' | 'PaidCurrentRound' | 'Overdue' | 'Defaulted' | 'ReceivedPayout';
+export type Frequency = 'Weekly' | 'BiWeekly' | 'Monthly';
 export interface SavingsGroup {
-    id: string;
+    group_id: string;
+    admin: string;
     name: string;
-    contributionAmount: number;
-    frequency: 'monthly' | 'weekly';
-    members: string[];
-    currentRound: number;
+    contribution_amount: bigint;
+    total_members: number;
+    frequency: Frequency;
+    start_timestamp: bigint;
+    status: GroupStatus;
+    is_public: boolean;
+    current_round: number;
+    platform_fee_percent: number;
+}
+export interface Member {
+    address: string;
+    join_timestamp: bigint;
+    join_order: number;
+    status: MemberStatus;
+    total_contributed: bigint;
+    has_received_payout: boolean;
+    payout_round: number;
 }
 export interface Contribution {
-    memberId: string;
-    amount: number;
-    timestamp: Date;
-    txHash: string;
+    member: string;
+    amount: bigint;
+    round: number;
+    timestamp: bigint;
+}
+export interface Payout {
+    recipient: string;
+    amount: bigint;
+    round: number;
+    timestamp: bigint;
+}
+export interface GroupInfo {
+    contract_address: string;
+    group_id: string;
+    name: string;
+    admin: string;
+    is_public: boolean;
+    created_at: bigint;
+    total_members: number;
+}
+export interface CreateGroupParams {
+    groupId: string;
+    name: string;
+    contributionAmount: bigint;
+    totalMembers: number;
+    frequency: Frequency;
+    startTimestamp: bigint;
+    isPublic: boolean;
 }
 export declare const STELLAR_NETWORK: {
     readonly testnet: "https://horizon-testnet.stellar.org";
     readonly mainnet: "https://horizon.stellar.org";
 };
-export declare function formatAmount(amount: number): string;
-export declare function validateContribution(amount: number, required: number): boolean;
+/**
+ * Convert stroops to XLM.
+ * 1 XLM = 10,000,000 stroops
+ */
+export declare function stroopsToXLM(stroops: bigint | number): number;
+/**
+ * Convert XLM to stroops.
+ */
+export declare function xlmToStroops(xlm: number): bigint;
+/**
+ * Format a stroops amount as a human-readable XLM string.
+ * e.g. 500000000n → "50.00 XLM"
+ */
+export declare function formatXLM(stroops: bigint | number): string;
+/**
+ * Convert a Unix timestamp (seconds) to a JS Date object.
+ */
+export declare function timestampToDate(timestamp: bigint | number): Date;
+/**
+ * Format a Unix timestamp as a readable date string.
+ * e.g. 1704067200n → "Jan 1, 2024"
+ */
+export declare function formatTimestamp(timestamp: bigint | number): string;
+/**
+ * Returns true if a contribution amount matches the required group amount.
+ */
+export declare function validateContribution(amount: bigint, required: bigint): boolean;
+/**
+ * Calculate the total payout pool for a group.
+ * Deducts the platform fee before returning.
+ */
+export declare function calculatePayoutAmount(contributionAmount: bigint, totalMembers: number, platformFeePercent: number): bigint;

--- a/packages/shared/dist/index.js
+++ b/packages/shared/dist/index.js
@@ -1,17 +1,73 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.STELLAR_NETWORK = void 0;
-exports.formatAmount = formatAmount;
+exports.stroopsToXLM = stroopsToXLM;
+exports.xlmToStroops = xlmToStroops;
+exports.formatXLM = formatXLM;
+exports.timestampToDate = timestampToDate;
+exports.formatTimestamp = formatTimestamp;
 exports.validateContribution = validateContribution;
-// Constants
+exports.calculatePayoutAmount = calculatePayoutAmount;
+// ============================================================
+// Network constants
+// ============================================================
 exports.STELLAR_NETWORK = {
     testnet: 'https://horizon-testnet.stellar.org',
-    mainnet: 'https://horizon.stellar.org'
+    mainnet: 'https://horizon.stellar.org',
 };
+// ============================================================
 // Utility functions
-function formatAmount(amount) {
-    return (amount / 10000000).toFixed(2); // Convert stroops to XLM
+// ============================================================
+/**
+ * Convert stroops to XLM.
+ * 1 XLM = 10,000,000 stroops
+ */
+function stroopsToXLM(stroops) {
+    return Number(stroops) / 10000000;
 }
+/**
+ * Convert XLM to stroops.
+ */
+function xlmToStroops(xlm) {
+    return BigInt(Math.floor(xlm * 10000000));
+}
+/**
+ * Format a stroops amount as a human-readable XLM string.
+ * e.g. 500000000n → "50.00 XLM"
+ */
+function formatXLM(stroops) {
+    const xlm = stroopsToXLM(stroops);
+    return `${xlm.toLocaleString(undefined, { maximumFractionDigits: 2 })} XLM`;
+}
+/**
+ * Convert a Unix timestamp (seconds) to a JS Date object.
+ */
+function timestampToDate(timestamp) {
+    return new Date(Number(timestamp) * 1000);
+}
+/**
+ * Format a Unix timestamp as a readable date string.
+ * e.g. 1704067200n → "Jan 1, 2024"
+ */
+function formatTimestamp(timestamp) {
+    return timestampToDate(timestamp).toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+    });
+}
+/**
+ * Returns true if a contribution amount matches the required group amount.
+ */
 function validateContribution(amount, required) {
     return amount === required;
+}
+/**
+ * Calculate the total payout pool for a group.
+ * Deducts the platform fee before returning.
+ */
+function calculatePayoutAmount(contributionAmount, totalMembers, platformFeePercent) {
+    const totalPool = contributionAmount * BigInt(totalMembers);
+    const fee = (totalPool * BigInt(platformFeePercent)) / 10000n;
+    return totalPool - fee;
 }


### PR DESCRIPTION

## ✅ Completed

- Added [groupId].tsx
- Reads `groupId` from route params via `useLocalSearchParams`
- Shows a hardcoded mock group matching the ID
- Includes `GroupDetailHeader` with:
  - group name
  - status badge
  - XLM contribution amount
  - frequency
  - member count
- Added a top navigation header with a back button that calls `router.back()` to return to the groups list

No TypeScript errors were found in the new page.

Made changes.


Closes #89 

## ✅ Done

Implemented page.tsx with:

- filter tab bar: `All`, `Joined`, `Open`
- `useState` tracking for active filter
- mock group data with `userJoined` and `status`
- filtered group list:
  - `All` shows everything
  - `Joined` shows `userJoined === true`
  - `Open` shows `status === 'Open'`
- active tab visually highlighted with background and active indicator
- group cards that navigate to `/groups/[groupId]`

Files updated:
- page.tsx

Validation:
- No TypeScript or syntax errors found in the new page or existing group detail page.

Made changes.

Closes #88 

## ✅ Updated

Implemented pull-to-refresh on page.tsx:

- Added `refreshing` state with `useState`
- Added `onRefresh` callback to simulate fetch delay
- Switched list rendering to `FlatList`
- Added `RefreshControl` using `refreshing` and `onRefresh`
- Set spinner `tintColor="#0F172A"` (primary color)

Result:
- pulling down shows refresh spinner
- spinner hides after 1 second
- list layout remains stable during refresh

Made changes.

Closes #87 

## ✅ Completed

Added MemberAvatarStack.tsx and integrated it into [groupId].tsx.

What’s included:
- Overlapping avatar stack with negative left margin
- `maxVisible` default to `5`
- `+N` badge for extra members
- `View All Members` tappable link
- mock member data in group detail screen
- handles a single-member case correctly

Validation:
- No TypeScript or syntax errors found in the new files.

Made changes.

Closes #90 