### PR TITLE
Feat/wallet connect loading

### DIFF
--- a/mobile/components/groups/GroupCard.tsx
+++ b/mobile/components/groups/GroupCard.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Pressable, View, Text, StyleSheet } from 'react-native';
+
+interface Props {
+  group: { id: string; name: string };
+  onPress: (id: string) => void;
+}
+
+export const GroupCard: React.FC<Props> = ({ group, onPress }) => {
+  return (
+    <Pressable
+      onPress={() => onPress(group.id)}
+      accessibilityLabel={`View ${group.name} savings group`}
+      accessibilityRole="button"
+    >
+      <View style={styles.card}>
+        <Text style={styles.name}>{group.name}</Text>
+      </View>
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    padding: 16,
+    backgroundColor: '#f9f9f9',
+    borderRadius: 8,
+    marginBottom: 12,
+  },
+  name: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/mobile/components/navigation/NotificationBell.tsx
+++ b/mobile/components/navigation/NotificationBell.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Pressable } from 'react-native';
+import { BellIcon } from '../icons/BellIcon';
+
+interface Props {
+  onPress: () => void;
+}
+
+export const NotificationBell: React.FC<Props> = ({ onPress }) => {
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityLabel="View notifications"
+      accessibilityRole="button"
+    >
+      <BellIcon />
+    </Pressable>
+  );
+};

--- a/mobile/components/notifications/NotificationItem.tsx
+++ b/mobile/components/notifications/NotificationItem.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { Pressable, View, Text, StyleSheet } from 'react-native';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+
+dayjs.extend(relativeTime);
+
+type NotificationType = 'contribution' | 'payout' | 'member' | 'status';
+
+interface NotificationItemProps {
+  type: NotificationType;
+  title: string;
+  message: string;
+  date: Date;
+  read: boolean;
+  onPress?: () => void;
+}
+
+const typeToEmoji: Record<NotificationType, string> = {
+  contribution: '💰',
+  payout: '💸',
+  member: '👥',
+  status: '📢',
+};
+
+export const NotificationItem: React.FC<NotificationItemProps> = ({
+  type,
+  title,
+  message,
+  date,
+  read,
+  onPress,
+}) => {
+  return (
+    <Pressable style={styles.container} onPress={onPress}>
+      <View style={styles.left}>
+        {!read && <View style={styles.unreadDot} />}
+        <Text style={styles.icon}>{typeToEmoji[type]}</Text>
+      </View>
+      <View style={styles.content}>
+        <Text style={styles.title}>{title}</Text>
+        <Text style={styles.message} numberOfLines={1}>
+          {message}
+        </Text>
+      </View>
+      <Text style={styles.date}>{dayjs(date).fromNow()}</Text>
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    alignItems: 'center',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#ddd',
+  },
+  left: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginRight: 12,
+  },
+  unreadDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: '#007AFF', // iOS blue
+    marginRight: 6,
+  },
+  icon: {
+    fontSize: 20,
+  },
+  content: {
+    flex: 1,
+  },
+  title: {
+    fontWeight: '600',
+    fontSize: 14,
+    marginBottom: 2,
+  },
+  message: {
+    color: '#555',
+    fontSize: 13,
+  },
+  date: {
+    marginLeft: 8,
+    fontSize: 12,
+    color: '#999',
+  },
+});

--- a/mobile/components/wallet/CopyAddressButton.tsx
+++ b/mobile/components/wallet/CopyAddressButton.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Pressable } from 'react-native';
+import { CopyIcon } from '../icons/CopyIcon';
+
+interface Props {
+  onPress: () => void;
+}
+
+export const CopyAddressButton: React.FC<Props> = ({ onPress }) => {
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityLabel="Copy wallet address"
+      accessibilityRole="button"
+      accessibilityHint="Copies your wallet address to the clipboard"
+    >
+      <CopyIcon />
+    </Pressable>
+  );
+};

--- a/mobile/components/wallet/DisconnectButton.tsx
+++ b/mobile/components/wallet/DisconnectButton.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Pressable } from 'react-native';
+import { DisconnectIcon } from '../icons/DisconnectIcon';
+
+interface Props {
+  onPress: () => void;
+}
+
+export const DisconnectButton: React.FC<Props> = ({ onPress }) => {
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityLabel="Disconnect wallet"
+      accessibilityRole="button"
+    >
+      <DisconnectIcon />
+    </Pressable>
+  );
+};

--- a/mobile/screens/wallet/WalletConnectScreen.tsx
+++ b/mobile/screens/wallet/WalletConnectScreen.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, Alert } from 'react-native';
+import { Button } from '../components/Button'; // assuming you have a shared Button component
+
+export const WalletConnectScreen: React.FC = () => {
+  const [connecting, setConnecting] = useState(false);
+
+  const connectWallet = async (walletType: string) => {
+    if (connecting) return; // prevent repeated taps
+    setConnecting(true);
+
+    try {
+      // simulate connection delay
+      await new Promise((resolve, reject) =>
+        setTimeout(() => {
+          // simulate random failure
+          Math.random() > 0.7 ? reject(new Error('Connection failed')) : resolve(true);
+        }, 2000)
+      );
+
+      Alert.alert('Success', `${walletType} connected successfully`);
+    } catch (error: any) {
+      Alert.alert('Error', error.message || 'Failed to connect wallet');
+    } finally {
+      setConnecting(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Connect Your Wallet</Text>
+      <Button
+        title="Connect MetaMask"
+        onPress={() => connectWallet('MetaMask')}
+        loading={connecting}
+        disabled={connecting}
+      />
+      <Button
+        title="Connect WalletConnect"
+        onPress={() => connectWallet('WalletConnect')}
+        loading={connecting}
+        disabled={connecting}
+      />
+      <Button
+        title="Connect Coinbase"
+        onPress={() => connectWallet('Coinbase')}
+        loading={connecting}
+        disabled={connecting}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 24,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '600',
+    marginBottom: 24,
+    textAlign: 'center',
+  },
+});


### PR DESCRIPTION
# Overview
This PR implements issue **#106 Add loading indicator while wallet is connecting**.  
It improves UX by preventing repeated taps and showing feedback during wallet connection attempts.

---

## Changes Introduced
- Added `connecting` state to wallet connect screen.
- Disabled all wallet buttons while connecting.
- Displayed spinner using Button’s `loading` prop.
- Simulated 2s delay for connection.
- Error message shown on simulated failure.
- State resets correctly after attempt.

---

## Acceptance Criteria ✅
- [x] Wallet button shows spinner while connecting
- [x] All wallet buttons disabled while one is connecting
- [x] Error message appears on simulated failure
- [x] State resets correctly after attempt

---

## How to Test
1. Tap any wallet button → spinner appears, all buttons disabled.
2. Wait 2s → either success or error message shown.
3. Verify state resets and buttons re‑enabled.

---

## Contribution Notes
- Close #106
