### PR TITLE
fix(mobile): resolve issues #115, #116, #125, #126

### DIFF
--- a/mobile/app/(tabs)/groups/[groupId].tsx
+++ b/mobile/app/(tabs)/groups/[groupId].tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { SafeAreaView, ScrollView, View, Text, Pressable, StyleSheet } from 'react-native';
+import { SafeAreaView, FlatList, View, Text, Pressable, StyleSheet } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { Badge } from '../../../components/ui/Badge';
 import { MemberAvatarStack } from '../../../components/groups/MemberAvatarStack';
@@ -86,11 +86,59 @@ function GroupDetailHeader({ group }: { group: Group }) {
   );
 }
 
+type Section = { key: string };
+
 export default function GroupDetailPage() {
   const router = useRouter();
   const params = useLocalSearchParams<{ groupId?: string }>();
   const groupId = params.groupId ?? '';
   const group = MOCK_GROUPS.find((item) => item.id === groupId) || null;
+
+  const sections: Section[] = group
+    ? [{ key: 'header' }, { key: 'members' }, { key: 'overview' }, { key: 'groupId' }]
+    : [{ key: 'notFound' }];
+
+  const renderItem = ({ item }: { item: Section }) => {
+    if (!group) {
+      return (
+        <View style={styles.section}>
+          <Text style={styles.sectionHeading}>Group not found</Text>
+          <Text style={styles.sectionText}>
+            No mock group was found for the requested ID. Use a valid group link to see details.
+          </Text>
+        </View>
+      );
+    }
+    switch (item.key) {
+      case 'header':
+        return <GroupDetailHeader group={group} />;
+      case 'members':
+        return (
+          <View style={styles.section}>
+            <Text style={styles.sectionHeading}>Members</Text>
+            <MemberAvatarStack members={group.members} onViewAll={() => {}} />
+          </View>
+        );
+      case 'overview':
+        return (
+          <View style={styles.section}>
+            <Text style={styles.sectionHeading}>Overview</Text>
+            <Text style={styles.sectionText}>
+              This is the group detail screen for &quot;{group.name}&quot;. The group has a contribution amount of {group.contribution} paid {group.frequency.toLowerCase()}, and currently includes {group.memberCount} members.
+            </Text>
+          </View>
+        );
+      case 'groupId':
+        return (
+          <View style={styles.section}>
+            <Text style={styles.sectionHeading}>Group ID</Text>
+            <Text style={styles.sectionText}>{groupId}</Text>
+          </View>
+        );
+      default:
+        return null;
+    }
+  };
 
   return (
     <SafeAreaView style={styles.container}>
@@ -101,37 +149,12 @@ export default function GroupDetailPage() {
         <Text style={styles.screenTitle}>Group Details</Text>
       </View>
 
-      <ScrollView contentContainerStyle={styles.content}>
-        {group ? (
-          <>
-            <GroupDetailHeader group={group} />
-
-            <View style={styles.section}>
-              <Text style={styles.sectionHeading}>Members</Text>
-              <MemberAvatarStack members={group.members} onViewAll={() => {}} />
-            </View>
-
-            <View style={styles.section}>
-              <Text style={styles.sectionHeading}>Overview</Text>
-              <Text style={styles.sectionText}>
-                This is the group detail screen for “{group.name}”. The group has a contribution amount of {group.contribution} paid {group.frequency.toLowerCase()}, and currently includes {group.memberCount} members.
-              </Text>
-            </View>
-
-            <View style={styles.section}>
-              <Text style={styles.sectionHeading}>Group ID</Text>
-              <Text style={styles.sectionText}>{groupId}</Text>
-            </View>
-          </>
-        ) : (
-          <View style={styles.section}>
-            <Text style={styles.sectionHeading}>Group not found</Text>
-            <Text style={styles.sectionText}>
-              No mock group was found for the requested ID. Use a valid group link to see details.
-            </Text>
-          </View>
-        )}
-      </ScrollView>
+      <FlatList
+        data={sections}
+        keyExtractor={(item) => item.key}
+        renderItem={renderItem}
+        contentContainerStyle={styles.content}
+      />
     </SafeAreaView>
   );
 }

--- a/mobile/app/groups/join.tsx
+++ b/mobile/app/groups/join.tsx
@@ -1,0 +1,99 @@
+import React, { useState } from 'react';
+import { SafeAreaView, View, Text, Pressable, StyleSheet } from 'react-native';
+import { useRouter } from 'expo-router';
+import { TextInput } from '../../components/ui/TextInput';
+
+const INVITE_CODE_REGEX = /^ESU-[A-Z0-9]{4}-[0-9]{4}$/;
+
+export default function JoinGroupScreen() {
+  const router = useRouter();
+  const [code, setCode] = useState('');
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  const handleChange = (value: string) => {
+    setCode(value);
+    if (error) setError(undefined);
+  };
+
+  const handleJoin = () => {
+    if (!code.trim()) {
+      setError('Invite code is required');
+      return;
+    }
+    if (!INVITE_CODE_REGEX.test(code.trim())) {
+      setError('Invalid invite code format');
+      return;
+    }
+    // TODO: submit join request
+    router.back();
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.navHeader}>
+        <Pressable onPress={() => router.back()} style={styles.backButton}>
+          <Text style={styles.backButtonText}>Back</Text>
+        </Pressable>
+        <Text style={styles.screenTitle}>Join Group</Text>
+      </View>
+
+      <View style={styles.content}>
+        <Text style={styles.description}>
+          Enter the invite code shared by the group organizer.{'\n'}
+          Format: ESU-XXXX-0000
+        </Text>
+
+        <TextInput
+          label="Invite Code"
+          placeholder="ESU-XXXX-0000"
+          value={code}
+          onChangeText={handleChange}
+          autoCapitalize="characters"
+          autoCorrect={false}
+          error={error}
+        />
+
+        <Pressable
+          onPress={handleJoin}
+          disabled={!code.trim()}
+          style={[styles.joinButton, !code.trim() && styles.joinButtonDisabled]}
+        >
+          <Text style={styles.joinButtonText}>Join</Text>
+        </Pressable>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#F8FAFC' },
+  navHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingTop: 16,
+    paddingBottom: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#CBD5E1',
+    backgroundColor: '#FFFFFF',
+  },
+  backButton: {
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 8,
+    backgroundColor: '#E2E8F0',
+  },
+  backButtonText: { color: '#0F172A', fontWeight: '600' },
+  screenTitle: { marginLeft: 16, fontSize: 18, fontWeight: '700', color: '#0F172A' },
+  content: { padding: 24 },
+  description: { fontSize: 14, color: '#475569', marginBottom: 24, lineHeight: 20 },
+  joinButton: {
+    marginTop: 8,
+    paddingVertical: 14,
+    borderRadius: 12,
+    backgroundColor: '#0F172A',
+    alignItems: 'center',
+  },
+  joinButtonDisabled: { opacity: 0.4 },
+  joinButtonText: { color: '#FFFFFF', fontWeight: '700', fontSize: 16 },
+});

--- a/mobile/app/settings/page.tsx
+++ b/mobile/app/settings/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
+import Constants from 'expo-constants';
 import {
   biometricService,
   pinService,
@@ -301,6 +302,24 @@ export default function SettingsPage() {
             <span className="text-sm">Checking device capabilities…</span>
           </div>
         )}
+      </section>
+
+      {/* ── About Section ─────────────────────────────────────────────────── */}
+      <section className="space-y-3">
+        <h2 className="text-lg font-semibold text-gray-800">About</h2>
+        <div className="p-4 bg-white border border-gray-200 rounded-lg space-y-1">
+          <p className="text-sm text-gray-700">
+            Version{' '}
+            <span className="font-medium">
+              {Constants.expoConfig?.version ?? 'N/A'}
+            </span>
+          </p>
+          {Constants.expoConfig?.extra?.buildNumber != null && (
+            <p className="text-sm text-gray-500">
+              Build: {Constants.expoConfig.extra.buildNumber}
+            </p>
+          )}
+        </div>
       </section>
 
       {/* ── PIN Section ────────────────────────────────────────────────────── */}

--- a/mobile/services/media/imageCache.ts
+++ b/mobile/services/media/imageCache.ts
@@ -1,0 +1,54 @@
+import * as FileSystem from 'expo-file-system';
+
+const CACHE_DIR = `${FileSystem.cacheDirectory}esustellar_images/`;
+
+/** Ensure the cache directory exists. */
+async function ensureCacheDir(): Promise<void> {
+  const info = await FileSystem.getInfoAsync(CACHE_DIR);
+  if (!info.exists) {
+    await FileSystem.makeDirectoryAsync(CACHE_DIR, { intermediates: true });
+  }
+}
+
+/** Derive a stable filename from a URL. */
+function cacheKey(url: string): string {
+  // Replace non-alphanumeric chars to get a safe filename
+  return url.replace(/[^a-zA-Z0-9]/g, '_').slice(-120);
+}
+
+/**
+ * Returns a local URI for the given remote image URL.
+ * Downloads and caches the image on first access; returns the cached
+ * path on subsequent calls.
+ */
+export async function getCachedImageUri(url: string): Promise<string> {
+  await ensureCacheDir();
+  const localPath = `${CACHE_DIR}${cacheKey(url)}`;
+  const info = await FileSystem.getInfoAsync(localPath);
+  if (info.exists) {
+    return localPath;
+  }
+  const result = await FileSystem.downloadAsync(url, localPath);
+  return result.uri;
+}
+
+/**
+ * Removes a single cached image.
+ */
+export async function evictCachedImage(url: string): Promise<void> {
+  const localPath = `${CACHE_DIR}${cacheKey(url)}`;
+  const info = await FileSystem.getInfoAsync(localPath);
+  if (info.exists) {
+    await FileSystem.deleteAsync(localPath, { idempotent: true });
+  }
+}
+
+/**
+ * Clears the entire image cache directory.
+ */
+export async function clearImageCache(): Promise<void> {
+  const info = await FileSystem.getInfoAsync(CACHE_DIR);
+  if (info.exists) {
+    await FileSystem.deleteAsync(CACHE_DIR, { idempotent: true });
+  }
+}

--- a/mobile/services/media/index.ts
+++ b/mobile/services/media/index.ts
@@ -1,0 +1,1 @@
+export { getCachedImageUri, evictCachedImage, clearImageCache } from './imageCache';


### PR DESCRIPTION
## Summary

Resolves four issues assigned to PortableDD.

### Changes

**#115 — App version in Settings > About**
- Imported `expo-constants` in `mobile/app/settings/page.tsx`
- Added an About section that reads `Constants.expoConfig?.version` dynamically
- Falls back to `'N/A'` if version is undefined; shows `buildNumber` when present

**#116 — Join group form validation**
- Created `mobile/app/groups/join.tsx`
- Validates invite code is non-empty and matches `/^ESU-[A-Z0-9]{4}-[0-9]{4}$/`
- Shows inline error via `TextInput`'s `error` prop
- Join button disabled while input is empty; error clears on edit

**#125 — Virtualized lists**
- Replaced `ScrollView` with `FlatList` in `mobile/app/(tabs)/groups/[groupId].tsx`
- Group detail sections rendered as keyed FlatList items for efficient virtualization

**#126 — Image caching service**
- Created `mobile/services/media/imageCache.ts` using `expo-file-system`
- `getCachedImageUri(url)` — downloads on first access, returns cached path thereafter
- `evictCachedImage(url)` — removes a single cached entry
- `clearImageCache()` — wipes the entire cache directory
- Exported via `mobile/services/media/index.ts`

Closes #115
Closes #116
Closes #125
Closes #126