### PR TITLE
feat(mobile): add NotificationItem component with icons

### DIFF
--- a/mobile/components/notifications/NotificationItem.tsx
+++ b/mobile/components/notifications/NotificationItem.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { Pressable, View, Text, StyleSheet } from 'react-native';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+
+dayjs.extend(relativeTime);
+
+type NotificationType = 'contribution' | 'payout' | 'member' | 'status';
+
+interface NotificationItemProps {
+  type: NotificationType;
+  title: string;
+  message: string;
+  date: Date;
+  read: boolean;
+  onPress?: () => void;
+}
+
+const typeToEmoji: Record<NotificationType, string> = {
+  contribution: '💰',
+  payout: '💸',
+  member: '👥',
+  status: '📢',
+};
+
+export const NotificationItem: React.FC<NotificationItemProps> = ({
+  type,
+  title,
+  message,
+  date,
+  read,
+  onPress,
+}) => {
+  return (
+    <Pressable style={styles.container} onPress={onPress}>
+      <View style={styles.left}>
+        {!read && <View style={styles.unreadDot} />}
+        <Text style={styles.icon}>{typeToEmoji[type]}</Text>
+      </View>
+      <View style={styles.content}>
+        <Text style={styles.title}>{title}</Text>
+        <Text style={styles.message} numberOfLines={1}>
+          {message}
+        </Text>
+      </View>
+      <Text style={styles.date}>{dayjs(date).fromNow()}</Text>
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    alignItems: 'center',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#ddd',
+  },
+  left: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginRight: 12,
+  },
+  unreadDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: '#007AFF', // iOS blue
+    marginRight: 6,
+  },
+  icon: {
+    fontSize: 20,
+  },
+  content: {
+    flex: 1,
+  },
+  title: {
+    fontWeight: '600',
+    fontSize: 14,
+    marginBottom: 2,
+  },
+  message: {
+    color: '#555',
+    fontSize: 13,
+  },
+  date: {
+    marginLeft: 8,
+    fontSize: 12,
+    color: '#999',
+  },
+});


### PR DESCRIPTION
# Pull Request: Create NotificationItem Component

## Overview
This PR implements issue **#101 Create NotificationItem component**.  
It introduces a reusable UI component for rendering notifications consistently across the mobile app.

---

## Changes Introduced
- Added `mobile/components/notifications/NotificationItem.tsx`.
- Props: `type`, `title`, `message`, `date`, `read`, `onPress`.
- Mapped notification types to emojis:
  - contribution → 💰
  - payout → 💸
  - member → 👥
  - status → 📢
- Added unread indicator (blue dot) when `read` is false.
- Date formatted as relative time using `dayjs`.
- Entire row is pressable for interaction.

---

## Acceptance Criteria ✅
- [x] All four types render with correct icons
- [x] Blue dot appears only on unread items
- [x] Date shows as relative time
- [x] Row is pressable

---

## How to Test
1. Render `NotificationItem` with each type → correct emoji displayed.
2. Pass `read=false` → blue dot visible.
3. Pass `date` values → relative time displayed (`2 hours ago`, `Yesterday`).
4. Tap row → `onPress` callback triggered.

---

## Contribution Notes
- Close #101
