### PR TITLE
feat(mobile): RTL support, locale formatting, language screen & env config

### DIFF
--- a/mobile/.env.development
+++ b/mobile/.env.development
@@ -1,0 +1,6 @@
+# Development environment
+EXPO_PUBLIC_ENV=development
+EXPO_PUBLIC_API_URL=https://dev-api.esustellar.com
+EXPO_PUBLIC_STELLAR_NETWORK=testnet
+EXPO_PUBLIC_STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
+EXPO_PUBLIC_STELLAR_NETWORK_PASSPHRASE=Test SDF Network ; September 2015

--- a/mobile/.env.example
+++ b/mobile/.env.example
@@ -1,0 +1,7 @@
+# Local overrides — NOT committed to source control.
+# Copy this file to .env.local and fill in your values.
+EXPO_PUBLIC_ENV=development
+EXPO_PUBLIC_API_URL=https://dev-api.esustellar.com
+EXPO_PUBLIC_STELLAR_NETWORK=testnet
+EXPO_PUBLIC_STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
+EXPO_PUBLIC_STELLAR_NETWORK_PASSPHRASE=Test SDF Network ; September 2015

--- a/mobile/.env.production
+++ b/mobile/.env.production
@@ -1,0 +1,6 @@
+# Production environment
+EXPO_PUBLIC_ENV=production
+EXPO_PUBLIC_API_URL=https://api.esustellar.com
+EXPO_PUBLIC_STELLAR_NETWORK=mainnet
+EXPO_PUBLIC_STELLAR_HORIZON_URL=https://horizon.stellar.org
+EXPO_PUBLIC_STELLAR_NETWORK_PASSPHRASE=Public Global Stellar Network ; September 2015

--- a/mobile/.env.staging
+++ b/mobile/.env.staging
@@ -1,0 +1,6 @@
+# Staging environment
+EXPO_PUBLIC_ENV=staging
+EXPO_PUBLIC_API_URL=https://staging-api.esustellar.com
+EXPO_PUBLIC_STELLAR_NETWORK=testnet
+EXPO_PUBLIC_STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
+EXPO_PUBLIC_STELLAR_NETWORK_PASSPHRASE=Test SDF Network ; September 2015

--- a/mobile/app/settings/index.tsx
+++ b/mobile/app/settings/index.tsx
@@ -32,7 +32,6 @@ import {
 } from '../../services/security/securityPreferences';
 
 import {
-  changeLanguage,
   getLanguage,
   languageOptions,
   loadLanguage,
@@ -239,22 +238,12 @@ export default function SettingsScreen() {
           ]}
         >
           <Text style={[styles.sectionTitle, { color: colors.text }]}>
-            Language
+            {t('settings.language')}
           </Text>
-          {languageOptions.map((opt) => (
-            <Button
-              key={opt.value}
-              onPress={async () => {
-                await changeLanguage(opt.value);
-                setLanguage(opt.value);
-              }}
-            >
-              {opt.label}
-            </Button>
-          ))}
-          <Text style={[styles.helperText, { color: colors.subtext }]}>
-            Current: {language.toUpperCase()}
-          </Text>
+          <Button onPress={() => router.push('/settings/language')}>
+            {languageOptions.find((o) => o.value === language)?.label ??
+              language.toUpperCase()}
+          </Button>
         </View>
 
         {/* Appearance */}

--- a/mobile/app/settings/language.tsx
+++ b/mobile/app/settings/language.tsx
@@ -1,0 +1,100 @@
+import React, { useEffect, useState } from 'react';
+import {
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useTranslation } from 'react-i18next';
+
+import { useTheme } from '../../context/ThemeContext';
+import {
+  changeLanguage,
+  getLanguage,
+  languageOptions,
+  loadLanguage,
+  type SupportedLanguage,
+} from '../../constants/i18n';
+
+export default function LanguageScreen() {
+  const { t } = useTranslation();
+  const { colors } = useTheme();
+  const [selected, setSelected] = useState<SupportedLanguage>(getLanguage());
+
+  useEffect(() => {
+    void loadLanguage().then(setSelected);
+  }, []);
+
+  const handleSelect = async (lang: SupportedLanguage) => {
+    await changeLanguage(lang);
+    setSelected(lang);
+  };
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
+      <ScrollView contentContainerStyle={styles.content}>
+        <Text style={[styles.title, { color: colors.text }]}>
+          {t('settings.language')}
+        </Text>
+        <Text style={[styles.subtitle, { color: colors.subtext }]}>
+          {t('settings.languageLabel')}
+        </Text>
+
+        <View style={[styles.list, { borderColor: colors.border }]}>
+          {languageOptions.map((opt, index) => {
+            const isSelected = selected === opt.value;
+            const isLast = index === languageOptions.length - 1;
+            return (
+              <TouchableOpacity
+                key={opt.value}
+                onPress={() => handleSelect(opt.value)}
+                style={[
+                  styles.row,
+                  { borderColor: colors.border },
+                  !isLast && styles.rowBorder,
+                ]}
+                accessibilityRole="radio"
+                accessibilityState={{ selected: isSelected }}
+              >
+                <Text style={[styles.label, { color: colors.text }]}>
+                  {opt.label}
+                </Text>
+                {isSelected && (
+                  <Text style={[styles.checkmark, { color: colors.accent }]}>
+                    ✓
+                  </Text>
+                )}
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  content: { padding: 16, gap: 12 },
+  title: { fontSize: 24, fontWeight: '700' },
+  subtitle: { fontSize: 14 },
+  list: {
+    borderWidth: 1,
+    borderRadius: 12,
+    overflow: 'hidden',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+  },
+  rowBorder: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  label: { fontSize: 16 },
+  checkmark: { fontSize: 18, fontWeight: '700' },
+});

--- a/mobile/config/env.ts
+++ b/mobile/config/env.ts
@@ -1,0 +1,62 @@
+/**
+ * Centralised, validated application configuration.
+ *
+ * All values come from `EXPO_PUBLIC_*` environment variables so they are
+ * inlined at build time by Expo's bundler and safe to read on the client.
+ *
+ * Environment files (loaded in priority order by Expo):
+ *   .env.local          – local overrides (git-ignored)
+ *   .env.<environment>  – e.g. .env.development / .env.staging / .env.production
+ *   .env               – shared defaults
+ *
+ * Switch environments by setting APP_VARIANT in eas.json or via:
+ *   npx expo start --env staging
+ */
+
+type Environment = 'development' | 'staging' | 'production';
+
+interface AppConfig {
+  /** Current runtime environment. */
+  env: Environment;
+  /** Base URL for the EsuStellar REST API. */
+  apiUrl: string;
+  /** Stellar network name ('testnet' | 'mainnet'). */
+  stellarNetwork: string;
+  /** Horizon server base URL. */
+  stellarHorizonUrl: string;
+  /** Stellar network passphrase used when signing transactions. */
+  stellarNetworkPassphrase: string;
+}
+
+function requireEnv(key: string): string {
+  const value = process.env[key];
+  if (!value) {
+    throw new Error(
+      `[config] Missing required environment variable: ${key}. ` +
+        'Copy .env.example to .env.local and fill in the values.',
+    );
+  }
+  return value;
+}
+
+function parseEnvironment(raw: string | undefined): Environment {
+  if (raw === 'staging' || raw === 'production') return raw;
+  return 'development';
+}
+
+const config: AppConfig = {
+  env: parseEnvironment(process.env.EXPO_PUBLIC_ENV),
+  apiUrl: requireEnv('EXPO_PUBLIC_API_URL'),
+  stellarNetwork: requireEnv('EXPO_PUBLIC_STELLAR_NETWORK'),
+  stellarHorizonUrl: requireEnv('EXPO_PUBLIC_STELLAR_HORIZON_URL'),
+  stellarNetworkPassphrase: requireEnv('EXPO_PUBLIC_STELLAR_NETWORK_PASSPHRASE'),
+};
+
+/** Returns true when running against the development environment. */
+export const isDev = (): boolean => config.env === 'development';
+/** Returns true when running against the staging environment. */
+export const isStaging = (): boolean => config.env === 'staging';
+/** Returns true when running against the production environment. */
+export const isProd = (): boolean => config.env === 'production';
+
+export default config;

--- a/mobile/constants/i18n/index.ts
+++ b/mobile/constants/i18n/index.ts
@@ -1,23 +1,37 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Localization from 'expo-localization';
 import i18n from 'i18next';
+import { I18nManager } from 'react-native';
 import { initReactI18next } from 'react-i18next';
 
+import ar from '../../locales/ar.json';
 import en from '../../locales/en.json';
 import fr from '../../locales/fr.json';
 import sw from '../../locales/sw.json';
 
-export type SupportedLanguage = 'en' | 'es' | 'fr' | 'sw';
+export type SupportedLanguage = 'ar' | 'en' | 'es' | 'fr' | 'sw';
 export const LANGUAGE_STORAGE_KEY = 'esustellar_app_language';
 
+/** Languages written right-to-left. */
+const RTL_LANGUAGES: ReadonlySet<SupportedLanguage> = new Set(['ar']);
+
 export const languageOptions = [
+  { label: 'العربية', value: 'ar' as SupportedLanguage },
   { label: 'English', value: 'en' as SupportedLanguage },
   { label: 'Español', value: 'es' as SupportedLanguage },
   { label: 'Français', value: 'fr' as SupportedLanguage },
   { label: 'Kiswahili', value: 'sw' as SupportedLanguage },
 ];
 
+const applyRTL = (lang: SupportedLanguage): void => {
+  const shouldBeRTL = RTL_LANGUAGES.has(lang);
+  if (I18nManager.isRTL !== shouldBeRTL) {
+    I18nManager.forceRTL(shouldBeRTL);
+  }
+};
+
 const resources = {
+  ar: { translation: ar },
   en: { translation: en },
   es: {
     translation: {
@@ -150,6 +164,7 @@ export const getLanguage = (): SupportedLanguage => {
 
 export const changeLanguage = async (language: SupportedLanguage): Promise<void> => {
   await AsyncStorage.setItem(LANGUAGE_STORAGE_KEY, language);
+  applyRTL(language);
   await i18n.changeLanguage(language);
 };
 
@@ -162,9 +177,11 @@ export const loadLanguage = async (): Promise<SupportedLanguage> => {
         : getDeviceLanguage();
 
     await i18n.changeLanguage(language);
+    applyRTL(language);
     return language;
   } catch {
     await i18n.changeLanguage('en');
+    applyRTL('en');
     return 'en';
   }
 };

--- a/mobile/i18n.ts
+++ b/mobile/i18n.ts
@@ -1,15 +1,21 @@
 import * as Localization from 'expo-localization';
 import i18n from 'i18next';
+import { I18nManager } from 'react-native';
 import { initReactI18next } from 'react-i18next';
 
+import ar from './locales/ar.json';
 import en from './locales/en.json';
 import fr from './locales/fr.json';
 import sw from './locales/sw.json';
 
-export const SUPPORTED_LANGUAGES = ['en', 'es', 'fr', 'sw'] as const;
+export const SUPPORTED_LANGUAGES = ['ar', 'en', 'es', 'fr', 'sw'] as const;
 export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
 
+/** Languages that are written right-to-left. */
+const RTL_LANGUAGES: ReadonlySet<string> = new Set(['ar', 'he', 'fa', 'ur']);
+
 const resources = {
+  ar: { translation: ar },
   en: { translation: en },
   fr: { translation: fr },
   sw: { translation: sw },
@@ -21,11 +27,25 @@ const getDeviceLanguage = (): SupportedLanguage => {
   return SUPPORTED_LANGUAGES.includes(tag) ? tag : 'en';
 };
 
+/**
+ * Apply RTL layout when the given language code is right-to-left.
+ * React Native's I18nManager.forceRTL takes effect on next render cycle.
+ */
+export const applyRTL = (lang: string): void => {
+  const shouldBeRTL = RTL_LANGUAGES.has(lang);
+  if (I18nManager.isRTL !== shouldBeRTL) {
+    I18nManager.forceRTL(shouldBeRTL);
+  }
+};
+
 if (!i18n.isInitialized) {
+  const initialLang = getDeviceLanguage();
+  applyRTL(initialLang);
+
   i18n.use(initReactI18next).init({
     compatibilityJSON: 'v3',
     resources,
-    lng: getDeviceLanguage(),
+    lng: initialLang,
     fallbackLng: 'en',
     interpolation: { escapeValue: false },
   });

--- a/mobile/locales/ar.json
+++ b/mobile/locales/ar.json
@@ -1,0 +1,95 @@
+{
+  "tabs": {
+    "home": "Home",
+    "groups": "Groups",
+    "notifications": "Notifications",
+    "profile": "Profile"
+  },
+  "home": {
+    "goodMorning": "Good morning",
+    "goodAfternoon": "Good afternoon",
+    "goodEvening": "Good evening",
+    "defaultUser": "EsuStellar User",
+    "totalBalance": "Total Balance",
+    "quickActions": "Quick Actions",
+    "balanceValue": "— XLM",
+    "notifications": "Notifications"
+  },
+  "onboarding": {
+    "skip": "Skip",
+    "next": "Next",
+    "getStarted": "Get Started",
+    "stayInformed": "Stay informed",
+    "notificationBody": "Get reminders for due dates, payouts, and group updates so you never miss an important moment.",
+    "allowNotifications": "Allow Notifications",
+    "skipForNow": "Skip for now",
+    "slides": {
+      "welcome": {
+        "eyebrow": "Welcome",
+        "title": "Save with people you trust",
+        "description": "Bring your community savings circle on-chain without losing the familiar group experience."
+      },
+      "transparent": {
+        "eyebrow": "Transparent",
+        "title": "Track every contribution clearly",
+        "description": "Stay on top of payouts, due dates, and group progress with simple updates in one place."
+      },
+      "secure": {
+        "eyebrow": "Secure",
+        "title": "Start with confidence",
+        "description": "Connect your Stellar wallet, manage your security options, and receive helpful reminders when it matters."
+      }
+    }
+  },
+  "settings": {
+    "title": "Security Settings",
+    "walletAddress": "Wallet Address",
+    "copyWalletAddress": "Copy wallet address",
+    "copyToast": "Wallet address copied to clipboard",
+    "copyFailed": "Failed to copy wallet address",
+    "biometricAuthentication": "Biometric Authentication",
+    "supported": "Supported",
+    "enableBiometrics": "Enable biometrics",
+    "useToSignIn": "Use {{supportedLabel}} to sign in",
+    "checkingDeviceCapabilities": "Checking device capabilities…",
+    "biometricsNotSupported": "Biometrics not supported on this device",
+    "setUpPinFallback": "Set a PIN below as a fallback when biometrics are unavailable.",
+    "noBiometricsEnrolled": "No biometrics enrolled",
+    "setupBiometricsHelper": "Please set up fingerprint or face recognition in your device settings, then return here to enable it.",
+    "about": "About",
+    "version": "Version",
+    "build": "Build",
+    "pinFallback": "PIN Fallback",
+    "pinDescription": "Set a 4-6 digit PIN as a fallback when biometrics are unavailable.",
+    "setUpPin": "Set up PIN",
+    "enterPin": "Enter your PIN",
+    "confirmYourPin": "Confirm your PIN",
+    "pinDigits": "4-6 digits",
+    "reenterPin": "Re-enter PIN",
+    "cancel": "Cancel",
+    "next": "Next",
+    "confirm": "Confirm",
+    "pinSet": "PIN is set",
+    "pinFallbackInfo": "Used as fallback when biometrics fail",
+    "change": "Change",
+    "remove": "Remove",
+    "pinMustDigits": "PIN must be 4-6 digits",
+    "pinsDoNotMatch": "PINs do not match",
+    "biometricsEnabled": "Biometric authentication enabled",
+    "biometricsDisabled": "Biometric authentication disabled",
+    "biometricFailed": "Biometric verification failed",
+    "failedToSavePin": "Failed to save PIN",
+    "pinRemoved": "PIN removed",
+    "language": "Language",
+    "languageLabel": "Choose your app language",
+    "languageChangeSuccess": "Language updated."
+  },
+  "profile": {
+    "editProfile": "Edit Profile",
+    "settings": "Settings",
+    "disconnectWallet": "Disconnect Wallet"
+  },
+  "lock": {
+    "tapToUnlock": "Tap to unlock"
+  }
+}

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -4,6 +4,8 @@
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",
+    "start:staging": "NODE_ENV=staging expo start --env staging",
+    "start:prod": "NODE_ENV=production expo start --env production",
     "android": "expo start --android",
     "ios": "expo start --ios",
     "lint": "eslint . --ext .ts,.tsx",

--- a/mobile/utils/formatCurrency.ts
+++ b/mobile/utils/formatCurrency.ts
@@ -1,16 +1,21 @@
+import * as Localization from 'expo-localization';
+
+/** Returns the current device locale (BCP-47). Falls back to 'en'. */
+const getLocale = (): string => Localization.locale ?? 'en';
+
 /**
  * Formats a numeric amount as a localized currency string.
  *
  * @param amount  - The numeric value to format.
  * @param currency - ISO 4217 currency code (default: 'USD').
- * @param locale   - BCP 47 locale tag (default: 'en-US').
+ * @param locale   - BCP 47 locale tag (defaults to device locale).
  */
 export function formatCurrency(
   amount: number,
   currency = 'USD',
-  locale = 'en-US',
+  locale?: string,
 ): string {
-  return new Intl.NumberFormat(locale, {
+  return new Intl.NumberFormat(locale ?? getLocale(), {
     style: 'currency',
     currency,
     minimumFractionDigits: 2,
@@ -19,18 +24,33 @@ export function formatCurrency(
 }
 
 /**
+ * Formats an XLM amount using the locale-appropriate decimal separator.
+ *
+ * @param amount  - The XLM amount.
+ * @param locale  - BCP 47 locale tag (defaults to device locale).
+ */
+export function formatXLM(amount: number, locale?: string): string {
+  return (
+    new Intl.NumberFormat(locale ?? getLocale(), {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 7,
+    }).format(amount) + ' XLM'
+  );
+}
+
+/**
  * Converts an XLM amount to a fiat equivalent string using a provided rate.
  *
  * @param xlmAmount - Amount in XLM.
  * @param rate      - Fiat price per 1 XLM.
  * @param currency  - ISO 4217 code for the fiat currency.
- * @param locale    - BCP 47 locale tag.
+ * @param locale    - BCP 47 locale tag (defaults to device locale).
  */
 export function xlmToFiat(
   xlmAmount: number,
   rate: number,
   currency = 'USD',
-  locale = 'en-US',
+  locale?: string,
 ): string {
   return formatCurrency(xlmAmount * rate, currency, locale);
 }

--- a/mobile/utils/formatDate.ts
+++ b/mobile/utils/formatDate.ts
@@ -1,0 +1,53 @@
+import * as Localization from 'expo-localization';
+
+/**
+ * Returns the current device locale (BCP-47), e.g. 'fr-FR', 'en-US'.
+ * Falls back to 'en' when unavailable.
+ */
+const getLocale = (): string => Localization.locale ?? 'en';
+
+/**
+ * Formats a date value using the device locale and the given Intl.DateTimeFormat options.
+ *
+ * @param date    - A Date object, ISO string, or timestamp.
+ * @param options - Optional Intl.DateTimeFormat options (defaults to date-only medium style).
+ * @param locale  - Override the locale; defaults to the device locale.
+ */
+export function formatDate(
+  date: Date | string | number,
+  options?: Intl.DateTimeFormatOptions,
+  locale?: string,
+): string {
+  const resolvedLocale = locale ?? getLocale();
+  const resolvedOptions: Intl.DateTimeFormatOptions = options ?? {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  };
+  return new Intl.DateTimeFormat(resolvedLocale, resolvedOptions).format(
+    new Date(date),
+  );
+}
+
+/**
+ * Formats a date + time value using the device locale.
+ *
+ * @param date   - A Date object, ISO string, or timestamp.
+ * @param locale - Override the locale; defaults to the device locale.
+ */
+export function formatDateTime(
+  date: Date | string | number,
+  locale?: string,
+): string {
+  return formatDate(
+    date,
+    {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    },
+    locale,
+  );
+}


### PR DESCRIPTION
## Summary

This PR implements four mobile issues covering internationalisation improvements and environment configuration hardening.

---

## Closes

closes #178
closes #179
closes #180
closes #184

---

## Changes

### #178 — RTL layout support for Arabic and other right-to-left locales

- Added `applyRTL(lang)` helper to both `mobile/i18n.ts` and `mobile/constants/i18n/index.ts` that calls `I18nManager.forceRTL(true/false)` whenever the active language changes.
- RTL is applied on cold start (using device language) **and** on every `changeLanguage` / `loadLanguage` call — no app restart required.
- Added `ar` to `SUPPORTED_LANGUAGES` and to `languageOptions` with native name `العربية`.
- Created `mobile/locales/ar.json` — Arabic placeholder seeded from English strings as a starting point for translation.

**Files changed**
- `mobile/i18n.ts`
- `mobile/constants/i18n/index.ts`
- `mobile/locales/ar.json` *(new)*

---

### #179 — Format dates and numbers according to device locale

- Created `mobile/utils/formatDate.ts` with `formatDate()` and `formatDateTime()` utilities — both use `Intl.DateTimeFormat` with the device locale read from `expo-localization`.
- Updated `mobile/utils/formatCurrency.ts`:
  - `locale` parameter now defaults to the device locale (removes all hard-coded `'en-US'`).
  - New `formatXLM(amount, locale?)` function formats XLM amounts with the locale-correct decimal separator.

**Files changed**
- `mobile/utils/formatDate.ts` *(new)*
- `mobile/utils/formatCurrency.ts`

---

### #180 — Language selection screen in Settings

- Created `mobile/app/settings/language.tsx`:
  - Lists every available locale with its **native name** (العربية, English, Español, Français, Kiswahili).
  - Shows a ✓ checkmark next to the currently selected language.
  - Calls `changeLanguage()` on selection → language updates immediately (no restart) and persists via `AsyncStorage`.
- Updated `mobile/app/settings/index.tsx`:
  - Replaced the inline language button list with a single **Language** row that navigates to `/settings/language`.
  - Removed unused `changeLanguage` import.

**Files changed**
- `mobile/app/settings/language.tsx` *(new)*
- `mobile/app/settings/index.tsx`

---

### #184 — Improve environment variable handling

- Added three environment files using Expo's `EXPO_PUBLIC_*` convention:
  - `mobile/.env.development` — dev/testnet defaults
  - `mobile/.env.staging` — staging/testnet config
  - `mobile/.env.production` — production/mainnet config
  - `mobile/.env.example` — template for local setup (committed; `.env.local` remains git-ignored per root `.gitignore`)
- Created `mobile/config/env.ts` — typed, **validated** config module:
  - `requireEnv()` throws at startup with a clear message if a required variable is missing.
  - Exports typed `AppConfig` interface and `isDev()` / `isStaging()` / `isProd()` helpers.
- Added `start:staging` and `start:prod` npm scripts to `mobile/package.json`.

**Files changed**
- `mobile/.env.development` *(new)*
- `mobile/.env.staging` *(new)*
- `mobile/.env.production` *(new)*
- `mobile/.env.example` *(new)*
- `mobile/config/env.ts` *(new)*
- `mobile/package.json`

---

## Testing

| Scenario | Expected result |
|---|---|
| Set language to `العربية` | `I18nManager.isRTL` becomes `true`; UI mirrors horizontally |
| Set language back to English | RTL reverts without restart |
| Run in French locale | Dates show `27 avr. 2026`; decimals use `,` separator |
| Run in US locale | Dates show `Apr 27, 2026`; decimals use `.` separator |
| Navigate Settings → Language | Language screen opens with checkmark on current language |
| Select a language | Takes effect immediately; persists after restart |
| Start without `.env` | App throws descriptive error at launch listing the missing variable |
| `npm run start:staging` | `config.env === 'staging'`, staging API URL used |