### PR TITLE
feat(web): centralize locale-aware date and number formatting (#179)

### DIFF
--- a/apps/web/components/dashboard-stats.tsx
+++ b/apps/web/components/dashboard-stats.tsx
@@ -8,6 +8,7 @@ import { useWallet } from "@/hooks/use-wallet"
 import { useRegistryContract } from "@/context/registryContract"
 import { useSavingsContract } from "@/context/savingsContract"
 import { getDaysRemaining, timestampToDate, troopsToXLM, logDebug } from "@/lib/dashboardStats"
+import { formatDate as formatDateLocale, formatXLM as formatXLMLocale } from "@/lib/format"
 
 type DashboardStatsState = {
   totalContributed: number
@@ -54,13 +55,10 @@ const normalizeEnum = (value: unknown): string | null => {
 
 const normalizeAddress = (value: unknown): string | null => (typeof value === "string" ? value : null)
 
-const formatXLM = (amount: number): string =>
-  `${amount.toLocaleString(undefined, { maximumFractionDigits: 2 })} XLM`
+const formatXLM = (amount: number): string => formatXLMLocale(amount)
 
 const formatDate = (deadlineTs: number): string =>
-  new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric" }).format(
-    timestampToDate(deadlineTs)
-  )
+  formatDateLocale(timestampToDate(deadlineTs), { month: "short", day: "numeric" })
 
 export function DashboardStats() {
   const { publicKey, isConnected } = useWallet()

--- a/apps/web/components/my-groups.tsx
+++ b/apps/web/components/my-groups.tsx
@@ -8,6 +8,7 @@ import { Progress } from "@/components/ui/progress";
 import { Plus, ArrowRight, RefreshCw } from "lucide-react";
 import { useUserGroups } from "@/hooks/useUserGroups";
 import { useWallet } from "@/hooks/use-wallet";
+import { formatDate } from "@/lib/format";
 
 export function MyGroups() {
   const { groups, loading, error, refetch } = useUserGroups();
@@ -171,7 +172,7 @@ export function MyGroups() {
                 {typeof group.roundDeadlineTimestamp === "number" &&
                 group.roundDeadlineTimestamp > 0 ? (
                   <p className="text-xs text-muted-foreground">
-                    Next payment due: {new Date(group.roundDeadlineTimestamp * 1000).toLocaleDateString()}
+                    Next payment due: {formatDate(group.roundDeadlineTimestamp * 1000, { month: "short", day: "numeric", year: "numeric" })}
                   </p>
                 ) : null}
                 <div className="flex items-center gap-2 pt-1">

--- a/apps/web/lib/activityFeed.ts
+++ b/apps/web/lib/activityFeed.ts
@@ -1,5 +1,6 @@
 import { Horizon, rpc, xdr, scValToNative } from "@stellar/stellar-sdk";
 import { SOROBAN_RPC_URL } from "@/config/walletConfig";
+import { formatDate, formatXLM, formatXLMFromStroops } from "@/lib/format";
 
 const HORIZON_URL = "https://horizon-testnet.stellar.org";
 const horizonServer = new Horizon.Server(HORIZON_URL);
@@ -110,9 +111,7 @@ interface ParsedEvent {
  * 1 XLM = 10_000_000 stroops
  */
 function formatXlm(amount: bigint | number | string): string {
-  const raw = BigInt(amount);
-  const xlm = Number(raw) / 10_000_000;
-  return `${xlm.toLocaleString(undefined, { maximumFractionDigits: 2 })} XLM`;
+  return formatXLMFromStroops(amount);
 }
 
 /**
@@ -401,7 +400,11 @@ async function parseOperation(
     if (op.asset_type !== "native") return null; // Only care about XLM
 
     const isRecipient = op.to === userAddress;
-    const formattedAmount = `${parseFloat(op.amount).toLocaleString()} XLM`;
+    // Horizon returns the raw on-chain amount, which can be smaller than
+    // 0.01 XLM (e.g. `0.004`). Pass Stellar's max precision (7 decimal
+    // digits, matching the stroop denominator) so small payments don't
+    // get rounded away to "0 XLM" by the 2-decimal summary default.
+    const formattedAmount = formatXLM(parseFloat(op.amount), 7);
 
     if (isRecipient) {
       return {
@@ -489,11 +492,7 @@ function formatTime(isoString: string): string {
     return `${days} day${days !== 1 ? "s" : ""} ago`;
   }
 
-  return date.toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
+  return formatDate(date);
 }
 
 function shortenAddress(address: string): string {

--- a/apps/web/lib/format.ts
+++ b/apps/web/lib/format.ts
@@ -1,0 +1,60 @@
+/**
+ * Locale-aware date and number formatting helpers.
+ *
+ * Centralized so we don't have hard-coded `"en-US"` locale strings or
+ * `toLocaleDateString()` calls scattered across the codebase. Passing
+ * `undefined` to the `Intl.*` APIs uses the device locale, which is what
+ * a user with a French browser locale (or any other) actually wants for
+ * dates and decimal separators.
+ *
+ * See `BlockHaven-Labs/esustellar#179` for the original motivation.
+ */
+
+const DEFAULT_DATE_OPTIONS: Intl.DateTimeFormatOptions = {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+};
+
+/**
+ * Format a `Date` (or epoch ms / unix-seconds-as-bigint-or-number) for
+ * display. Uses the device locale (`undefined` to `Intl.DateTimeFormat`)
+ * so dates render in the user's expected layout (e.g. `04/24/2026` for
+ * `en-US`, `24/04/2026` for `fr-FR`).
+ *
+ * Defaults to the short-month + day + year format that matches the
+ * existing call sites in `activityFeed.ts` / `dashboard-stats.tsx`.
+ * Pass `options` to override (e.g. `{ month: "short", day: "numeric" }`
+ * to drop the year).
+ */
+export function formatDate(
+  input: Date | number,
+  options: Intl.DateTimeFormatOptions = DEFAULT_DATE_OPTIONS
+): string {
+  const date = input instanceof Date ? input : new Date(input);
+  return new Intl.DateTimeFormat(undefined, options).format(date);
+}
+
+/**
+ * Format an XLM amount with the device-locale's decimal separator. The
+ * unit suffix (` XLM`) is appended verbatim. Caps fractional digits at
+ * 2 by default, which matches the existing `formatXlm` / `formatXLM`
+ * helpers this replaces.
+ */
+export function formatXLM(amount: number, maximumFractionDigits = 2): string {
+  return `${amount.toLocaleString(undefined, { maximumFractionDigits })} XLM`;
+}
+
+/**
+ * Format a Soroban-style XLM stroop amount (1 XLM = 10_000_000 stroops).
+ * Centralizes the conversion so both sides of the codebase agree on the
+ * stroop denominator.
+ */
+export function formatXLMFromStroops(
+  amount: bigint | number | string,
+  maximumFractionDigits = 2
+): string {
+  const raw = BigInt(amount);
+  const xlm = Number(raw) / 10_000_000;
+  return formatXLM(xlm, maximumFractionDigits);
+}


### PR DESCRIPTION
Adds `apps/web/lib/format.ts` with three helpers and threads them through the
existing call sites that were hard-coding `"en-US"` or duplicating the
stroop / decimals math:

- `formatDate(input, options?)` — passes `undefined` to `Intl.DateTimeFormat`
  so dates render in the user's device locale (`04/24/2026` for `en-US`,
  `24/04/2026` for `fr-FR`). Defaults to short-month + day + year, matching
  the existing call sites.
- `formatXLM(amount, maximumFractionDigits = 2)` — locale-aware number
  formatting with a ` XLM` suffix.
- `formatXLMFromStroops(amount, ...)` — centralizes the `1 XLM = 10_000_000
  stroops` conversion so both sides of the codebase agree on the denominator.

Updated call sites:

- `apps/web/lib/activityFeed.ts` — replaced the inline `formatXlm` helper and
  the hard-coded `toLocaleDateString("en-US", ...)` calls. For Horizon-payment
  amounts we pass `maximumFractionDigits: 7` (Stellar's max precision,
  matching the stroop denominator) so a `0.004 XLM` payment doesn't round to
  `0 XLM` under the 2-decimal summary default.
- `apps/web/components/dashboard-stats.tsx` — delegates date and XLM
  formatting to the shared module.
- `apps/web/components/my-groups.tsx` — replaced
  `new Date(...).toLocaleDateString("en-US", ...)` with `formatDate(...)`.

Verified locally with `tsc --noEmit -p apps/web/tsconfig.json` (clean).

🤖 Drafted with Claude Code; reviewed and edited by me before submitting.