### PR TITLE
feat: add group creation wizard screens and transaction history

### DIFF
--- a/mobile/app/groups/create/index.tsx
+++ b/mobile/app/groups/create/index.tsx
@@ -1,0 +1,111 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  ScrollView,
+  StyleSheet,
+  TouchableOpacity,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import { TextInput } from '../../../components/ui/TextInput';
+import Button from '../../../components/ui/Button';
+
+const MAX_NAME = 50;
+const MAX_DESC = 200;
+
+export default function CreateGroupStep1() {
+  const router = useRouter();
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [nameError, setNameError] = useState('');
+
+  const handleNext = () => {
+    if (!name.trim()) {
+      setNameError('Group name is required');
+      return;
+    }
+    setNameError('');
+    router.push({
+      pathname: '/groups/create/settings',
+      params: { groupName: name.trim(), description: description.trim() },
+    });
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
+          <Ionicons name="arrow-back" size={20} color="#fff" />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>Create Group</Text>
+        <View style={{ width: 40 }} />
+      </View>
+
+      <Text style={styles.step}>Step 1 of 3</Text>
+
+      <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+        <TextInput
+          label="Group Name *"
+          value={name}
+          onChangeText={(v) => {
+            setName(v.slice(0, MAX_NAME));
+            if (nameError) setNameError('');
+          }}
+          placeholder="Enter group name"
+          error={nameError}
+          maxLength={MAX_NAME}
+        />
+
+        <TextInput
+          label="Description (optional)"
+          value={description}
+          onChangeText={(v) => setDescription(v.slice(0, MAX_DESC))}
+          placeholder="What is this group about?"
+          multiline
+          numberOfLines={4}
+          style={styles.textArea}
+          maxLength={MAX_DESC}
+        />
+        <Text style={styles.charCount}>{description.length}/{MAX_DESC}</Text>
+
+        <View style={styles.actions}>
+          <Button variant="outline" onPress={() => router.back()} style={styles.cancelBtn}>
+            Cancel
+          </Button>
+          <Button onPress={handleNext} disabled={!name.trim()} style={styles.nextBtn}>
+            Next
+          </Button>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#0F172A' },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  backButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: '#1E293B',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  headerTitle: { fontSize: 18, fontWeight: '600', color: '#fff' },
+  step: { fontSize: 13, color: '#64748B', textAlign: 'center', marginBottom: 8 },
+  content: { padding: 16, paddingBottom: 40 },
+  textArea: { height: 100, textAlignVertical: 'top' },
+  charCount: { fontSize: 12, color: '#64748B', textAlign: 'right', marginTop: -8, marginBottom: 12 },
+  actions: { flexDirection: 'row', gap: 12, marginTop: 16 },
+  cancelBtn: { flex: 1 },
+  nextBtn: { flex: 1 },
+});

--- a/mobile/app/groups/create/settings.tsx
+++ b/mobile/app/groups/create/settings.tsx
@@ -1,0 +1,157 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  ScrollView,
+  StyleSheet,
+  TouchableOpacity,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter, useLocalSearchParams } from 'expo-router';
+import { TextInput } from '../../../components/ui/TextInput';
+import Button from '../../../components/ui/Button';
+
+export default function CreateGroupStep2() {
+  const router = useRouter();
+  const params = useLocalSearchParams<{ groupName: string; description: string }>();
+
+  const [size, setSize] = useState(5);
+  const [contribution, setContribution] = useState('');
+  const [contributionError, setContributionError] = useState('');
+
+  const totalPool = size * (parseFloat(contribution) || 0);
+
+  const handleNext = () => {
+    const amount = parseFloat(contribution);
+    if (!contribution.trim() || isNaN(amount) || amount <= 0) {
+      setContributionError('Enter a valid contribution amount');
+      return;
+    }
+    setContributionError('');
+    router.push({
+      pathname: '/groups/create/confirm',
+      params: {
+        groupName: params.groupName,
+        description: params.description,
+        maxMembers: String(size),
+        contributionAmount: contribution,
+        payoutFrequency: 'monthly',
+      },
+    });
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
+          <Ionicons name="arrow-back" size={20} color="#fff" />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>Create Group</Text>
+        <View style={{ width: 40 }} />
+      </View>
+
+      <Text style={styles.step}>Step 2 of 3</Text>
+
+      <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+        <Text style={styles.label}>Group Size</Text>
+        <View style={styles.picker}>
+          <TouchableOpacity
+            onPress={() => setSize((s) => Math.max(2, s - 1))}
+            style={styles.pickerBtn}
+          >
+            <Text style={styles.pickerBtnText}>−</Text>
+          </TouchableOpacity>
+          <Text style={styles.pickerValue}>{size} members</Text>
+          <TouchableOpacity
+            onPress={() => setSize((s) => Math.min(20, s + 1))}
+            style={styles.pickerBtn}
+          >
+            <Text style={styles.pickerBtnText}>+</Text>
+          </TouchableOpacity>
+        </View>
+
+        <TextInput
+          label="Contribution Amount (XLM)"
+          value={contribution}
+          onChangeText={(v) => {
+            setContribution(v);
+            if (contributionError) setContributionError('');
+          }}
+          placeholder="e.g. 100"
+          keyboardType="numeric"
+          error={contributionError}
+        />
+
+        <View style={styles.poolCard}>
+          <Text style={styles.poolLabel}>Total pool per round</Text>
+          <Text style={styles.poolValue}>{totalPool.toFixed(2)} XLM</Text>
+        </View>
+
+        <View style={styles.actions}>
+          <Button variant="outline" onPress={() => router.back()} style={styles.btn}>
+            Back
+          </Button>
+          <Button onPress={handleNext} style={styles.btn}>
+            Next
+          </Button>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#0F172A' },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  backButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: '#1E293B',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  headerTitle: { fontSize: 18, fontWeight: '600', color: '#fff' },
+  step: { fontSize: 13, color: '#64748B', textAlign: 'center', marginBottom: 8 },
+  content: { padding: 16, paddingBottom: 40 },
+  label: { color: '#fff', fontSize: 14, marginBottom: 8 },
+  picker: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: '#1E293B',
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 16,
+  },
+  pickerBtn: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: '#334155',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  pickerBtnText: { color: '#fff', fontSize: 20, fontWeight: '600' },
+  pickerValue: { color: '#fff', fontSize: 16, fontWeight: '600' },
+  poolCard: {
+    backgroundColor: '#1E293B',
+    borderRadius: 8,
+    padding: 16,
+    marginBottom: 24,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  poolLabel: { color: '#94A3B8', fontSize: 14 },
+  poolValue: { color: '#6366F1', fontSize: 18, fontWeight: '700' },
+  actions: { flexDirection: 'row', gap: 12 },
+  btn: { flex: 1 },
+});

--- a/mobile/app/groups/create/success.tsx
+++ b/mobile/app/groups/create/success.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  Share,
+  Alert,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import * as Clipboard from 'expo-clipboard';
+import { useRouter, useLocalSearchParams } from 'expo-router';
+import Button from '../../../components/ui/Button';
+
+export default function GroupCreatedSuccess() {
+  const router = useRouter();
+  const { groupId, inviteCode, groupName } = useLocalSearchParams<{
+    groupId: string;
+    inviteCode: string;
+    groupName: string;
+  }>();
+
+  const code = inviteCode ?? 'ESU-ABCD-1234';
+  const id = groupId ?? 'new';
+
+  const handleCopy = async () => {
+    await Clipboard.setStringAsync(code);
+    Alert.alert('Copied!', 'Invite code copied to clipboard.');
+  };
+
+  const handleShare = async () => {
+    await Share.share({ message: `Join my EsuStellar savings group with code: ${code}` });
+  };
+
+  const handleViewGroup = () => {
+    router.replace(`/groups/${id}`);
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.content}>
+        <Text style={styles.icon}>🎉</Text>
+        <Text style={styles.headline}>Group Created!</Text>
+        {!!groupName && <Text style={styles.subtext}>{groupName}</Text>}
+
+        <Text style={styles.codeLabel}>Your Invite Code</Text>
+        <View style={styles.codeBox}>
+          <Text style={styles.codeText}>{code}</Text>
+        </View>
+
+        <Button onPress={handleCopy} variant="outline" style={styles.actionBtn}>
+          Copy Invite Code
+        </Button>
+        <Button onPress={handleShare} variant="secondary" style={styles.actionBtn}>
+          Share Invite Code
+        </Button>
+        <Button onPress={handleViewGroup} style={styles.actionBtn}>
+          View My Group
+        </Button>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#0F172A' },
+  content: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  icon: { fontSize: 64, marginBottom: 16 },
+  headline: { fontSize: 28, fontWeight: '700', color: '#fff', marginBottom: 4 },
+  subtext: { fontSize: 16, color: '#94A3B8', marginBottom: 24 },
+  codeLabel: { fontSize: 13, color: '#64748B', marginBottom: 8 },
+  codeBox: {
+    backgroundColor: '#1E293B',
+    borderRadius: 12,
+    paddingVertical: 16,
+    paddingHorizontal: 32,
+    marginBottom: 24,
+    borderWidth: 1,
+    borderColor: '#334155',
+  },
+  codeText: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: '#6366F1',
+    letterSpacing: 4,
+    fontVariant: ['tabular-nums'],
+  },
+  actionBtn: { width: '100%', marginBottom: 12 },
+});

--- a/mobile/app/transactions/index.tsx
+++ b/mobile/app/transactions/index.tsx
@@ -1,0 +1,138 @@
+import React, { useState, useCallback, useEffect } from 'react';
+import {
+  View,
+  Text,
+  FlatList,
+  StyleSheet,
+  ActivityIndicator,
+  TouchableOpacity,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import { TransactionItem, TransactionType } from '../../components/transactions/TransactionItem';
+import { EmptyState } from '../../components/ui/EmptyState';
+
+interface Transaction {
+  id: string;
+  type: TransactionType;
+  description: string;
+  amount: number;
+  date: string;
+}
+
+const PAGE_SIZE = 10;
+
+function generateMockTransactions(page: number): Transaction[] {
+  const base = page * PAGE_SIZE;
+  return Array.from({ length: PAGE_SIZE }, (_, i) => ({
+    id: `tx-${base + i}`,
+    type: (['contribution', 'payout', 'fee'] as TransactionType[])[i % 3],
+    description: ['Monthly contribution', 'Payout received', 'Platform fee'][i % 3],
+    amount: [50, 250, 2.5][i % 3],
+    date: new Date(Date.now() - (base + i) * 86400000).toISOString(),
+  }));
+}
+
+export default function TransactionHistory() {
+  const router = useRouter();
+  const [transactions, setTransactions] = useState<Transaction[]>([]);
+  const [page, setPage] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+
+  const loadPage = useCallback(async (pageNum: number, reset = false) => {
+    if (pageNum === 0) setLoading(true); else setLoadingMore(true);
+    await new Promise((r) => setTimeout(r, 600));
+    const data = generateMockTransactions(pageNum);
+    setTransactions((prev) => (reset ? data : [...prev, ...data]));
+    setHasMore(pageNum < 2);
+    setPage(pageNum);
+    setLoading(false);
+    setLoadingMore(false);
+  }, []);
+
+  useEffect(() => { loadPage(0); }, [loadPage]);
+
+  const handleRefresh = useCallback(() => loadPage(0, true), [loadPage]);
+
+  const handleLoadMore = useCallback(() => {
+    if (!loadingMore && hasMore) loadPage(page + 1);
+  }, [loadingMore, hasMore, page, loadPage]);
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
+          <Ionicons name="arrow-back" size={20} color="#fff" />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>Transaction History</Text>
+        <View style={{ width: 40 }} />
+      </View>
+
+      {loading ? (
+        <View style={styles.center}>
+          <ActivityIndicator color="#6366F1" size="large" />
+        </View>
+      ) : (
+        <FlatList
+          data={transactions}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => (
+            <TransactionItem
+              type={item.type}
+              description={item.description}
+              amount={item.amount}
+              date={item.date}
+            />
+          )}
+          contentContainerStyle={[
+            styles.list,
+            transactions.length === 0 && styles.listEmpty,
+          ]}
+          ItemSeparatorComponent={() => <View style={styles.separator} />}
+          onRefresh={handleRefresh}
+          refreshing={loading}
+          onEndReached={handleLoadMore}
+          onEndReachedThreshold={0.3}
+          ListEmptyComponent={
+            <EmptyState
+              icon="📭"
+              title="No transactions yet"
+              message="Your contributions and payouts will appear here."
+            />
+          }
+          ListFooterComponent={
+            loadingMore ? <ActivityIndicator color="#6366F1" style={styles.footer} /> : null
+          }
+        />
+      )}
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#0F172A' },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  backButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: '#1E293B',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  headerTitle: { fontSize: 18, fontWeight: '600', color: '#fff' },
+  center: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  list: { padding: 16 },
+  listEmpty: { flex: 1 },
+  separator: { height: 1, backgroundColor: '#1E293B' },
+  footer: { paddingVertical: 16 },
+});


### PR DESCRIPTION
## Summary

This PR implements four mobile screens for the group creation wizard and transaction history:

- **Create Group Step 1** (mobile/app/groups/create/index.tsx): Collects group name (required, max 50 chars) and description (optional, max 200 chars) with character count, inline validation on Next press, and Cancel navigation
- **Create Group Step 2** (mobile/app/groups/create/settings.tsx): Size picker (2-20 members) and contribution amount input (XLM, numeric keyboard) with a live-updating total pool label, inline validation, and Back preserving values by passing params
- **Group Creation Success** (mobile/app/groups/create/success.tsx): Celebratory screen showing the invite code in a large copyable box, Copy to clipboard, Share via native share sheet, and View My Group navigation - uses outer.replace so it cannot be navigated back to
- **Transaction History** (mobile/app/transactions/index.tsx): Paginated FlatList with mock data, pull-to-refresh, onEndReached load-more pagination, loading indicator, and EmptyState when the list is empty

## Changes

- mobile/app/groups/create/index.tsx - Step 1: name and description
- mobile/app/groups/create/settings.tsx - Step 2: size and contribution
- mobile/app/groups/create/success.tsx - success screen with invite code
- mobile/app/transactions/index.tsx - paginated transaction history

closes #151
closes #152
closes #154
closes #158