### PR TITLE
feat(mobile): navigation, path aliases, lint, Button component

### DIFF
--- a/mobile/.eslintrc.js
+++ b/mobile/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  extends: ['expo', 'plugin:@typescript-eslint/recommended'],
+  plugins: ['react', 'react-native'],
+  rules: {},
+};

--- a/mobile/.prettierrc
+++ b/mobile/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "all"
+}

--- a/mobile/app/(tabs)/_layout.tsx
+++ b/mobile/app/(tabs)/_layout.tsx
@@ -1,0 +1,36 @@
+import { Tabs } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+
+const TAB_BAR_BG = '#0F172A';
+const ACTIVE = '#6366F1';
+const INACTIVE = '#64748B';
+
+export default function TabsLayout() {
+  return (
+    <Tabs
+      screenOptions={{
+        headerShown: false,
+        tabBarStyle: { backgroundColor: TAB_BAR_BG, borderTopWidth: 0 },
+        tabBarActiveTintColor: ACTIVE,
+        tabBarInactiveTintColor: INACTIVE,
+      }}
+    >
+      <Tabs.Screen
+        name="index"
+        options={{ title: 'Home', tabBarIcon: ({ color }) => <Ionicons name="home-outline" size={22} color={color} /> }}
+      />
+      <Tabs.Screen
+        name="groups"
+        options={{ title: 'Groups', tabBarIcon: ({ color }) => <Ionicons name="people-outline" size={22} color={color} /> }}
+      />
+      <Tabs.Screen
+        name="notifications"
+        options={{ title: 'Notifications', tabBarIcon: ({ color }) => <Ionicons name="notifications-outline" size={22} color={color} /> }}
+      />
+      <Tabs.Screen
+        name="profile"
+        options={{ title: 'Profile', tabBarIcon: ({ color }) => <Ionicons name="person-outline" size={22} color={color} /> }}
+      />
+    </Tabs>
+  );
+}

--- a/mobile/app/(tabs)/groups.tsx
+++ b/mobile/app/(tabs)/groups.tsx
@@ -1,0 +1,5 @@
+import { View, Text } from 'react-native';
+
+export default function GroupsScreen() {
+  return <View style={{ flex: 1, backgroundColor: '#0F172A', justifyContent: 'center', alignItems: 'center' }}><Text style={{ color: '#fff' }}>Groups</Text></View>;
+}

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -39,12 +39,10 @@ export default function HomeScreen() {
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.content}>
       <HomeHeader />
-      {/* Balance placeholder */}
       <View style={styles.section}>
         <Text style={styles.sectionLabel}>Total Balance</Text>
         <Text style={styles.sectionValue}>— XLM</Text>
       </View>
-      {/* Quick actions placeholder */}
       <View style={styles.section}>
         <Text style={styles.sectionLabel}>Quick Actions</Text>
       </View>

--- a/mobile/app/(tabs)/notifications.tsx
+++ b/mobile/app/(tabs)/notifications.tsx
@@ -1,0 +1,5 @@
+import { View, Text } from 'react-native';
+
+export default function NotificationsScreen() {
+  return <View style={{ flex: 1, backgroundColor: '#0F172A', justifyContent: 'center', alignItems: 'center' }}><Text style={{ color: '#fff' }}>Notifications</Text></View>;
+}

--- a/mobile/app/(tabs)/profile.tsx
+++ b/mobile/app/(tabs)/profile.tsx
@@ -1,0 +1,5 @@
+import { View, Text } from 'react-native';
+
+export default function ProfileScreen() {
+  return <View style={{ flex: 1, backgroundColor: '#0F172A', justifyContent: 'center', alignItems: 'center' }}><Text style={{ color: '#fff' }}>Profile</Text></View>;
+}

--- a/mobile/babel.config.js
+++ b/mobile/babel.config.js
@@ -1,0 +1,9 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: [
+      ['module-resolver', { root: ['.'], alias: { '@': '.' } }],
+    ],
+  };
+};

--- a/mobile/components/ui/Button.tsx
+++ b/mobile/components/ui/Button.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { TouchableOpacity, Text, ActivityIndicator, StyleSheet, ViewStyle } from 'react-native';
+
+type Variant = 'primary' | 'secondary' | 'outline' | 'ghost';
+type Size = 'sm' | 'md' | 'lg';
+
+interface ButtonProps {
+  variant?: Variant;
+  size?: Size;
+  onPress?: () => void;
+  disabled?: boolean;
+  loading?: boolean;
+  children: React.ReactNode;
+}
+
+const bg: Record<Variant, string> = {
+  primary: '#6366F1',
+  secondary: '#1E293B',
+  outline: 'transparent',
+  ghost: 'transparent',
+};
+
+const border: Record<Variant, string> = {
+  primary: '#6366F1',
+  secondary: '#1E293B',
+  outline: '#6366F1',
+  ghost: 'transparent',
+};
+
+const textColor: Record<Variant, string> = {
+  primary: '#fff',
+  secondary: '#fff',
+  outline: '#6366F1',
+  ghost: '#6366F1',
+};
+
+const padding: Record<Size, ViewStyle> = {
+  sm: { paddingVertical: 6, paddingHorizontal: 12 },
+  md: { paddingVertical: 10, paddingHorizontal: 20 },
+  lg: { paddingVertical: 14, paddingHorizontal: 28 },
+};
+
+const fontSize: Record<Size, number> = { sm: 13, md: 15, lg: 17 };
+
+export default function Button({ variant = 'primary', size = 'md', onPress, disabled, loading, children }: ButtonProps) {
+  const isDisabled = disabled || loading;
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      disabled={isDisabled}
+      style={[styles.base, padding[size], { backgroundColor: bg[variant], borderColor: border[variant], opacity: isDisabled ? 0.5 : 1 }]}
+      activeOpacity={0.8}
+    >
+      {loading
+        ? <ActivityIndicator color={textColor[variant]} size="small" />
+        : <Text style={{ color: textColor[variant], fontSize: fontSize[size], fontWeight: '600' }}>{children}</Text>}
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  base: { borderRadius: 8, borderWidth: 1, alignItems: 'center', justifyContent: 'center' },
+});

--- a/mobile/components/ui/index.ts
+++ b/mobile/components/ui/index.ts
@@ -5,3 +5,4 @@ export { Card } from './Card';
 export { EmptyState } from './EmptyState';
 export { Divider } from './Divider';
 export { SectionHeader } from './SectionHeader';
+export { default as Button } from './Button';

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "esustellar-mobile",
+  "version": "1.0.0",
+  "main": "expo-router/entry",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "lint": "eslint . --ext .ts,.tsx",
+    "format": "prettier --write ."
+  },
+  "dependencies": {
+    "expo": "~51.0.0",
+    "expo-router": "~3.5.0",
+    "expo-status-bar": "~1.12.1",
+    "@expo/vector-icons": "^14.0.0",
+    "react": "18.2.0",
+    "react-native": "0.74.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.24.0",
+    "babel-plugin-module-resolver": "^5.0.0",
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "@typescript-eslint/parser": "^7.0.0",
+    "eslint": "^8.57.0",
+    "eslint-config-expo": "^7.0.0",
+    "eslint-plugin-react": "^7.34.0",
+    "eslint-plugin-react-native": "^4.1.0",
+    "prettier": "^3.2.0",
+    "typescript": "~5.3.0"
+  }
+}

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}


### PR DESCRIPTION
Closes #67, closes #68, closes #69, closes #70

- Expo Router root Stack + bottom Tabs (Home, Groups, Notifications, Profile) with dark theme
- TS path aliases `@/*` in tsconfig + babel module-resolver
- ESLint (expo + @typescript-eslint) + Prettier with lint/format scripts
- Reusable `Button` component (4 variants, 3 sizes, loading/disabled states)