### PR TITLE
feat(mobile): Hermes engine, i18n infrastructure, French & Swahili translations

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -1,0 +1,30 @@
+{
+  "expo": {
+    "name": "EsuStellar",
+    "slug": "esustellar",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "icon": "./assets/icon.png",
+    "userInterfaceStyle": "automatic",
+    "jsEngine": "hermes",
+    "splash": {
+      "resizeMode": "contain",
+      "backgroundColor": "#0F172A"
+    },
+    "ios": {
+      "supportsTablet": true,
+      "jsEngine": "hermes"
+    },
+    "android": {
+      "adaptiveIcon": {
+        "backgroundColor": "#0F172A"
+      },
+      "jsEngine": "hermes"
+    },
+    "plugins": [
+      "expo-router",
+      "expo-localization"
+    ],
+    "scheme": "esustellar"
+  }
+}

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -10,6 +10,7 @@ import {
   Text,
   View,
 } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { NotificationBanner } from '../components/notifications/NotificationBanner';
 import { ThemeProvider, useTheme } from '../context/ThemeContext';
 import { useAutoLock } from '../hooks/useAutoLock';
@@ -41,6 +42,7 @@ function RootLayoutContent() {
   const [locked, setLocked] = useState(false);
   const router = useRouter();
   const { colors } = useTheme();
+  const { t } = useTranslation();
 
   const promptBiometric = useCallback(async () => {
     const enabled = await AsyncStorage.getItem(BIOMETRIC_LOCK_KEY);
@@ -139,7 +141,7 @@ function RootLayoutContent() {
     setBanner({
       body: content.body ?? undefined,
       data: (content.data ?? {}) as Record<string, unknown>,
-      title: content.title ?? 'New notification',
+      title: content.title ?? t('tabs.notifications'),
     });
 
     if (bannerTimerRef.current) {
@@ -211,7 +213,7 @@ function RootLayoutContent() {
         <View style={styles.overlay}>
           <Text style={styles.overlayText}>EsuStellar</Text>
           <Text style={styles.lockHint} onPress={promptBiometric}>
-            Tap to unlock
+            {t('lock.tapToUnlock')}
           </Text>
         </View>
       )}

--- a/mobile/constants/i18n/index.ts
+++ b/mobile/constants/i18n/index.ts
@@ -3,84 +3,22 @@ import * as Localization from 'expo-localization';
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 
-export type SupportedLanguage = 'en' | 'es';
+import en from '../../locales/en.json';
+import fr from '../../locales/fr.json';
+import sw from '../../locales/sw.json';
+
+export type SupportedLanguage = 'en' | 'es' | 'fr' | 'sw';
 export const LANGUAGE_STORAGE_KEY = 'esustellar_app_language';
 
 export const languageOptions = [
   { label: 'English', value: 'en' as SupportedLanguage },
   { label: 'Español', value: 'es' as SupportedLanguage },
+  { label: 'Français', value: 'fr' as SupportedLanguage },
+  { label: 'Kiswahili', value: 'sw' as SupportedLanguage },
 ];
 
 const resources = {
-  en: {
-    translation: {
-      tabs: {
-        home: 'Home',
-        groups: 'Groups',
-        notifications: 'Notifications',
-        profile: 'Profile',
-      },
-      home: {
-        goodMorning: 'Good morning',
-        goodAfternoon: 'Good afternoon',
-        goodEvening: 'Good evening',
-        defaultUser: 'EsuStellar User',
-        totalBalance: 'Total Balance',
-        quickActions: 'Quick Actions',
-        balanceValue: '— XLM',
-      },
-      settings: {
-        title: 'Security Settings',
-        walletAddress: 'Wallet Address',
-        copyWalletAddress: 'Copy wallet address',
-        copyToast: 'Wallet address copied to clipboard',
-        copyFailed: 'Failed to copy wallet address',
-        biometricAuthentication: 'Biometric Authentication',
-        supported: 'Supported',
-        enableBiometrics: 'Enable biometrics',
-        useToSignIn: 'Use {{supportedLabel}} to sign in',
-        checkingDeviceCapabilities: 'Checking device capabilities…',
-        biometricsNotSupported: 'Biometrics not supported on this device',
-        setUpPinFallback: 'Set a PIN below as a fallback when biometrics are unavailable.',
-        noBiometricsEnrolled: 'No biometrics enrolled',
-        setupBiometricsHelper:
-          'Please set up fingerprint or face recognition in your device settings, then return here to enable it.',
-        about: 'About',
-        version: 'Version',
-        build: 'Build',
-        pinFallback: 'PIN Fallback',
-        pinDescription:
-          'Set a 4-6 digit PIN as a fallback when biometrics are unavailable.',
-        setUpPin: 'Set up PIN',
-        enterPin: 'Enter your PIN',
-        confirmYourPin: 'Confirm your PIN',
-        pinDigits: '4-6 digits',
-        reenterPin: 'Re-enter PIN',
-        cancel: 'Cancel',
-        next: 'Next',
-        confirm: 'Confirm',
-        pinSet: 'PIN is set',
-        pinFallbackInfo: 'Used as fallback when biometrics fail',
-        change: 'Change',
-        remove: 'Remove',
-        pinMustDigits: 'PIN must be 4-6 digits',
-        pinsDoNotMatch: 'PINs do not match',
-        biometricsEnabled: 'Biometric authentication enabled',
-        biometricsDisabled: 'Biometric authentication disabled',
-        biometricFailed: 'Biometric verification failed',
-        failedToSavePin: 'Failed to save PIN',
-        pinRemoved: 'PIN removed',
-        language: 'Language',
-        languageLabel: 'Choose your app language',
-        languageChangeSuccess: 'Language updated.',
-      },
-      profile: {
-        editProfile: 'Edit Profile',
-        settings: 'Settings',
-        disconnectWallet: 'Disconnect Wallet',
-      },
-    },
-  },
+  en: { translation: en },
   es: {
     translation: {
       tabs: {
@@ -97,6 +35,37 @@ const resources = {
         totalBalance: 'Saldo total',
         quickActions: 'Accesos rápidos',
         balanceValue: '— XLM',
+        notifications: 'Notificaciones',
+      },
+      onboarding: {
+        skip: 'Omitir',
+        next: 'Siguiente',
+        getStarted: 'Comenzar',
+        stayInformed: 'Mantente informado',
+        notificationBody:
+          'Recibe recordatorios de fechas de vencimiento, pagos y actualizaciones del grupo para no perderte ningún momento importante.',
+        allowNotifications: 'Permitir notificaciones',
+        skipForNow: 'Omitir por ahora',
+        slides: {
+          welcome: {
+            eyebrow: 'Bienvenido',
+            title: 'Ahorra con personas de confianza',
+            description:
+              'Lleva tu círculo de ahorro comunitario a la cadena de bloques sin perder la experiencia familiar de grupo.',
+          },
+          transparent: {
+            eyebrow: 'Transparente',
+            title: 'Sigue cada contribución claramente',
+            description:
+              'Mantente al tanto de los pagos, fechas de vencimiento y el progreso del grupo con actualizaciones simples en un solo lugar.',
+          },
+          secure: {
+            eyebrow: 'Seguro',
+            title: 'Comienza con confianza',
+            description:
+              'Conecta tu billetera Stellar, gestiona tus opciones de seguridad y recibe recordatorios útiles cuando importa.',
+          },
+        },
       },
       settings: {
         title: 'Ajustes de seguridad',
@@ -149,8 +118,13 @@ const resources = {
         settings: 'Ajustes',
         disconnectWallet: 'Desconectar billetera',
       },
+      lock: {
+        tapToUnlock: 'Toca para desbloquear',
+      },
     },
   },
+  fr: { translation: fr },
+  sw: { translation: sw },
 };
 
 i18n.use(initReactI18next).init({
@@ -182,9 +156,10 @@ export const changeLanguage = async (language: SupportedLanguage): Promise<void>
 export const loadLanguage = async (): Promise<SupportedLanguage> => {
   try {
     const stored = await AsyncStorage.getItem(LANGUAGE_STORAGE_KEY);
-    const language = stored && languageOptions.some((item) => item.value === stored)
-      ? (stored as SupportedLanguage)
-      : getDeviceLanguage();
+    const language =
+      stored && languageOptions.some((item) => item.value === stored)
+        ? (stored as SupportedLanguage)
+        : getDeviceLanguage();
 
     await i18n.changeLanguage(language);
     return language;

--- a/mobile/i18n.ts
+++ b/mobile/i18n.ts
@@ -1,0 +1,34 @@
+import * as Localization from 'expo-localization';
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+import en from './locales/en.json';
+import fr from './locales/fr.json';
+import sw from './locales/sw.json';
+
+export const SUPPORTED_LANGUAGES = ['en', 'es', 'fr', 'sw'] as const;
+export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+
+const resources = {
+  en: { translation: en },
+  fr: { translation: fr },
+  sw: { translation: sw },
+};
+
+const getDeviceLanguage = (): SupportedLanguage => {
+  const locale = Localization.locale ?? 'en';
+  const tag = locale.split('-')[0] as SupportedLanguage;
+  return SUPPORTED_LANGUAGES.includes(tag) ? tag : 'en';
+};
+
+if (!i18n.isInitialized) {
+  i18n.use(initReactI18next).init({
+    compatibilityJSON: 'v3',
+    resources,
+    lng: getDeviceLanguage(),
+    fallbackLng: 'en',
+    interpolation: { escapeValue: false },
+  });
+}
+
+export default i18n;

--- a/mobile/locales/en.json
+++ b/mobile/locales/en.json
@@ -1,0 +1,95 @@
+{
+  "tabs": {
+    "home": "Home",
+    "groups": "Groups",
+    "notifications": "Notifications",
+    "profile": "Profile"
+  },
+  "home": {
+    "goodMorning": "Good morning",
+    "goodAfternoon": "Good afternoon",
+    "goodEvening": "Good evening",
+    "defaultUser": "EsuStellar User",
+    "totalBalance": "Total Balance",
+    "quickActions": "Quick Actions",
+    "balanceValue": "— XLM",
+    "notifications": "Notifications"
+  },
+  "onboarding": {
+    "skip": "Skip",
+    "next": "Next",
+    "getStarted": "Get Started",
+    "stayInformed": "Stay informed",
+    "notificationBody": "Get reminders for due dates, payouts, and group updates so you never miss an important moment.",
+    "allowNotifications": "Allow Notifications",
+    "skipForNow": "Skip for now",
+    "slides": {
+      "welcome": {
+        "eyebrow": "Welcome",
+        "title": "Save with people you trust",
+        "description": "Bring your community savings circle on-chain without losing the familiar group experience."
+      },
+      "transparent": {
+        "eyebrow": "Transparent",
+        "title": "Track every contribution clearly",
+        "description": "Stay on top of payouts, due dates, and group progress with simple updates in one place."
+      },
+      "secure": {
+        "eyebrow": "Secure",
+        "title": "Start with confidence",
+        "description": "Connect your Stellar wallet, manage your security options, and receive helpful reminders when it matters."
+      }
+    }
+  },
+  "settings": {
+    "title": "Security Settings",
+    "walletAddress": "Wallet Address",
+    "copyWalletAddress": "Copy wallet address",
+    "copyToast": "Wallet address copied to clipboard",
+    "copyFailed": "Failed to copy wallet address",
+    "biometricAuthentication": "Biometric Authentication",
+    "supported": "Supported",
+    "enableBiometrics": "Enable biometrics",
+    "useToSignIn": "Use {{supportedLabel}} to sign in",
+    "checkingDeviceCapabilities": "Checking device capabilities…",
+    "biometricsNotSupported": "Biometrics not supported on this device",
+    "setUpPinFallback": "Set a PIN below as a fallback when biometrics are unavailable.",
+    "noBiometricsEnrolled": "No biometrics enrolled",
+    "setupBiometricsHelper": "Please set up fingerprint or face recognition in your device settings, then return here to enable it.",
+    "about": "About",
+    "version": "Version",
+    "build": "Build",
+    "pinFallback": "PIN Fallback",
+    "pinDescription": "Set a 4-6 digit PIN as a fallback when biometrics are unavailable.",
+    "setUpPin": "Set up PIN",
+    "enterPin": "Enter your PIN",
+    "confirmYourPin": "Confirm your PIN",
+    "pinDigits": "4-6 digits",
+    "reenterPin": "Re-enter PIN",
+    "cancel": "Cancel",
+    "next": "Next",
+    "confirm": "Confirm",
+    "pinSet": "PIN is set",
+    "pinFallbackInfo": "Used as fallback when biometrics fail",
+    "change": "Change",
+    "remove": "Remove",
+    "pinMustDigits": "PIN must be 4-6 digits",
+    "pinsDoNotMatch": "PINs do not match",
+    "biometricsEnabled": "Biometric authentication enabled",
+    "biometricsDisabled": "Biometric authentication disabled",
+    "biometricFailed": "Biometric verification failed",
+    "failedToSavePin": "Failed to save PIN",
+    "pinRemoved": "PIN removed",
+    "language": "Language",
+    "languageLabel": "Choose your app language",
+    "languageChangeSuccess": "Language updated."
+  },
+  "profile": {
+    "editProfile": "Edit Profile",
+    "settings": "Settings",
+    "disconnectWallet": "Disconnect Wallet"
+  },
+  "lock": {
+    "tapToUnlock": "Tap to unlock"
+  }
+}

--- a/mobile/locales/fr.json
+++ b/mobile/locales/fr.json
@@ -1,0 +1,95 @@
+{
+  "tabs": {
+    "home": "Accueil",
+    "groups": "Groupes",
+    "notifications": "Notifications",
+    "profile": "Profil"
+  },
+  "home": {
+    "goodMorning": "Bonjour",
+    "goodAfternoon": "Bon après-midi",
+    "goodEvening": "Bonsoir",
+    "defaultUser": "Utilisateur EsuStellar",
+    "totalBalance": "Solde total",
+    "quickActions": "Actions rapides",
+    "balanceValue": "— XLM",
+    "notifications": "Notifications"
+  },
+  "onboarding": {
+    "skip": "Passer",
+    "next": "Suivant",
+    "getStarted": "Commencer",
+    "stayInformed": "Restez informé",
+    "notificationBody": "Recevez des rappels pour les échéances, les paiements et les mises à jour de groupe afin de ne jamais manquer un moment important.",
+    "allowNotifications": "Autoriser les notifications",
+    "skipForNow": "Passer pour l'instant",
+    "slides": {
+      "welcome": {
+        "eyebrow": "Bienvenue",
+        "title": "Épargnez avec des personnes de confiance",
+        "description": "Amenez votre tontine communautaire sur la blockchain sans perdre l'expérience de groupe familière."
+      },
+      "transparent": {
+        "eyebrow": "Transparent",
+        "title": "Suivez chaque contribution clairement",
+        "description": "Gardez un œil sur les paiements, les échéances et la progression du groupe avec des mises à jour simples en un seul endroit."
+      },
+      "secure": {
+        "eyebrow": "Sécurisé",
+        "title": "Commencez en toute confiance",
+        "description": "Connectez votre portefeuille Stellar, gérez vos options de sécurité et recevez des rappels utiles au bon moment."
+      }
+    }
+  },
+  "settings": {
+    "title": "Paramètres de sécurité",
+    "walletAddress": "Adresse du portefeuille",
+    "copyWalletAddress": "Copier l'adresse du portefeuille",
+    "copyToast": "Adresse du portefeuille copiée dans le presse-papiers",
+    "copyFailed": "Échec de la copie de l'adresse du portefeuille",
+    "biometricAuthentication": "Authentification biométrique",
+    "supported": "Pris en charge",
+    "enableBiometrics": "Activer la biométrie",
+    "useToSignIn": "Utiliser {{supportedLabel}} pour se connecter",
+    "checkingDeviceCapabilities": "Vérification des capacités de l'appareil…",
+    "biometricsNotSupported": "La biométrie n'est pas prise en charge sur cet appareil",
+    "setUpPinFallback": "Définissez un code PIN ci-dessous comme solution de secours lorsque la biométrie n'est pas disponible.",
+    "noBiometricsEnrolled": "Aucune biométrie enregistrée",
+    "setupBiometricsHelper": "Veuillez configurer l'empreinte digitale ou la reconnaissance faciale dans les paramètres de votre appareil, puis revenez ici pour l'activer.",
+    "about": "À propos",
+    "version": "Version",
+    "build": "Build",
+    "pinFallback": "Code PIN de secours",
+    "pinDescription": "Définissez un code PIN de 4 à 6 chiffres comme solution de secours lorsque la biométrie n'est pas disponible.",
+    "setUpPin": "Configurer le code PIN",
+    "enterPin": "Entrez votre code PIN",
+    "confirmYourPin": "Confirmez votre code PIN",
+    "pinDigits": "4 à 6 chiffres",
+    "reenterPin": "Ressaisissez le code PIN",
+    "cancel": "Annuler",
+    "next": "Suivant",
+    "confirm": "Confirmer",
+    "pinSet": "Le code PIN est défini",
+    "pinFallbackInfo": "Utilisé comme solution de secours lorsque la biométrie échoue",
+    "change": "Modifier",
+    "remove": "Supprimer",
+    "pinMustDigits": "Le code PIN doit comporter 4 à 6 chiffres",
+    "pinsDoNotMatch": "Les codes PIN ne correspondent pas",
+    "biometricsEnabled": "Authentification biométrique activée",
+    "biometricsDisabled": "Authentification biométrique désactivée",
+    "biometricFailed": "La vérification biométrique a échoué",
+    "failedToSavePin": "Échec de l'enregistrement du code PIN",
+    "pinRemoved": "Code PIN supprimé",
+    "language": "Langue",
+    "languageLabel": "Choisissez la langue de l'application",
+    "languageChangeSuccess": "Langue mise à jour."
+  },
+  "profile": {
+    "editProfile": "Modifier le profil",
+    "settings": "Paramètres",
+    "disconnectWallet": "Déconnecter le portefeuille"
+  },
+  "lock": {
+    "tapToUnlock": "Appuyez pour déverrouiller"
+  }
+}

--- a/mobile/locales/sw.json
+++ b/mobile/locales/sw.json
@@ -1,0 +1,95 @@
+{
+  "tabs": {
+    "home": "Nyumbani",
+    "groups": "Vikundi",
+    "notifications": "Arifa",
+    "profile": "Wasifu"
+  },
+  "home": {
+    "goodMorning": "Habari za asubuhi",
+    "goodAfternoon": "Habari za mchana",
+    "goodEvening": "Habari za jioni",
+    "defaultUser": "Mtumiaji wa EsuStellar",
+    "totalBalance": "Jumla ya Salio",
+    "quickActions": "Vitendo vya Haraka",
+    "balanceValue": "— XLM",
+    "notifications": "Arifa"
+  },
+  "onboarding": {
+    "skip": "Ruka",
+    "next": "Endelea",
+    "getStarted": "Anza",
+    "stayInformed": "Kaa na habari",
+    "notificationBody": "Pokea vikumbusho vya tarehe za mwisho, malipo, na masasisho ya kikundi ili usikose wakati muhimu.",
+    "allowNotifications": "Ruhusu Arifa",
+    "skipForNow": "Ruka kwa sasa",
+    "slides": {
+      "welcome": {
+        "eyebrow": "Karibu",
+        "title": "Weka akiba na watu unaowaaminia",
+        "description": "Leta mzunguko wako wa akiba ya jamii kwenye blockchain bila kupoteza uzoefu wa kawaida wa kikundi."
+      },
+      "transparent": {
+        "eyebrow": "Uwazi",
+        "title": "Fuatilia kila mchango kwa uwazi",
+        "description": "Fuatilia malipo, tarehe za mwisho, na maendeleo ya kikundi kwa masasisho rahisi mahali pamoja."
+      },
+      "secure": {
+        "eyebrow": "Salama",
+        "title": "Anza kwa ujasiri",
+        "description": "Unganisha pochi yako ya Stellar, simamia chaguo zako za usalama, na upokee vikumbusho vya msaada wakati unahitajika."
+      }
+    }
+  },
+  "settings": {
+    "title": "Mipangilio ya Usalama",
+    "walletAddress": "Anwani ya Pochi",
+    "copyWalletAddress": "Nakili anwani ya pochi",
+    "copyToast": "Anwani ya pochi imenakiliwa kwenye ubao wa kunakili",
+    "copyFailed": "Imeshindwa kunakili anwani ya pochi",
+    "biometricAuthentication": "Uthibitishaji wa Biometriki",
+    "supported": "Inasaidiwa",
+    "enableBiometrics": "Wezesha biometriki",
+    "useToSignIn": "Tumia {{supportedLabel}} kuingia",
+    "checkingDeviceCapabilities": "Inakagua uwezo wa kifaa…",
+    "biometricsNotSupported": "Biometriki haziungwi mkono kwenye kifaa hiki",
+    "setUpPinFallback": "Weka PIN hapa chini kama mbadala wakati biometriki haipatikani.",
+    "noBiometricsEnrolled": "Hakuna biometriki zilizosajiliwa",
+    "setupBiometricsHelper": "Tafadhali sanidi alama ya kidole au utambuzi wa uso katika mipangilio ya kifaa chako, kisha rudi hapa kuiwezesha.",
+    "about": "Kuhusu",
+    "version": "Toleo",
+    "build": "Muundo",
+    "pinFallback": "PIN ya Mbadala",
+    "pinDescription": "Weka PIN ya tarakimu 4-6 kama mbadala wakati biometriki haipatikani.",
+    "setUpPin": "Weka PIN",
+    "enterPin": "Ingiza PIN yako",
+    "confirmYourPin": "Thibitisha PIN yako",
+    "pinDigits": "Tarakimu 4-6",
+    "reenterPin": "Ingiza tena PIN",
+    "cancel": "Ghairi",
+    "next": "Endelea",
+    "confirm": "Thibitisha",
+    "pinSet": "PIN imewekwa",
+    "pinFallbackInfo": "Inatumika kama mbadala wakati biometriki inashindwa",
+    "change": "Badilisha",
+    "remove": "Ondoa",
+    "pinMustDigits": "PIN lazima iwe tarakimu 4-6",
+    "pinsDoNotMatch": "PIN hazilingani",
+    "biometricsEnabled": "Uthibitishaji wa biometriki umewezeshwa",
+    "biometricsDisabled": "Uthibitishaji wa biometriki umezimwa",
+    "biometricFailed": "Uthibitishaji wa biometriki umeshindwa",
+    "failedToSavePin": "Imeshindwa kuhifadhi PIN",
+    "pinRemoved": "PIN imeondolewa",
+    "language": "Lugha",
+    "languageLabel": "Chagua lugha ya programu",
+    "languageChangeSuccess": "Lugha imesasishwa."
+  },
+  "profile": {
+    "editProfile": "Hariri Wasifu",
+    "settings": "Mipangilio",
+    "disconnectWallet": "Tenganisha Pochi"
+  },
+  "lock": {
+    "tapToUnlock": "Gusa ili kufungua"
+  }
+}


### PR DESCRIPTION
## Summary

### Changes

**Issue #174 — Hermes engine**
- Created `mobile/app.json` with `expo.jsEngine: "hermes"` set at the root level and explicitly for both `ios` and `android` targets.
- `global.HermesInternal` will be truthy in production builds; no runtime errors introduced.

**Issue #175 — i18n infrastructure**
- Created `mobile/locales/en.json` with all UI strings extracted from the codebase.
- Created `mobile/i18n.ts` that initialises i18next with `expo-localization` device-locale detection and falls back to English for unsupported locales.
- Updated `mobile/constants/i18n/index.ts` to import locale JSON files and register all four languages (en, es, fr, sw).
- Replaced hardcoded strings in `mobile/app/_layout.tsx` with `t()` calls (`lock.tapToUnlock`, `tabs.notifications`).

**Issue #176 — French translation**
- Created `mobile/locales/fr.json` with accurate French translations for all keys in `en.json`.
- Registered the `fr` locale in `mobile/i18n.ts` and `mobile/constants/i18n/index.ts`.

**Issue #177 — Swahili translation**
- Created `mobile/locales/sw.json` with accurate Swahili translations for all keys in `en.json`.
- Registered the `sw` locale in `mobile/i18n.ts` and `mobile/constants/i18n/index.ts`.

### Testing
- Changing device locale to `fr` or `sw` will display the app in the respective language.
- Unsupported locales fall back to English — no missing-key warnings.
- TypeScript types are satisfied; no new dependencies required (expo-localization, i18next, react-i18next already in package.json).

Closes #174
Closes #175
Closes #176
Closes #177