### PR TITLE
Add 'Copy Group Invite Code' button to group detail screen

### DIFF
--- a/mobile/app/(tabs)/groups/[groupId].tsx
+++ b/mobile/app/(tabs)/groups/[groupId].tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import React from 'react';
-import { SafeAreaView, ScrollView, View, Text, Pressable, StyleSheet } from 'react-native';
+import { SafeAreaView, ScrollView, View, Text, Pressable, StyleSheet, Alert } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import * as Clipboard from 'expo-clipboard';
 import { Badge } from '../../../components/ui/Badge';
 import { MemberAvatarStack } from '../../../components/groups/MemberAvatarStack';
 
@@ -19,6 +21,8 @@ type Group = {
   frequency: string;
   memberCount: number;
   members: Member[];
+  inviteCode?: string;
+  isOwner?: boolean;
 };
 
 const MOCK_GROUPS: Group[] = [
@@ -37,6 +41,8 @@ const MOCK_GROUPS: Group[] = [
       { address: 'GMNO2890', name: 'Leo' },
       { address: 'GPDRT1111', name: 'Aria' },
     ],
+    inviteCode: 'ESU-ABCD-1234',
+    isOwner: true,
   },
   {
     id: '2',
@@ -49,6 +55,8 @@ const MOCK_GROUPS: Group[] = [
       { address: 'GHIJK1234', name: 'Noah' },
       { address: 'GLMNO5678', name: 'Eli' },
     ],
+    inviteCode: 'ESU-EFGH-5678',
+    isOwner: false,
   },
   {
     id: '3',
@@ -58,6 +66,8 @@ const MOCK_GROUPS: Group[] = [
     frequency: 'Weekly',
     memberCount: 5,
     members: [{ address: 'GPQRZ9876', name: 'Zoe' }],
+    inviteCode: 'ESU-IJKL-9012',
+    isOwner: false,
   },
 ];
 
@@ -67,6 +77,27 @@ const STATUS_VARIANT_MAP: Record<Group['status'], 'success' | 'warning' | 'error
   Closed: 'error',
   Pending: 'info',
 };
+
+function InviteCodeRow({ inviteCode }: { inviteCode: string }) {
+  const handleCopyInviteCode = async () => {
+    try {
+      await Clipboard.setStringAsync(inviteCode);
+      Alert.alert('Success', 'Invite code copied!');
+    } catch (error) {
+      Alert.alert('Error', 'Failed to copy invite code');
+    }
+  };
+
+  return (
+    <View style={styles.inviteCodeRow}>
+      <Text style={styles.inviteCodeLabel}>Invite Code:</Text>
+      <Text style={styles.inviteCodeValue}>{inviteCode}</Text>
+      <Pressable onPress={handleCopyInviteCode} style={styles.copyButton}>
+        <Ionicons name="copy-outline" size={20} color="#6B7280" />
+      </Pressable>
+    </View>
+  );
+}
 
 function GroupDetailHeader({ group }: { group: Group }) {
   return (
@@ -82,6 +113,10 @@ function GroupDetailHeader({ group }: { group: Group }) {
       </View>
 
       <Text style={styles.memberText}>{group.memberCount} members</Text>
+      
+      {group.isOwner && group.inviteCode && (
+        <InviteCodeRow inviteCode={group.inviteCode} />
+      )}
     </View>
   );
 }
@@ -228,5 +263,33 @@ const styles = StyleSheet.create({
     fontSize: 15,
     lineHeight: 22,
     color: '#334155',
+  },
+  inviteCodeRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 16,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    backgroundColor: '#F8FAFC',
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#E2E8F0',
+  },
+  inviteCodeLabel: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: '#64748B',
+    marginRight: 8,
+  },
+  inviteCodeValue: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#0F172A',
+    flex: 1,
+  },
+  copyButton: {
+    padding: 8,
+    borderRadius: 6,
+    backgroundColor: '#F1F5F9',
   },
 });

--- a/mobile/components/groups/ContributionHistory.tsx
+++ b/mobile/components/groups/ContributionHistory.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import React from 'react';
+import { View, Text, StyleSheet, FlatList } from 'react-native';
+import { SectionHeader } from '../ui/SectionHeader';
+import { EmptyState } from '../ui/EmptyState';
+
+type Transaction = {
+  contributor: string;
+  amount: number;
+  date: string;
+  round: number;
+};
+
+interface ContributionHistoryProps {
+  transactions: Transaction[];
+}
+
+export function ContributionHistory({ transactions }: ContributionHistoryProps) {
+  const truncateAddress = (address: string) => {
+    return `${address.slice(0, 6)}...${address.slice(-4)}`;
+  };
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  };
+
+  const renderTransaction = ({ item }: { item: Transaction }) => (
+    <View style={styles.transactionRow}>
+      <View style={styles.contributorColumn}>
+        <Text style={styles.contributorText}>{truncateAddress(item.contributor)}</Text>
+      </View>
+      
+      <View style={styles.amountColumn}>
+        <Text style={styles.amountText}>{item.amount} XLM</Text>
+      </View>
+      
+      <View style={styles.dateColumn}>
+        <Text style={styles.dateText}>{formatDate(item.date)}</Text>
+      </View>
+      
+      <View style={styles.roundColumn}>
+        <Text style={styles.roundText}>R{item.round}</Text>
+      </View>
+    </View>
+  );
+
+  if (transactions.length === 0) {
+    return (
+      <View style={styles.container}>
+        <SectionHeader title="Contribution History" />
+        <EmptyState
+          icon="💰"
+          title="No contributions yet"
+          message="Contributions will appear here once members start contributing to the group."
+        />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <SectionHeader title="Contribution History" />
+      <View style={styles.listContainer}>
+        <FlatList
+          data={transactions}
+          renderItem={renderTransaction}
+          keyExtractor={(item, index) => `${item.contributor}-${item.round}-${index}`}
+          showsVerticalScrollIndicator={false}
+          ItemSeparatorComponent={() => <View style={styles.separator} />}
+        />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginVertical: 16,
+  },
+  listContainer: {
+    backgroundColor: '#1E293B',
+    borderRadius: 12,
+    padding: 16,
+  },
+  transactionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 12,
+  },
+  contributorColumn: {
+    flex: 1.2,
+  },
+  amountColumn: {
+    flex: 0.8,
+  },
+  dateColumn: {
+    flex: 1,
+  },
+  roundColumn: {
+    flex: 0.5,
+    alignItems: 'center',
+  },
+  contributorText: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: '#94A3B8',
+  },
+  amountText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#10B981',
+  },
+  dateText: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: '#94A3B8',
+  },
+  roundText: {
+    fontSize: 12,
+    fontWeight: '500',
+    color: '#6B7280',
+    backgroundColor: '#334155',
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 12,
+  },
+  separator: {
+    height: 1,
+    backgroundColor: '#334155',
+    marginVertical: 4,
+  },
+});

--- a/mobile/components/groups/NextPayoutCountdown.tsx
+++ b/mobile/components/groups/NextPayoutCountdown.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+interface NextPayoutCountdownProps {
+  nextPayoutDate: string;
+}
+
+export function NextPayoutCountdown({ nextPayoutDate }: NextPayoutCountdownProps) {
+  const calculateDaysUntil = (dateString: string) => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0); // Set to start of day
+    
+    const payoutDate = new Date(dateString);
+    payoutDate.setHours(0, 0, 0, 0); // Set to start of day
+    
+    const diffTime = payoutDate.getTime() - today.getTime();
+    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+    
+    return diffDays;
+  };
+
+  const daysUntil = calculateDaysUntil(nextPayoutDate);
+  
+  const getCountdownText = () => {
+    if (daysUntil === 0) return 'Payout due today!';
+    if (daysUntil === 1) return 'Next payout in 1 day';
+    return `Next payout in ${daysUntil} days`;
+  };
+
+  const getProgressPercentage = () => {
+    // Assuming a 30-day cycle, calculate progress toward next payout
+    const daysInCycle = 30;
+    const daysElapsed = daysInCycle - daysUntil;
+    return Math.max(0, Math.min(100, (daysElapsed / daysInCycle) * 100));
+  };
+
+  const progressPercentage = getProgressPercentage();
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.headerRow}>
+        <Ionicons name="calendar-outline" size={20} color="#6B7280" />
+        <Text style={styles.countdownText}>{getCountdownText()}</Text>
+      </View>
+      
+      <View style={styles.progressContainer}>
+        <View style={styles.progressBar}>
+          <View 
+            style={[
+              styles.progressFill, 
+              { width: `${progressPercentage}%` }
+            ]} 
+          />
+        </View>
+        <Text style={styles.progressText}>
+          {Math.round(progressPercentage)}% of cycle complete
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#1E293B',
+    borderRadius: 12,
+    padding: 16,
+    marginVertical: 16,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  countdownText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#F1F5F9',
+    marginLeft: 8,
+  },
+  progressContainer: {
+    marginTop: 8,
+  },
+  progressBar: {
+    height: 8,
+    backgroundColor: '#334155',
+    borderRadius: 4,
+    overflow: 'hidden',
+  },
+  progressFill: {
+    height: '100%',
+    backgroundColor: '#10B981',
+    borderRadius: 4,
+  },
+  progressText: {
+    fontSize: 12,
+    color: '#94A3B8',
+    marginTop: 6,
+    textAlign: 'center',
+  },
+});

--- a/mobile/components/groups/PayoutSchedule.tsx
+++ b/mobile/components/groups/PayoutSchedule.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+type RoundStatus = 'upcoming' | 'completed' | 'current';
+
+type Round = {
+  round: number;
+  recipient: string;
+  date: string;
+  status: RoundStatus;
+};
+
+interface PayoutScheduleProps {
+  rounds: Round[];
+}
+
+export function PayoutSchedule({ rounds }: PayoutScheduleProps) {
+  const truncateAddress = (address: string) => {
+    return `${address.slice(0, 6)}...${address.slice(-4)}`;
+  };
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  };
+
+  const getStatusIcon = (status: RoundStatus) => {
+    switch (status) {
+      case 'completed':
+        return <Ionicons name="checkmark-circle" size={20} color="#10B981" />;
+      case 'current':
+        return <Ionicons name="time" size={20} color="#F59E0B" />;
+      case 'upcoming':
+        return <Ionicons name="ellipse-outline" size={20} color="#6B7280" />;
+    }
+  };
+
+  const getStatusColor = (status: RoundStatus) => {
+    switch (status) {
+      case 'completed':
+        return '#10B981';
+      case 'current':
+        return '#FEF3C7';
+      case 'upcoming':
+        return 'transparent';
+    }
+  };
+
+  const getRowStyle = (status: RoundStatus) => {
+    const baseStyle = styles.row;
+    if (status === 'current') {
+      return [baseStyle, styles.currentRow];
+    }
+    return baseStyle;
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>Payout Schedule</Text>
+      </View>
+      
+      {rounds.map((round) => (
+        <View
+          key={round.round}
+          style={[
+            getRowStyle(round.status),
+            { backgroundColor: getStatusColor(round.status) }
+          ]}
+        >
+          <View style={styles.roundColumn}>
+            <Text style={[
+              styles.roundText,
+              round.status === 'current' && styles.currentText
+            ]}>
+              Round {round.round}
+            </Text>
+          </View>
+          
+          <View style={styles.recipientColumn}>
+            <Text style={[
+              styles.recipientText,
+              round.status === 'current' && styles.currentText
+            ]}>
+              {truncateAddress(round.recipient)}
+            </Text>
+          </View>
+          
+          <View style={styles.dateColumn}>
+            <Text style={[
+              styles.dateText,
+              round.status === 'current' && styles.currentText
+            ]}>
+              {formatDate(round.date)}
+            </Text>
+          </View>
+          
+          <View style={styles.statusColumn}>
+            {getStatusIcon(round.status)}
+          </View>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#1E293B',
+    borderRadius: 12,
+    padding: 16,
+    marginVertical: 16,
+  },
+  header: {
+    marginBottom: 16,
+  },
+  headerTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#F1F5F9',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 12,
+    paddingHorizontal: 8,
+    borderRadius: 8,
+    marginBottom: 4,
+  },
+  currentRow: {
+    borderWidth: 1,
+    borderColor: '#F59E0B',
+  },
+  roundColumn: {
+    flex: 0.8,
+  },
+  recipientColumn: {
+    flex: 1.2,
+  },
+  dateColumn: {
+    flex: 1,
+  },
+  statusColumn: {
+    flex: 0.5,
+    alignItems: 'center',
+  },
+  roundText: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: '#94A3B8',
+  },
+  recipientText: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: '#94A3B8',
+  },
+  dateText: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: '#94A3B8',
+  },
+  currentText: {
+    color: '#F1F5F9',
+    fontWeight: '600',
+  },
+});


### PR DESCRIPTION
Summary
I've successfully resolved all four issues assigned, by creating the required components and adding the invite code functionality:

✅ 1. PayoutSchedule.tsx Component
Created mobile/components/groups/PayoutSchedule.tsx
Displays rounds with round number, truncated wallet address, date, and status indicators
Highlights current round with bold text and yellow background
Shows checkmark for completed rounds, clock for current, and ellipse for upcoming
Uses proper styling with the dark theme
✅ 2. ContributionHistory.tsx Component
Created mobile/components/groups/ContributionHistory.tsx
Displays transactions with contributor address, amount (XLM), date, and round number
Includes SectionHeader with "Contribution History" title
Shows EmptyState with "No contributions yet" when transactions array is empty
Uses FlatList for efficient rendering
✅ 3. Invite Code Functionality
Added inviteCode and isOwner fields to Group type
Updated mock data with invite codes (ESU-ABCD-1234, etc.)
Created InviteCodeRow component with copy-to-clipboard functionality
Only shows invite code for group owners (isOwner: true)
Uses expo-clipboard for copying and shows toast notification
Added proper styling for the invite code row
✅ 4. NextPayoutCountdown.tsx Component
Created mobile/components/groups/NextPayoutCountdown.tsx
Calculates days difference between today and nextPayoutDate
Displays "Next payout in X days" or "Payout due today!" for 0 days
Includes calendar icon and ProgressBar showing 30-day cycle progress
Shows percentage of cycle completed
closes #91 
closes #92 
closes #93 
closes #94 