### PR TITLE
fix(web): fetch real group members from contract using groupId

### DIFF
--- a/apps/web/components/group-members.tsx
+++ b/apps/web/components/group-members.tsx
@@ -1,65 +1,146 @@
+"use client"
+
+import { useEffect, useState } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
-
-const members = [
-  { address: "GDQP...X7KL", position: 1, status: "received", joinedAt: "Nov 2025" },
-  { address: "GAKM...F9KL", position: 2, status: "received", joinedAt: "Nov 2025" },
-  { address: "GBXC...H2MN", position: 3, status: "paid", joinedAt: "Nov 2025" },
-  { address: "GDEF...J4PQ", position: 4, status: "paid", joinedAt: "Nov 2025" },
-  { address: "GHIJ...L6RS", position: 5, status: "paid", joinedAt: "Dec 2025", isYou: true },
-  { address: "GKLM...N8TU", position: 6, status: "pending", joinedAt: "Dec 2025" },
-  { address: "GNOP...P0VW", position: 7, status: "paid", joinedAt: "Dec 2025" },
-  { address: "GQRS...R2XY", position: 8, status: "overdue", joinedAt: "Jan 2026" },
-]
+import { Skeleton } from "@/components/ui/skeleton"
+import { useSavingsContract, type Member, type MemberStatus } from "@/context/savingsContract"
+import { useWallet } from "@/hooks/use-wallet"
 
 interface GroupMembersProps {
   groupId: string
 }
 
+type BadgeVariant = "received" | "paid" | "pending" | "overdue"
+
+interface DisplayMember {
+  address: string
+  position: number
+  status: BadgeVariant
+  joinedAt: string
+  isYou: boolean
+}
+
+const STATUS_TO_VARIANT: Record<MemberStatus, BadgeVariant> = {
+  Active: "pending",
+  PaidCurrentRound: "paid",
+  Overdue: "overdue",
+  Defaulted: "overdue",
+  ReceivedPayout: "received",
+}
+
+function formatJoinedAt(joinTimestamp: bigint): string {
+  const seconds = Number(joinTimestamp)
+  if (!Number.isFinite(seconds) || seconds <= 0) return "Unknown"
+  const date = new Date(seconds * 1000)
+  if (Number.isNaN(date.getTime())) return "Unknown"
+  return date.toLocaleDateString("en-US", { month: "short", year: "numeric" })
+}
+
+function shortAddress(address: string): string {
+  if (address.length <= 12) return address
+  return `${address.slice(0, 4)}...${address.slice(-4)}`
+}
+
 export function GroupMembers({ groupId }: GroupMembersProps) {
+  const { getMembersByGroup, isReady } = useSavingsContract()
+  const { publicKey } = useWallet()
+  const canFetch = Boolean(groupId) && isReady
+  const [members, setMembers] = useState<DisplayMember[]>([])
+  const [loading, setLoading] = useState(canFetch)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!canFetch) return
+    let cancelled = false
+
+    const run = async () => {
+      try {
+        const raw = await getMembersByGroup(groupId)
+        if (cancelled) return
+        const mapped: DisplayMember[] = raw.map((m: Member) => ({
+          address: shortAddress(m.address),
+          position: m.joinOrder,
+          status: STATUS_TO_VARIANT[m.status] ?? "pending",
+          joinedAt: formatJoinedAt(m.joinTimestamp),
+          isYou: publicKey != null && m.address === publicKey,
+        }))
+        setMembers(mapped)
+        setError(null)
+      } catch (err: unknown) {
+        if (cancelled) return
+        setError(err instanceof Error ? err.message : "Failed to load members")
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    run()
+
+    return () => {
+      cancelled = true
+    }
+  }, [canFetch, groupId, getMembersByGroup, publicKey])
+
   return (
     <Card className="border-border bg-card">
       <CardHeader>
-        <CardTitle className="text-foreground">Members ({members.length})</CardTitle>
+        <CardTitle className="text-foreground">
+          Members{loading ? "" : ` (${members.length})`}
+        </CardTitle>
       </CardHeader>
       <CardContent>
-        <div className="space-y-3">
-          {members.map((member) => (
-            <div
-              key={member.address}
-              className={`flex items-center justify-between rounded-lg border p-3 ${
-                member.isYou ? "border-primary/30 bg-primary/5" : "border-border"
-              }`}
-            >
-              <div className="flex items-center gap-3">
-                <Avatar className="h-10 w-10">
-                  <AvatarFallback className="bg-muted text-muted-foreground text-xs">#{member.position}</AvatarFallback>
-                </Avatar>
-                <div>
-                  <div className="flex items-center gap-2">
-                    <span className="font-mono text-sm text-foreground">{member.address}</span>
-                    {member.isYou && (
-                      <Badge variant="outline" className="text-xs bg-primary/10 text-primary border-primary/20">
-                        You
-                      </Badge>
-                    )}
+        {loading ? (
+          <div className="space-y-3">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <Skeleton key={i} className="h-16 w-full rounded-lg" />
+            ))}
+          </div>
+        ) : error ? (
+          <p className="text-sm text-error">{error}</p>
+        ) : members.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No members in this group yet.</p>
+        ) : (
+          <div className="space-y-3">
+            {members.map((member) => (
+              <div
+                key={member.address}
+                className={`flex items-center justify-between rounded-lg border p-3 ${
+                  member.isYou ? "border-primary/30 bg-primary/5" : "border-border"
+                }`}
+              >
+                <div className="flex items-center gap-3">
+                  <Avatar className="h-10 w-10">
+                    <AvatarFallback className="bg-muted text-muted-foreground text-xs">
+                      #{member.position}
+                    </AvatarFallback>
+                  </Avatar>
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <span className="font-mono text-sm text-foreground">{member.address}</span>
+                      {member.isYou && (
+                        <Badge variant="outline" className="text-xs bg-primary/10 text-primary border-primary/20">
+                          You
+                        </Badge>
+                      )}
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      Position #{member.position} • Joined {member.joinedAt}
+                    </p>
                   </div>
-                  <p className="text-xs text-muted-foreground">
-                    Position #{member.position} • Joined {member.joinedAt}
-                  </p>
                 </div>
+                <MemberStatusBadge status={member.status} />
               </div>
-              <MemberStatusBadge status={member.status} />
-            </div>
-          ))}
-        </div>
+            ))}
+          </div>
+        )}
       </CardContent>
     </Card>
   )
 }
 
-function MemberStatusBadge({ status }: { status: string }) {
+function MemberStatusBadge({ status }: { status: BadgeVariant }) {
   const config = {
     received: { label: "🎉 Received", className: "bg-stellar/10 text-stellar border-stellar/20" },
     paid: { label: "✅ Paid", className: "bg-primary/10 text-primary border-primary/20" },
@@ -67,7 +148,7 @@ function MemberStatusBadge({ status }: { status: string }) {
     overdue: { label: "⚠️ Overdue", className: "bg-error/10 text-error border-error/20" },
   }
 
-  const { label, className } = config[status as keyof typeof config]
+  const { label, className } = config[status]
 
   return (
     <Badge variant="outline" className={className}>


### PR DESCRIPTION
## Summary

`GroupMembers` accepted a `groupId` prop but never read it; it rendered a hardcoded array of 8 fake members at the top of `apps/web/components/group-members.tsx`. Real members from the savings contract were never displayed. This PR replaces the hardcoded array with a contract fetch via `useSavingsContract().getMembersByGroup(groupId)`, mapped onto the existing render surface.

Closes #49

## Why this matters

The component is wired into a group detail page that already passes the right `groupId`, so users opening a group's "Members" tab were seeing eight invented Stellar addresses regardless of which group they were looking at. The contract already exposes `get_members(groupId)` through `useSavingsContract`; the hook just wasn't being called. This is exactly the scenario the issue describes as the bug, and the fix is to wire the existing hook to the existing prop.

## Approach

The component is now a client component (`"use client"` is required because it uses `useEffect`, `useState`, and the wallet/contract hooks). The fetch runs inside a `useEffect` keyed on `[canFetch, groupId, getMembersByGroup, publicKey]`. Updates happen in `try/catch/finally` callbacks of an async IIFE so the effect body itself does not synchronously call `setState` (`react-hooks/set-state-in-effect` is enforced and was the only new lint error in the first iteration).

Contract members map to the existing render shape with three small adapters. Addresses are truncated to `XXXX...XXXX` for display, the position number comes from `joinOrder`, and `joinTimestamp` (a `u64` of unix seconds, BigInt) is formatted as `Mmm YYYY` via `toLocaleDateString`. Contract status maps to the existing badge variants: `Active` -> `pending`, `PaidCurrentRound` -> `paid`, `Overdue` -> `overdue`, `Defaulted` -> `overdue` (closest at-risk match), `ReceivedPayout` -> `received`. The `isYou` flag is derived by comparing each member's full `address` against `publicKey` from `useWallet()`. `MemberStatusBadge` itself is unchanged per the issue notes.

The component renders a skeleton row stack while fetching (matches `dashboard-stats.tsx`), an empty-state message when no members come back, and an inline error message if the contract call rejects.

## Acceptance criteria (issue body)

- [x] Hardcoded `const members = [...]` array removed
- [x] `"use client"` added
- [x] `useSavingsContract().getMembersByGroup(groupId)` called inside a `useEffect`
- [x] Contract statuses mapped to existing badge variants (no new variants)
- [x] `isYou` derived from `publicKey === member.address`
- [x] Loading state added
- [x] Empty state added
- [x] `joinTimestamp` (u64) formatted as a readable date string

## Verification

`npx tsc --noEmit` is clean for the changed file. `npx eslint components/group-members.tsx` is clean; the previously reported `react-hooks/set-state-in-effect` violation is gone after moving updates into the async callback. Pre-existing lint problems elsewhere in the repo (for example `dashboard-stats.tsx` and `useUserGroups.ts`) are untouched.

## Notes

Contract `MemberStatus.Defaulted` has no direct existing badge variant; it is mapped to `overdue` because both communicate an at-risk state. Happy to add a dedicated `defaulted` variant in a follow-up if preferred.
