### PR TITLE
feat(mobile): transaction screens + FlatList performance optimisations

### DIFF
--- a/mobile/app/(tabs)/groups/page.tsx
+++ b/mobile/app/(tabs)/groups/page.tsx
@@ -123,7 +123,7 @@ export default function GroupsPage() {
     setRefreshing(false);
   }, [fetchGroups]);
 
-  const renderGroup = ({ item }: { item: Group }) => (
+  const renderGroup = useCallback(({ item }: { item: Group }) => (
     <Pressable
       key={item.id}
       onPress={() => router.push(`/groups/${item.id}`)}
@@ -142,7 +142,7 @@ export default function GroupsPage() {
         <Text style={styles.cardMeta}>{item.memberCount} members</Text>
       </View>
     </Pressable>
-  );
+  ), [router]);
 
   return (
     <SafeAreaView style={styles.container}>
@@ -185,6 +185,10 @@ export default function GroupsPage() {
           data={filteredGroups}
           keyExtractor={(item) => item.id}
           renderItem={renderGroup}
+          getItemLayout={(_, index) => ({ length: 110, offset: 110 * index, index })}
+          removeClippedSubviews
+          maxToRenderPerBatch={10}
+          windowSize={5}
           contentContainerStyle={styles.content}
           refreshControl={
             <RefreshControl

--- a/mobile/app/transaction/confirm.tsx
+++ b/mobile/app/transaction/confirm.tsx
@@ -1,0 +1,161 @@
+import React, { useState } from 'react';
+import { SafeAreaView, View, Text, StyleSheet, ActivityIndicator } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import Button from '../../components/ui/Button';
+
+type TxType = 'contribution' | 'payout' | 'fee';
+
+const TYPE_LABEL: Record<TxType, string> = {
+  contribution: 'Contribution',
+  payout: 'Payout',
+  fee: 'Fee',
+};
+
+function truncate(addr: string) {
+  if (addr.length <= 12) return addr;
+  return `${addr.slice(0, 6)}...${addr.slice(-4)}`;
+}
+
+export default function TransactionConfirmScreen() {
+  const router = useRouter();
+  const params = useLocalSearchParams<{
+    type?: string;
+    amount?: string;
+    destination?: string;
+    fee?: string;
+    memo?: string;
+  }>();
+
+  const type = (params.type ?? 'contribution') as TxType;
+  const amount = params.amount ?? '0';
+  const destination = params.destination ?? '';
+  const fee = params.fee ?? '0.00001';
+  const memo = params.memo ?? '';
+
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleConfirm = async () => {
+    setSubmitting(true);
+    // Simulate signing + submission; replace with real Stellar tx logic
+    await new Promise((r) => setTimeout(r, 1500));
+    router.replace({
+      pathname: '/transaction/success',
+      params: { txHash: 'mock_tx_hash_' + Date.now() },
+    });
+  };
+
+  const handleCancel = () => {
+    router.back();
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.content}>
+        <Text style={styles.title}>Confirm Transaction</Text>
+        <Text style={styles.subtitle}>
+          Review the details below before signing.
+        </Text>
+
+        <View style={styles.card}>
+          <Row label="Type" value={TYPE_LABEL[type] ?? type} />
+          <Divider />
+          <Row label="You are sending" value={`${amount} XLM`} highlight />
+          <Divider />
+          {destination ? (
+            <>
+              <Row label="To" value={truncate(destination)} mono />
+              <Divider />
+            </>
+          ) : null}
+          <Row label="Network Fee" value={`${fee} XLM`} warn />
+          {memo ? (
+            <>
+              <Divider />
+              <Row label="Memo" value={memo} />
+            </>
+          ) : null}
+        </View>
+      </View>
+
+      <View style={styles.actions}>
+        {submitting ? (
+          <View style={styles.spinner}>
+            <ActivityIndicator color="#6366F1" size="large" />
+            <Text style={styles.spinnerText}>Submitting transaction…</Text>
+          </View>
+        ) : (
+          <>
+            <Button variant="primary" size="lg" onPress={handleConfirm} style={styles.btn}>
+              Confirm and Sign
+            </Button>
+            <Button variant="outline" size="lg" onPress={handleCancel} style={styles.btn}>
+              Cancel
+            </Button>
+          </>
+        )}
+      </View>
+    </SafeAreaView>
+  );
+}
+
+function Row({
+  label,
+  value,
+  highlight,
+  warn,
+  mono,
+}: {
+  label: string;
+  value: string;
+  highlight?: boolean;
+  warn?: boolean;
+  mono?: boolean;
+}) {
+  return (
+    <View style={styles.row}>
+      <Text style={styles.rowLabel}>{label}</Text>
+      <Text
+        style={[
+          styles.rowValue,
+          highlight && styles.rowValueHighlight,
+          warn && styles.rowValueWarn,
+          mono && styles.rowValueMono,
+        ]}
+      >
+        {value}
+      </Text>
+    </View>
+  );
+}
+
+function Divider() {
+  return <View style={styles.divider} />;
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#0F172A' },
+  content: { flex: 1, padding: 24 },
+  title: { fontSize: 24, fontWeight: '800', color: '#F8FAFC', marginBottom: 6 },
+  subtitle: { fontSize: 14, color: '#94A3B8', marginBottom: 24 },
+  card: {
+    backgroundColor: '#1E293B',
+    borderRadius: 16,
+    padding: 20,
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 10,
+  },
+  rowLabel: { fontSize: 14, color: '#94A3B8' },
+  rowValue: { fontSize: 15, fontWeight: '600', color: '#F8FAFC', textAlign: 'right', flex: 1, paddingLeft: 12 },
+  rowValueHighlight: { color: '#4ADE80', fontSize: 18 },
+  rowValueWarn: { color: '#F59E0B' },
+  rowValueMono: { fontFamily: 'monospace', fontSize: 13 },
+  divider: { height: StyleSheet.hairlineWidth, backgroundColor: '#334155' },
+  actions: { padding: 24, gap: 12 },
+  btn: { width: '100%' },
+  spinner: { alignItems: 'center', gap: 12, paddingVertical: 16 },
+  spinnerText: { color: '#94A3B8', fontSize: 14 },
+});

--- a/mobile/app/transaction/history.tsx
+++ b/mobile/app/transaction/history.tsx
@@ -1,0 +1,196 @@
+import React, { memo, useState, useCallback, useMemo } from 'react';
+import {
+  SafeAreaView,
+  View,
+  Text,
+  FlatList,
+  Pressable,
+  StyleSheet,
+  RefreshControl,
+  ListRenderItemInfo,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+import { TransactionItem, TransactionType } from '../../components/transactions/TransactionItem';
+
+type TabKey = 'All' | 'Contributions' | 'Payouts';
+
+const TABS: TabKey[] = ['All', 'Contributions', 'Payouts'];
+
+const TAB_TYPE_MAP: Record<TabKey, TransactionType | null> = {
+  All: null,
+  Contributions: 'contribution',
+  Payouts: 'payout',
+};
+
+type Transaction = {
+  id: string;
+  type: TransactionType;
+  description: string;
+  amount: number;
+  date: string;
+};
+
+const MOCK_TRANSACTIONS: Transaction[] = [
+  { id: '1', type: 'contribution', description: 'Monthly contribution – Solar Saver', amount: 45, date: new Date(Date.now() - 3600000).toISOString() },
+  { id: '2', type: 'payout', description: 'Payout received – Lunar Growth', amount: 540, date: new Date(Date.now() - 86400000).toISOString() },
+  { id: '3', type: 'fee', description: 'Network fee', amount: 0.00001, date: new Date(Date.now() - 86400000 * 2).toISOString() },
+  { id: '4', type: 'contribution', description: 'Monthly contribution – Horizon Fund', amount: 120, date: new Date(Date.now() - 86400000 * 5).toISOString() },
+  { id: '5', type: 'payout', description: 'Payout received – Solar Saver', amount: 360, date: new Date(Date.now() - 86400000 * 10).toISOString() },
+  { id: '6', type: 'contribution', description: 'Monthly contribution – Orbit Fund', amount: 60, date: new Date(Date.now() - 86400000 * 15).toISOString() },
+];
+
+const ITEM_HEIGHT = 60; // paddingVertical 12 * 2 + ~36 content
+
+const FilterTabs = memo(function FilterTabs({
+  active,
+  counts,
+  onSelect,
+}: {
+  active: TabKey;
+  counts: Record<TabKey, number>;
+  onSelect: (tab: TabKey) => void;
+}) {
+  return (
+    <View style={styles.tabBar}>
+      {TABS.map((tab) => {
+        const isActive = tab === active;
+        return (
+          <Pressable
+            key={tab}
+            onPress={() => onSelect(tab)}
+            style={[styles.tab, isActive && styles.tabActive]}
+            accessibilityRole="tab"
+            accessibilityState={{ selected: isActive }}
+          >
+            <Text style={[styles.tabLabel, isActive && styles.tabLabelActive]}>
+              {tab} ({counts[tab]})
+            </Text>
+            {isActive && <View style={styles.tabIndicator} />}
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+});
+
+const keyExtractor = (item: Transaction) => item.id;
+
+const getItemLayout = (_: unknown, index: number) => ({
+  length: ITEM_HEIGHT,
+  offset: ITEM_HEIGHT * index,
+  index,
+});
+
+export default function TransactionHistoryScreen() {
+  const router = useRouter();
+  const [activeTab, setActiveTab] = useState<TabKey>('All');
+  const [refreshing, setRefreshing] = useState(false);
+  const [data, setData] = useState(MOCK_TRANSACTIONS);
+
+  const counts = useMemo<Record<TabKey, number>>(
+    () => ({
+      All: data.length,
+      Contributions: data.filter((t) => t.type === 'contribution').length,
+      Payouts: data.filter((t) => t.type === 'payout').length,
+    }),
+    [data],
+  );
+
+  const filtered = useMemo(() => {
+    const typeFilter = TAB_TYPE_MAP[activeTab];
+    return typeFilter ? data.filter((t) => t.type === typeFilter) : data;
+  }, [activeTab, data]);
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    // Replace with real fetch
+    await new Promise((r) => setTimeout(r, 800));
+    setData([...MOCK_TRANSACTIONS]);
+    setRefreshing(false);
+  }, []);
+
+  const renderItem = useCallback(
+    ({ item }: ListRenderItemInfo<Transaction>) => (
+      <TransactionItem
+        type={item.type}
+        description={item.description}
+        amount={item.amount}
+        date={item.date}
+      />
+    ),
+    [],
+  );
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.header}>
+        <Pressable onPress={() => router.back()} style={styles.backBtn}>
+          <Text style={styles.backBtnText}>Back</Text>
+        </Pressable>
+        <Text style={styles.title}>Transaction History</Text>
+      </View>
+
+      <FilterTabs active={activeTab} counts={counts} onSelect={setActiveTab} />
+
+      <FlatList
+        data={filtered}
+        keyExtractor={keyExtractor}
+        renderItem={renderItem}
+        getItemLayout={getItemLayout}
+        removeClippedSubviews
+        maxToRenderPerBatch={10}
+        windowSize={5}
+        contentContainerStyle={styles.list}
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor="#6366F1" />}
+        ListEmptyComponent={
+          <View style={styles.empty}>
+            <Text style={styles.emptyText}>No {activeTab.toLowerCase()} to show.</Text>
+          </View>
+        }
+      />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#0F172A' },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#1E293B',
+  },
+  backBtn: { paddingVertical: 6, paddingHorizontal: 12, borderRadius: 8, backgroundColor: '#1E293B' },
+  backBtnText: { color: '#F8FAFC', fontWeight: '600', fontSize: 14 },
+  title: { marginLeft: 14, fontSize: 18, fontWeight: '800', color: '#F8FAFC' },
+  tabBar: {
+    flexDirection: 'row',
+    backgroundColor: '#0F172A',
+    paddingHorizontal: 16,
+    paddingTop: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#1E293B',
+  },
+  tab: {
+    flex: 1,
+    alignItems: 'center',
+    paddingBottom: 10,
+    marginHorizontal: 4,
+  },
+  tabActive: {},
+  tabLabel: { fontSize: 13, fontWeight: '600', color: '#64748B' },
+  tabLabelActive: { color: '#6366F1' },
+  tabIndicator: {
+    position: 'absolute',
+    bottom: 0,
+    width: '80%',
+    height: 2,
+    borderRadius: 1,
+    backgroundColor: '#6366F1',
+  },
+  list: { paddingHorizontal: 16, paddingTop: 8 },
+  empty: { marginTop: 48, alignItems: 'center' },
+  emptyText: { color: '#64748B', fontSize: 15 },
+});

--- a/mobile/app/transaction/success.tsx
+++ b/mobile/app/transaction/success.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { SafeAreaView, View, Text, StyleSheet, Linking } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { Stack } from 'expo-router';
+import Button from '../../components/ui/Button';
+import { txExplorerLink } from '../../utils/explorerLink';
+
+export default function TransactionSuccessScreen() {
+  const router = useRouter();
+  const { txHash } = useLocalSearchParams<{ txHash?: string }>();
+  const hash = txHash ?? '';
+
+  const explorerUrl = txExplorerLink(hash, 'testnet');
+
+  const handleViewExplorer = () => {
+    Linking.openURL(explorerUrl);
+  };
+
+  const handleDone = () => {
+    router.replace('/(tabs)');
+  };
+
+  return (
+    <>
+      {/* Disable back gesture */}
+      <Stack.Screen options={{ gestureEnabled: false, headerShown: false }} />
+
+      <SafeAreaView style={styles.container}>
+        <View style={styles.content}>
+          {/* Success icon */}
+          <View style={styles.iconWrap}>
+            <View style={styles.iconCircle}>
+              <Text style={styles.checkmark}>✓</Text>
+            </View>
+          </View>
+
+          <Text style={styles.title}>Transaction Sent!</Text>
+          <Text style={styles.subtitle}>Your transaction was submitted to the Stellar network.</Text>
+
+          {/* Hash display */}
+          {hash ? (
+            <View style={styles.hashCard}>
+              <Text style={styles.hashLabel}>Transaction Hash</Text>
+              <Text style={styles.hashValue} numberOfLines={1} ellipsizeMode="middle">
+                {hash}
+              </Text>
+            </View>
+          ) : null}
+        </View>
+
+        <View style={styles.actions}>
+          <Button variant="outline" size="lg" onPress={handleViewExplorer} style={styles.btn}>
+            View on Stellar Expert
+          </Button>
+          <Button variant="primary" size="lg" onPress={handleDone} style={styles.btn}>
+            Done
+          </Button>
+        </View>
+      </SafeAreaView>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#0F172A' },
+  content: { flex: 1, padding: 24, alignItems: 'center', justifyContent: 'center' },
+  iconWrap: { marginBottom: 28 },
+  iconCircle: {
+    width: 120,
+    height: 120,
+    borderRadius: 60,
+    backgroundColor: '#14532D',
+    justifyContent: 'center',
+    alignItems: 'center',
+    shadowColor: '#14532D',
+    shadowOpacity: 0.4,
+    shadowRadius: 20,
+    shadowOffset: { width: 0, height: 8 },
+    elevation: 12,
+  },
+  checkmark: { fontSize: 64, fontWeight: '800', color: '#4ADE80', lineHeight: 64 },
+  title: { fontSize: 26, fontWeight: '800', color: '#F8FAFC', marginBottom: 8, textAlign: 'center' },
+  subtitle: { fontSize: 14, color: '#94A3B8', textAlign: 'center', marginBottom: 32 },
+  hashCard: {
+    width: '100%',
+    backgroundColor: '#1E293B',
+    borderRadius: 12,
+    padding: 16,
+    alignItems: 'center',
+  },
+  hashLabel: { fontSize: 11, color: '#64748B', textTransform: 'uppercase', letterSpacing: 0.5, marginBottom: 6 },
+  hashValue: { fontSize: 13, color: '#94A3B8', fontFamily: 'monospace', width: '100%', textAlign: 'center' },
+  actions: { padding: 24, gap: 12 },
+  btn: { width: '100%' },
+});

--- a/mobile/components/transactions/TransactionItem.tsx
+++ b/mobile/components/transactions/TransactionItem.tsx
@@ -34,7 +34,7 @@ function relativeDate(dateStr: string): string {
   return `${days}d ago`;
 }
 
-export function TransactionItem({ type, description, amount, date }: Props) {
+export const TransactionItem = React.memo(function TransactionItem({ type, description, amount, date }: Props) {
   const color = COLOR[type];
   return (
     <View style={styles.row} accessibilityRole="text">
@@ -48,7 +48,7 @@ export function TransactionItem({ type, description, amount, date }: Props) {
       <Text style={[styles.amount, { color }]}>{formatXLM(amount)}</Text>
     </View>
   );
-}
+});
 
 const styles = StyleSheet.create({
   row: {

--- a/mobile/components/ui/GroupCard.tsx
+++ b/mobile/components/ui/GroupCard.tsx
@@ -17,7 +17,7 @@ const STATUS_COLORS: Record<Status, string> = {
   completed: '#6366F1',
 };
 
-export function GroupCard({ name, status, contributionAmount, dueDate, onPress }: Props) {
+export const GroupCard = React.memo(function GroupCard({ name, status, contributionAmount, dueDate, onPress }: Props) {
   return (
     <TouchableOpacity style={styles.card} onPress={onPress} testID="group-card">
       <View style={styles.row}>
@@ -34,7 +34,7 @@ export function GroupCard({ name, status, contributionAmount, dueDate, onPress }
       )}
     </TouchableOpacity>
   );
-}
+});
 
 const styles = StyleSheet.create({
   card: { backgroundColor: '#1E293B', borderRadius: 12, padding: 16, marginBottom: 12 },


### PR DESCRIPTION
## Summary

Implements all four issues assigned to @Tinna23 in a single branch.

Closes #156
Closes #157
Closes #159
Closes #169

---

## Changes

### #156 — Transaction signing confirmation screen
- New screen at `mobile/app/transaction/confirm.tsx`
- Accepts route params: `type`, `amount`, `destination`, `fee`, `memo`
- Displays a clear summary card with all transaction details
- Network fee shown prominently in amber
- 'Confirm and Sign' primary button + 'Cancel' secondary button
- Spinner shown while transaction is being submitted
- On success navigates to `/transaction/success`

### #157 — Transaction success screen with explorer link
- New screen at `mobile/app/transaction/success.tsx`
- Accepts route param: `txHash`
- Success checkmark animation (green circle, consistent with contributions/success)
- Truncated transaction hash displayed in monospace card
- 'View on Stellar Expert' opens `txExplorerLink(hash, 'testnet')` in browser
- 'Done' replaces navigation back to `/(tabs)`
- Back gesture disabled via `Stack.Screen options={{ gestureEnabled: false }}`

### #159 — Transaction type filter tabs on history screen
- New screen at `mobile/app/transaction/history.tsx`
- 'All / Contributions / Payouts' tab row with animated underline indicator
- Item count shown in each tab label (e.g. `Contributions (3)`)
- Counts update on pull-to-refresh
- Active tab visually distinct (indigo underline + label colour)
- Filtered list updates instantly on tab switch

### #169 — FlatList performance optimisations
- `GroupCard` wrapped with `React.memo`
- `TransactionItem` wrapped with `React.memo`
- `renderGroup` in groups list memoised with `useCallback`
- Groups list FlatList gains: `keyExtractor`, `getItemLayout`, `removeClippedSubviews`, `maxToRenderPerBatch={10}`, `windowSize={5}`
- History screen FlatList has the same perf props from the start