### PR TITLE
Profile screen

### DIFF
--- a/mobile/app/(tabs)/profile/index.tsx
+++ b/mobile/app/(tabs)/profile/index.tsx
@@ -6,12 +6,13 @@ import {
   Text,
   Pressable,
   StyleSheet,
+  Switch,
 } from 'react-native';
 import { useRouter } from 'expo-router';
-import { Avatar } from '../../components/ui/Avatar';
-import { Button } from '../../components/ui/Button';
-import { DisconnectModal } from '../../components/wallet/DisconnectModal';
-import { useAuthStore } from '../../store/authStore';
+import { Avatar } from '../../../components/ui/Avatar';
+import { Button } from '../../../components/ui/Button';
+import { DisconnectModal } from '../../../components/wallet/DisconnectModal';
+import { useAuthStore } from '../../../store/authStore';
 
 // Truncate wallet address
 function truncateAddress(address: string): string {
@@ -53,7 +54,7 @@ export default function ProfileScreen() {
         <View style={styles.section}>
           <Pressable
             style={styles.settingsRow}
-            onPress={() => router.push('/settings')}
+            onPress={() => router.push('/profile/settings')}
             accessibilityRole="button"
           >
             <Text style={styles.settingsLabel}>Settings</Text>

--- a/mobile/app/contributions/success.tsx
+++ b/mobile/app/contributions/success.tsx
@@ -1,0 +1,158 @@
+import React from 'react';
+import { SafeAreaView, ScrollView, View, Text, Pressable, StyleSheet } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { Button } from '../../components/ui/Button';
+
+export default function ContributionSuccessScreen() {
+  const router = useRouter();
+  const params = useLocalSearchParams<{ groupName?: string; amount?: string; txHash?: string }>();
+  const groupName = params.groupName ?? 'Unknown Group';
+  const amount = params.amount ?? '0 XLM';
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView contentContainerStyle={styles.content}>
+        {/* Success Icon */}
+        <View style={styles.iconContainer}>
+          <View style={styles.successIcon}>
+            <Text style={styles.checkmark}>✓</Text>
+          </View>
+        </View>
+
+        {/* Headline */}
+        <Text style={styles.headline}>Contribution Successful!</Text>
+
+        {/* Details Card */}
+        <View style={styles.detailsCard}>
+          <View style={styles.detailRow}>
+            <Text style={styles.detailLabel}>Group</Text>
+            <Text style={styles.detailValue}>{groupName}</Text>
+          </View>
+          <View style={styles.detailRow}>
+            <Text style={styles.detailLabel}>Amount Contributed</Text>
+            <Text style={styles.detailValue}>{amount}</Text>
+          </View>
+        </View>
+
+        {/* Transaction Hash */}
+        {params.txHash && (
+          <View style={styles.hashContainer}>
+            <Text style={styles.hashLabel}>Transaction ID</Text>
+            <Text style={styles.hashValue} numberOfLines={1} ellipsizeMode="middle">
+              {params.txHash}
+            </Text>
+          </View>
+        )}
+
+        <View style={styles.spacer} />
+      </ScrollView>
+
+      {/* Action Buttons */}
+      <View style={styles.buttonContainer}>
+        <Button variant="outline" size="lg" onPress={() => router.replace('/(tabs)')} style={styles.button}>
+          Back to Home
+        </Button>
+        <Button variant="primary" size="lg" onPress={() => router.back()} style={styles.button}>
+          View Group
+        </Button>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#0F172A',
+  },
+  content: {
+    padding: 24,
+    alignItems: 'center',
+  },
+  iconContainer: {
+    marginTop: 40,
+    marginBottom: 24,
+  },
+  successIcon: {
+    width: 120,
+    height: 120,
+    borderRadius: 60,
+    backgroundColor: '#14532D',
+    justifyContent: 'center',
+    alignItems: 'center',
+    shadowColor: '#14532D',
+    shadowOpacity: 0.4,
+    shadowRadius: 20,
+    shadowOffset: { width: 0, height: 8 },
+    elevation: 12,
+  },
+  checkmark: {
+    fontSize: 64,
+    fontWeight: '800',
+    color: '#4ADE80',
+    lineHeight: 64,
+  },
+  headline: {
+    fontSize: 24,
+    fontWeight: '800',
+    color: '#F8FAFC',
+    marginBottom: 24,
+    textAlign: 'center',
+  },
+  detailsCard: {
+    width: '100%',
+    backgroundColor: '#1E293B',
+    borderRadius: 16,
+    padding: 20,
+    marginBottom: 16,
+  },
+  detailRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 8,
+  },
+  detailLabel: {
+    fontSize: 15,
+    color: '#94A3B8',
+  },
+  detailValue: {
+    fontSize: 17,
+    fontWeight: '700',
+    color: '#F8FAFC',
+    textAlign: 'right',
+    flex: 1,
+    paddingLeft: 12,
+  },
+  hashContainer: {
+    width: '100%',
+    alignItems: 'center',
+    padding: 12,
+    backgroundColor: '#0F172A',
+    borderRadius: 12,
+    marginTop: 8,
+  },
+  hashLabel: {
+    fontSize: 11,
+    color: '#64748B',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginBottom: 4,
+  },
+  hashValue: {
+    fontSize: 12,
+    color: '#94A3B8',
+    fontFamily: 'monospace',
+  },
+  spacer: {
+    height: 20,
+  },
+  buttonContainer: {
+    padding: 24,
+    paddingTop: 0,
+    gap: 12,
+  },
+  button: {
+    width: '100%',
+  },
+});


### PR DESCRIPTION
 Build profile screen with wallet address and display name

?? BlockHaven-Labs / esustellar mobile | Priority: Medium
?? Context
The Profile tab shows the user's identity and account details: avatar, display name, wallet address, and links to settings.

??? Tasks
 Create or update mobile/app/(tabs)/profile/index.tsx
 Show large (64px) Avatar with user initials
 Show display name (mock: 'EsuStellar User') and truncated wallet address
 'Edit Profile' button ? navigates to profile/edit
 'Settings' row ? navigates to profile/settings
 'Disconnect Wallet' row ? opens disconnect modal
? Acceptance Criteria
 Profile screen renders with avatar, name, and address
 All navigation links work
 Screen is part of the bottom tab navigator
 closes #97
 
 Build settings screen layout with grouped sections

?? BlockHaven-Labs / esustellar mobile | Priority: Medium
?? Context
The Settings screen gives users control over app preferences. It should be a grouped list: Appearance, Notifications, Security, and About.

??? Tasks
 Create mobile/app/(tabs)/profile/settings.tsx
 Group settings into sections:
Appearance: Theme toggle
Notifications: Notification preferences
Security: Biometric toggle
About: App version, Privacy Policy, Open Source
 Each row has a label and right-side value or arrow
 Read app version from expo-constants
? Acceptance Criteria
 All four sections render with correct items
 App version displays correctly
 Rows navigate or log on tap
 Back button returns to profile
 
 closes  #98