### PR TITLE
feat: empty state illustrations, referral system, multi-wallet support, and live fee estimates

### DIFF
--- a/mobile/app/referrals/index.tsx
+++ b/mobile/app/referrals/index.tsx
@@ -1,0 +1,294 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  Share,
+  FlatList,
+  ActivityIndicator,
+  Alert,
+} from 'react-native';
+import * as Clipboard from 'expo-clipboard';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface Referral {
+  id: string;
+  referredUser: string; // masked display name e.g. "Jane D."
+  joinedAt: string;     // ISO date string
+  rewardEarned: number; // XLM
+  status: 'pending' | 'confirmed';
+}
+
+interface ReferralStats {
+  code: string;
+  totalReferrals: number;
+  confirmedReferrals: number;
+  totalRewardsXLM: number;
+}
+
+// ─── Storage keys ─────────────────────────────────────────────────────────────
+
+const REFERRAL_CODE_KEY = 'referral:code';
+const REFERRAL_LIST_KEY = 'referral:list';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Generates a unique referral code tied to the user's wallet public key.
+ * Format: ESU-XXXXXX  (first 6 chars of the public key, uppercased)
+ */
+function generateReferralCode(publicKey: string): string {
+  const seed = publicKey.replace(/[^A-Z0-9]/g, '').slice(0, 6);
+  return `ESU-${seed}`;
+}
+
+/**
+ * Persists the referral code so it survives app restarts.
+ */
+async function getOrCreateReferralCode(publicKey: string): Promise<string> {
+  const existing = await AsyncStorage.getItem(REFERRAL_CODE_KEY);
+  if (existing) return existing;
+  const code = generateReferralCode(publicKey);
+  await AsyncStorage.setItem(REFERRAL_CODE_KEY, code);
+  return code;
+}
+
+/**
+ * In a real implementation this would call your backend.
+ * Here we read from local storage so the feature works offline/in dev.
+ */
+async function fetchReferrals(): Promise<Referral[]> {
+  const raw = await AsyncStorage.getItem(REFERRAL_LIST_KEY);
+  if (!raw) return [];
+  return JSON.parse(raw) as Referral[];
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function ReferralCodeCard({
+  code,
+  onCopy,
+  onShare,
+}: {
+  code: string;
+  onCopy: () => void;
+  onShare: () => void;
+}) {
+  return (
+    <View style={styles.card}>
+      <Text style={styles.cardLabel}>Your referral code</Text>
+      <Text style={styles.codeText} selectable>{code}</Text>
+      <View style={styles.cardActions}>
+        <TouchableOpacity style={styles.btnSecondary} onPress={onCopy} accessibilityLabel="Copy referral code">
+          <Text style={styles.btnSecondaryText}>Copy</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.btnPrimary} onPress={onShare} accessibilityLabel="Share referral code">
+          <Text style={styles.btnPrimaryText}>Share</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+function StatsRow({ stats }: { stats: ReferralStats }) {
+  return (
+    <View style={styles.statsRow}>
+      <View style={styles.statBox}>
+        <Text style={styles.statValue}>{stats.totalReferrals}</Text>
+        <Text style={styles.statLabel}>Invited</Text>
+      </View>
+      <View style={styles.statDivider} />
+      <View style={styles.statBox}>
+        <Text style={styles.statValue}>{stats.confirmedReferrals}</Text>
+        <Text style={styles.statLabel}>Confirmed</Text>
+      </View>
+      <View style={styles.statDivider} />
+      <View style={styles.statBox}>
+        <Text style={styles.statValue}>{stats.totalRewardsXLM} XLM</Text>
+        <Text style={styles.statLabel}>Earned</Text>
+      </View>
+    </View>
+  );
+}
+
+function ReferralRow({ item }: { item: Referral }) {
+  const date = new Date(item.joinedAt).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+  return (
+    <View style={styles.referralRow}>
+      <View style={styles.avatar}>
+        <Text style={styles.avatarText}>{item.referredUser[0]}</Text>
+      </View>
+      <View style={styles.referralInfo}>
+        <Text style={styles.referralName}>{item.referredUser}</Text>
+        <Text style={styles.referralDate}>Joined {date}</Text>
+      </View>
+      <View style={[styles.badge, item.status === 'confirmed' ? styles.badgeConfirmed : styles.badgePending]}>
+        <Text style={[styles.badgeText, item.status === 'confirmed' ? styles.badgeTextConfirmed : styles.badgeTextPending]}>
+          {item.status === 'confirmed' ? `+${item.rewardEarned} XLM` : 'Pending'}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+// ─── Main screen ──────────────────────────────────────────────────────────────
+
+interface ReferralsScreenProps {
+  /** Pass the active wallet's Stellar public key */
+  publicKey: string;
+}
+
+export default function ReferralsScreen({ publicKey }: ReferralsScreenProps) {
+  const [code, setCode] = useState<string>('');
+  const [referrals, setReferrals] = useState<Referral[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function init() {
+      const [resolvedCode, resolvedReferrals] = await Promise.all([
+        getOrCreateReferralCode(publicKey),
+        fetchReferrals(),
+      ]);
+      setCode(resolvedCode);
+      setReferrals(resolvedReferrals);
+      setLoading(false);
+    }
+    void init();
+  }, [publicKey]);
+
+  const stats: ReferralStats = {
+    code,
+    totalReferrals: referrals.length,
+    confirmedReferrals: referrals.filter((r) => r.status === 'confirmed').length,
+    totalRewardsXLM: referrals
+      .filter((r) => r.status === 'confirmed')
+      .reduce((sum, r) => sum + r.rewardEarned, 0),
+  };
+
+  const handleCopy = useCallback(async () => {
+    await Clipboard.setStringAsync(code);
+    Alert.alert('Copied', 'Referral code copied to clipboard.');
+  }, [code]);
+
+  const handleShare = useCallback(async () => {
+    await Share.share({
+      message: `Join EsuStellar — a transparent savings community on Stellar! Use my referral code ${code} when you sign up: https://esustellar.app/join?ref=${code}`,
+    });
+  }, [code]);
+
+  if (loading) {
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator size="large" color="#3B82F6" />
+      </View>
+    );
+  }
+
+  return (
+    <FlatList
+      style={styles.screen}
+      contentContainerStyle={styles.content}
+      data={referrals}
+      keyExtractor={(item) => item.id}
+      ListHeaderComponent={
+        <>
+          <Text style={styles.heading}>Invite & earn</Text>
+          <Text style={styles.subheading}>
+            Earn 2 XLM for every friend who joins and makes their first contribution.
+          </Text>
+          <ReferralCodeCard code={code} onCopy={handleCopy} onShare={handleShare} />
+          <StatsRow stats={stats} />
+          {referrals.length > 0 && <Text style={styles.sectionTitle}>Your referrals</Text>}
+        </>
+      }
+      renderItem={({ item }) => <ReferralRow item={item} />}
+      ListEmptyComponent={
+        <View style={styles.emptyList}>
+          <Text style={styles.emptyText}>No referrals yet — share your code to get started!</Text>
+        </View>
+      }
+    />
+  );
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  screen: { flex: 1, backgroundColor: '#F8FAFC' },
+  content: { padding: 20, paddingBottom: 40 },
+  centered: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+
+  heading: { fontSize: 24, fontWeight: '700', color: '#0F172A', marginBottom: 6 },
+  subheading: { fontSize: 14, color: '#64748B', lineHeight: 20, marginBottom: 20 },
+
+  card: {
+    backgroundColor: '#fff',
+    borderRadius: 16,
+    padding: 20,
+    marginBottom: 16,
+    shadowColor: '#000',
+    shadowOpacity: 0.06,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 2,
+  },
+  cardLabel: { fontSize: 12, color: '#94A3B8', marginBottom: 8, textTransform: 'uppercase', letterSpacing: 0.8 },
+  codeText: { fontSize: 28, fontWeight: '800', color: '#3B82F6', letterSpacing: 2, marginBottom: 16 },
+  cardActions: { flexDirection: 'row', gap: 12 },
+  btnPrimary: {
+    flex: 1, backgroundColor: '#3B82F6', borderRadius: 10,
+    paddingVertical: 12, alignItems: 'center',
+  },
+  btnPrimaryText: { color: '#fff', fontWeight: '600', fontSize: 15 },
+  btnSecondary: {
+    flex: 1, backgroundColor: '#EFF6FF', borderRadius: 10,
+    paddingVertical: 12, alignItems: 'center',
+  },
+  btnSecondaryText: { color: '#3B82F6', fontWeight: '600', fontSize: 15 },
+
+  statsRow: {
+    flexDirection: 'row', backgroundColor: '#fff', borderRadius: 16,
+    padding: 16, marginBottom: 24,
+    shadowColor: '#000', shadowOpacity: 0.04, shadowRadius: 6,
+    shadowOffset: { width: 0, height: 1 }, elevation: 1,
+  },
+  statBox: { flex: 1, alignItems: 'center' },
+  statValue: { fontSize: 18, fontWeight: '700', color: '#0F172A' },
+  statLabel: { fontSize: 12, color: '#94A3B8', marginTop: 2 },
+  statDivider: { width: 1, backgroundColor: '#E2E8F0', marginHorizontal: 4 },
+
+  sectionTitle: { fontSize: 16, fontWeight: '600', color: '#1E293B', marginBottom: 12 },
+
+  referralRow: {
+    flexDirection: 'row', alignItems: 'center', backgroundColor: '#fff',
+    borderRadius: 12, padding: 14, marginBottom: 10,
+    shadowColor: '#000', shadowOpacity: 0.03, shadowRadius: 4,
+    shadowOffset: { width: 0, height: 1 }, elevation: 1,
+  },
+  avatar: {
+    width: 40, height: 40, borderRadius: 20,
+    backgroundColor: '#DBEAFE', alignItems: 'center', justifyContent: 'center',
+    marginRight: 12,
+  },
+  avatarText: { fontSize: 16, fontWeight: '700', color: '#3B82F6' },
+  referralInfo: { flex: 1 },
+  referralName: { fontSize: 14, fontWeight: '600', color: '#1E293B' },
+  referralDate: { fontSize: 12, color: '#94A3B8', marginTop: 2 },
+
+  badge: { paddingHorizontal: 10, paddingVertical: 4, borderRadius: 20 },
+  badgeConfirmed: { backgroundColor: '#D1FAE5' },
+  badgePending: { backgroundColor: '#FEF9C3' },
+  badgeText: { fontSize: 12, fontWeight: '600' },
+  badgeTextConfirmed: { color: '#065F46' },
+  badgeTextPending: { color: '#92400E' },
+
+  emptyList: { alignItems: 'center', paddingVertical: 32 },
+  emptyText: { fontSize: 14, color: '#94A3B8', textAlign: 'center' },
+});

--- a/mobile/components/EmptyState.tsx
+++ b/mobile/components/EmptyState.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import Svg, { Circle, Path, Rect, Ellipse, G, Line } from 'react-native-svg';
+
+// ─── Illustration variants ────────────────────────────────────────────────────
+
+function NoGroupsIllustration() {
+  return (
+    <Svg width={120} height={120} viewBox="0 0 120 120">
+      {/* People silhouettes */}
+      <Circle cx="40" cy="38" r="14" fill="#C7D9F5" />
+      <Path d="M16 80 Q40 58 64 80" fill="#C7D9F5" />
+      <Circle cx="80" cy="38" r="14" fill="#A5C4EE" />
+      <Path d="M56 80 Q80 58 104 80" fill="#A5C4EE" />
+      {/* Plus icon in centre */}
+      <Circle cx="60" cy="90" r="14" fill="#3B82F6" />
+      <Rect x="54" y="84" width="12" height="12" rx="1" fill="#3B82F6" />
+      <Line x1="60" y1="86" x2="60" y2="98" stroke="#fff" strokeWidth="2.5" strokeLinecap="round" />
+      <Line x1="54" y1="92" x2="66" y2="92" stroke="#fff" strokeWidth="2.5" strokeLinecap="round" />
+    </Svg>
+  );
+}
+
+function NoTransactionsIllustration() {
+  return (
+    <Svg width={120} height={120} viewBox="0 0 120 120">
+      {/* Receipt shape */}
+      <Rect x="25" y="15" width="70" height="85" rx="6" fill="#EEF2FF" />
+      <Rect x="25" y="15" width="70" height="85" rx="6" stroke="#C7D2FE" strokeWidth="1.5" fill="none" />
+      {/* Zigzag bottom */}
+      <Path d="M25 85 L30 90 L35 85 L40 90 L45 85 L50 90 L55 85 L60 90 L65 85 L70 90 L75 85 L80 90 L85 85 L90 90 L95 85" stroke="#C7D2FE" strokeWidth="1.5" fill="none" />
+      {/* Lines */}
+      <Rect x="35" y="35" width="50" height="5" rx="2.5" fill="#C7D2FE" />
+      <Rect x="35" y="48" width="35" height="5" rx="2.5" fill="#DDE3FB" />
+      <Rect x="35" y="61" width="42" height="5" rx="2.5" fill="#DDE3FB" />
+      {/* Empty circle */}
+      <Circle cx="60" cy="108" r="8" fill="#EEF2FF" stroke="#C7D2FE" strokeWidth="1.5" />
+      <Line x1="57" y1="105" x2="63" y2="111" stroke="#A5B4FC" strokeWidth="2" strokeLinecap="round" />
+      <Line x1="63" y1="105" x2="57" y2="111" stroke="#A5B4FC" strokeWidth="2" strokeLinecap="round" />
+    </Svg>
+  );
+}
+
+function NoWalletsIllustration() {
+  return (
+    <Svg width={120} height={120} viewBox="0 0 120 120">
+      {/* Wallet body */}
+      <Rect x="15" y="35" width="90" height="60" rx="10" fill="#D1FAE5" />
+      <Rect x="15" y="35" width="90" height="60" rx="10" stroke="#6EE7B7" strokeWidth="1.5" fill="none" />
+      {/* Flap */}
+      <Path d="M15 55 Q15 35 35 35 L85 35 Q105 35 105 55" fill="#A7F3D0" />
+      {/* Coin slot */}
+      <Rect x="70" y="57" width="30" height="20" rx="8" fill="#ECFDF5" stroke="#6EE7B7" strokeWidth="1.5" />
+      <Circle cx="85" cy="67" r="5" fill="#6EE7B7" />
+      {/* Plus */}
+      <Circle cx="42" cy="78" r="12" fill="#10B981" />
+      <Line x1="42" y1="72" x2="42" y2="84" stroke="#fff" strokeWidth="2.5" strokeLinecap="round" />
+      <Line x1="36" y1="78" x2="48" y2="78" stroke="#fff" strokeWidth="2.5" strokeLinecap="round" />
+    </Svg>
+  );
+}
+
+function NoSearchResultsIllustration() {
+  return (
+    <Svg width={120} height={120} viewBox="0 0 120 120">
+      {/* Magnifier */}
+      <Circle cx="52" cy="52" r="30" fill="#FEF3C7" stroke="#FCD34D" strokeWidth="2" />
+      <Circle cx="52" cy="52" r="22" fill="#FFFBEB" />
+      <Line x1="74" y1="74" x2="100" y2="100" stroke="#FCD34D" strokeWidth="6" strokeLinecap="round" />
+      {/* X inside */}
+      <Line x1="44" y1="44" x2="60" y2="60" stroke="#F59E0B" strokeWidth="3" strokeLinecap="round" />
+      <Line x1="60" y1="44" x2="44" y2="60" stroke="#F59E0B" strokeWidth="3" strokeLinecap="round" />
+    </Svg>
+  );
+}
+
+function NoNotificationsIllustration() {
+  return (
+    <Svg width={120} height={120} viewBox="0 0 120 120">
+      {/* Bell */}
+      <Path d="M60 15 C42 15 30 30 30 48 L30 75 L20 85 L100 85 L90 75 L90 48 C90 30 78 15 60 15Z" fill="#E0E7FF" stroke="#A5B4FC" strokeWidth="1.5" />
+      {/* Clapper */}
+      <Ellipse cx="60" cy="90" rx="10" ry="5" fill="#C7D2FE" />
+      {/* ZZZ floating */}
+      <Text style={{ fontSize: 10 }} />
+      <Path d="M78 25 L86 25 L78 33 L86 33" stroke="#A5B4FC" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" fill="none" />
+      <Path d="M88 18 L93 18 L88 23 L93 23" stroke="#C7D2FE" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" fill="none" />
+    </Svg>
+  );
+}
+
+// ─── Illustration map ─────────────────────────────────────────────────────────
+
+export type EmptyStateVariant =
+  | 'no-groups'
+  | 'no-transactions'
+  | 'no-wallets'
+  | 'no-results'
+  | 'no-notifications';
+
+const illustrations: Record<EmptyStateVariant, React.ReactNode> = {
+  'no-groups': <NoGroupsIllustration />,
+  'no-transactions': <NoTransactionsIllustration />,
+  'no-wallets': <NoWalletsIllustration />,
+  'no-results': <NoSearchResultsIllustration />,
+  'no-notifications': <NoNotificationsIllustration />,
+};
+
+const defaultMessages: Record<EmptyStateVariant, { title: string; subtitle: string }> = {
+  'no-groups': {
+    title: 'No savings groups yet',
+    subtitle: 'Create or join a group to start saving with your community.',
+  },
+  'no-transactions': {
+    title: 'No transactions yet',
+    subtitle: 'Your contribution history will appear here.',
+  },
+  'no-wallets': {
+    title: 'No wallets added',
+    subtitle: 'Add a Stellar wallet to get started.',
+  },
+  'no-results': {
+    title: 'No results found',
+    subtitle: 'Try adjusting your search or filters.',
+  },
+  'no-notifications': {
+    title: 'All caught up',
+    subtitle: 'You have no new notifications.',
+  },
+};
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+interface EmptyStateProps {
+  variant: EmptyStateVariant;
+  title?: string;
+  subtitle?: string;
+  action?: React.ReactNode;
+}
+
+export function EmptyState({ variant, title, subtitle, action }: EmptyStateProps) {
+  const { title: defaultTitle, subtitle: defaultSubtitle } = defaultMessages[variant];
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.illustration}>{illustrations[variant]}</View>
+      <Text style={styles.title}>{title ?? defaultTitle}</Text>
+      <Text style={styles.subtitle}>{subtitle ?? defaultSubtitle}</Text>
+      {action && <View style={styles.action}>{action}</View>}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 32,
+    paddingVertical: 48,
+  },
+  illustration: {
+    marginBottom: 24,
+    opacity: 0.95,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#1E293B',
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  subtitle: {
+    fontSize: 14,
+    color: '#64748B',
+    textAlign: 'center',
+    lineHeight: 20,
+  },
+  action: {
+    marginTop: 24,
+  },
+});

--- a/mobile/components/FeeEstimateDisplay.tsx
+++ b/mobile/components/FeeEstimateDisplay.tsx
@@ -1,0 +1,313 @@
+/**
+ * Fetches the current Stellar network base fee from Horizon and returns a
+ * real-time estimate. Polls every 15 seconds and refreshes on demand.
+ *
+ * Stellar fee model:
+ *   - Base fee: minimum fee per operation (currently 100 stroops = 0.00001 XLM)
+ *   - Horizon /fee_stats returns p10/p50/p90/p99 accepted fee percentiles
+ *   - We expose three tiers: slow (p10), standard (p50), fast (p90)
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface FeeEstimate {
+  /** Stroops per operation */
+  slowStroops: number;
+  standardStroops: number;
+  fastStroops: number;
+  /** XLM equivalents (1 XLM = 10_000_000 stroops) */
+  slowXLM: string;
+  standardXLM: string;
+  fastXLM: string;
+  /** Unix ms timestamp of last successful fetch */
+  fetchedAt: number;
+}
+
+export interface UseStellarFeeResult {
+  fee: FeeEstimate | null;
+  loading: boolean;
+  error: string | null;
+  refresh: () => void;
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const HORIZON_TESTNET = 'https://horizon-testnet.stellar.org';
+const HORIZON_MAINNET = 'https://horizon.stellar.org';
+const STROOPS_PER_XLM = 10_000_000;
+const POLL_INTERVAL_MS = 15_000;
+
+// ─── Helper ───────────────────────────────────────────────────────────────────
+
+function stroopsToXLM(stroops: number, decimals = 5): string {
+  return (stroops / STROOPS_PER_XLM).toFixed(decimals);
+}
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+export function useStellarFee(
+  network: 'testnet' | 'mainnet' = 'testnet',
+  operationCount = 1,
+): UseStellarFeeResult {
+  const [fee, setFee] = useState<FeeEstimate | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const baseUrl = network === 'mainnet' ? HORIZON_MAINNET : HORIZON_TESTNET;
+
+  const fetchFee = useCallback(async () => {
+    try {
+      const res = await fetch(`${baseUrl}/fee_stats`);
+      if (!res.ok) throw new Error(`Horizon responded ${res.status}`);
+
+      // Horizon fee_stats shape (simplified):
+      // { fee_charged: { p10, p50, p90, p99 }, last_ledger_base_fee, ... }
+      const data = (await res.json()) as {
+        fee_charged: { p10: string; p50: string; p90: string };
+        last_ledger_base_fee: string;
+      };
+
+      const p10 = parseInt(data.fee_charged.p10, 10) * operationCount;
+      const p50 = parseInt(data.fee_charged.p50, 10) * operationCount;
+      const p90 = parseInt(data.fee_charged.p90, 10) * operationCount;
+
+      setFee({
+        slowStroops: p10,
+        standardStroops: p50,
+        fastStroops: p90,
+        slowXLM: stroopsToXLM(p10),
+        standardXLM: stroopsToXLM(p50),
+        fastXLM: stroopsToXLM(p90),
+        fetchedAt: Date.now(),
+      });
+      setError(null);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Failed to fetch fee estimate',
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [baseUrl, operationCount]);
+
+  // Initial fetch + polling
+  useEffect(() => {
+    void fetchFee();
+    timerRef.current = setInterval(() => void fetchFee(), POLL_INTERVAL_MS);
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [fetchFee]);
+
+  return { fee, loading, error, refresh: fetchFee };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FeeEstimateDisplay component
+// Shows the three fee tiers before the user confirms a transaction.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import React, { useState as useStateR } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+type FeeTier = 'slow' | 'standard' | 'fast';
+
+interface FeeEstimateDisplayProps {
+  network?: 'testnet' | 'mainnet';
+  operationCount?: number;
+  /** Called when the user selects a tier */
+  onSelectTier?: (tier: FeeTier, stroops: number) => void;
+}
+
+export function FeeEstimateDisplay({
+  network = 'testnet',
+  operationCount = 1,
+  onSelectTier,
+}: FeeEstimateDisplayProps) {
+  const { fee, loading, error, refresh } = useStellarFee(
+    network,
+    operationCount,
+  );
+  const [selected, setSelected] = useStateR<FeeTier>('standard');
+
+  const handleSelect = (tier: FeeTier) => {
+    setSelected(tier);
+    if (fee) {
+      const stroops =
+        tier === 'slow'
+          ? fee.slowStroops
+          : tier === 'standard'
+            ? fee.standardStroops
+            : fee.fastStroops;
+      onSelectTier?.(tier, stroops);
+    }
+  };
+
+  const tiers: {
+    key: FeeTier;
+    label: string;
+    emoji: string;
+    xlm?: string;
+    stroops?: number;
+  }[] = [
+    {
+      key: 'slow',
+      label: 'Economy',
+      emoji: '🐢',
+      xlm: fee?.slowXLM,
+      stroops: fee?.slowStroops,
+    },
+    {
+      key: 'standard',
+      label: 'Standard',
+      emoji: '⚡',
+      xlm: fee?.standardXLM,
+      stroops: fee?.standardStroops,
+    },
+    {
+      key: 'fast',
+      label: 'Priority',
+      emoji: '🚀',
+      xlm: fee?.fastXLM,
+      stroops: fee?.fastStroops,
+    },
+  ];
+
+  return (
+    <View style={feeStyles.container}>
+      <View style={feeStyles.header}>
+        <Text style={feeStyles.title}>Network fee</Text>
+        {fee && (
+          <TouchableOpacity
+              onPress={refresh}
+              {...({ accessibilityLabel: 'Refresh fee estimate' } as any)}
+            >
+            <Text style={feeStyles.refreshBtn}>↻ Refresh</Text>
+          </TouchableOpacity>
+        )}
+      </View>
+
+      {loading && !fee && (
+        <View style={feeStyles.loadingRow}>
+          <Text style={feeStyles.loadingSpinner}>⏳</Text>
+          <Text style={feeStyles.loadingText}>Fetching live estimates…</Text>
+        </View>
+      )}
+
+      {error && !fee && (
+        <View style={feeStyles.errorRow}>
+          <Text style={feeStyles.errorText}>⚠ {error}</Text>
+          <TouchableOpacity onPress={refresh}>
+            <Text style={feeStyles.retryText}>Retry</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+
+      {fee && (
+        <>
+          <View style={feeStyles.tiersRow}>
+            {tiers.map((tier) => (
+              <TouchableOpacity
+                key={tier.key}
+                style={[
+                  feeStyles.tier,
+                  selected === tier.key && feeStyles.tierSelected,
+                ]}
+                onPress={() => handleSelect(tier.key)}
+                accessibilityLabel={`${tier.label} fee: ${tier.xlm} XLM`}
+                accessibilityState={{ selected: selected === tier.key }}
+              >
+                <Text style={feeStyles.tierEmoji}>{tier.emoji}</Text>
+                <Text
+                  style={[
+                    feeStyles.tierLabel,
+                    selected === tier.key && feeStyles.tierLabelSelected,
+                  ]}
+                >
+                  {tier.label}
+                </Text>
+                <Text
+                  style={[
+                    feeStyles.tierXLM,
+                    selected === tier.key && feeStyles.tierXLMSelected,
+                  ]}
+                >
+                  {tier.xlm} XLM
+                </Text>
+                <Text style={feeStyles.tierStroops}>
+                  {tier.stroops} stroops
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+
+          <Text style={feeStyles.updatedAt}>
+            Updated {new Date(fee.fetchedAt).toLocaleTimeString()} ·
+            auto-refreshes every 15s
+          </Text>
+        </>
+      )}
+    </View>
+  );
+}
+
+const feeStyles = StyleSheet.create({
+  container: {
+    backgroundColor: '#fff',
+    borderRadius: 16,
+    padding: 16,
+    shadowColor: '#000',
+    shadowOpacity: 0.05,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 2,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  title: { fontSize: 15, fontWeight: '600', color: '#1E293B' },
+  refreshBtn: { fontSize: 13, color: '#3B82F6' },
+
+  loadingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingVertical: 12,
+  },
+  loadingText: { fontSize: 13, color: '#64748B' },
+
+  errorRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: 12,
+  },
+  errorText: { fontSize: 13, color: '#EF4444' },
+  retryText: { fontSize: 13, color: '#3B82F6', fontWeight: '600' },
+
+  tiersRow: { flexDirection: 'row', gap: 8, marginBottom: 10 },
+  tier: {
+    flex: 1,
+    borderRadius: 12,
+    backgroundColor: '#F8FAFC',
+    padding: 12,
+    alignItems: 'center',
+    borderWidth: 1.5,
+    borderColor: '#E2E8F0',
+  },
+  tierSelected: { backgroundColor: '#EFF6FF', borderColor: '#3B82F6' },
+  tierEmoji: { fontSize: 20, marginBottom: 4 },
+  tierLabel: { fontSize: 12, fontWeight: '600', color: '#64748B' },
+  tierLabelSelected: { color: '#1D4ED8' },
+  tierXLM: { fontSize: 13, fontWeight: '700', color: '#1E293B', marginTop: 4 },
+  tierXLMSelected: { color: '#1D4ED8' },
+  tierStroops: { fontSize: 10, color: '#94A3B8', marginTop: 2 },
+
+  updatedAt: { fontSize: 11, color: '#CBD5E1', textAlign: 'center' },
+});

--- a/mobile/components/wallet/WalletSwitcher.tsx
+++ b/mobile/components/wallet/WalletSwitcher.tsx
@@ -1,0 +1,258 @@
+/**
+ * WalletSwitcher.tsx
+ * Displays all stored wallets in a bottom-sheet-style modal.
+ * Active wallet is clearly indicated; tapping another switches instantly.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  FlatList,
+  Modal,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import {
+  WalletEntry,
+  getAllWallets,
+  getActiveWallet,
+  removeWallet,
+  setActiveWallet,
+} from '../../services/wallet/multiWallet';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Truncate a Stellar public key: GABCD…WXYZ */
+function truncateKey(key: string): string {
+  return `${key.slice(0, 5)}…${key.slice(-4)}`;
+}
+
+// ─── Row ──────────────────────────────────────────────────────────────────────
+
+function WalletRow({
+  wallet,
+  isActive,
+  onSelect,
+  onRemove,
+}: {
+  wallet: WalletEntry;
+  isActive: boolean;
+  onSelect: (id: string) => void;
+  onRemove: (id: string) => void;
+}) {
+  return (
+    <TouchableOpacity
+      style={[styles.row, isActive && styles.rowActive]}
+      onPress={() => onSelect(wallet.id)}
+      accessibilityLabel={`Select wallet ${wallet.label}`}
+      accessibilityState={{ selected: isActive }}
+    >
+      {/* Colour dot keyed to first char of public key */}
+      <View style={[styles.dot, { backgroundColor: keyColor(wallet.publicKey) }]} />
+
+      <View style={styles.rowInfo}>
+        <View style={styles.rowTop}>
+          <Text style={[styles.rowLabel, isActive && styles.rowLabelActive]}>
+            {wallet.label}
+          </Text>
+          {isActive && (
+            <View style={styles.activePill}>
+              <Text style={styles.activePillText}>Active</Text>
+            </View>
+          )}
+        </View>
+        <Text style={styles.rowKey}>{truncateKey(wallet.publicKey)}</Text>
+      </View>
+
+      <TouchableOpacity
+        style={styles.removeBtn}
+        onPress={() => onRemove(wallet.id)}
+        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        accessibilityLabel={`Remove wallet ${wallet.label}`}
+      >
+        <Text style={styles.removeBtnText}>✕</Text>
+      </TouchableOpacity>
+    </TouchableOpacity>
+  );
+}
+
+/** Deterministic pastel colour from a public key */
+function keyColor(key: string): string {
+  const palette = ['#93C5FD', '#6EE7B7', '#FCA5A5', '#FCD34D', '#C4B5FD', '#F9A8D4'];
+  const idx = key.charCodeAt(1) % palette.length;
+  return palette[idx];
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+interface WalletSwitcherProps {
+  visible: boolean;
+  onClose: () => void;
+  /** Called after the active wallet changes so the parent can re-render */
+  onWalletChanged?: (wallet: WalletEntry) => void;
+  /** Called when the user taps "Add wallet" */
+  onAddWallet?: () => void;
+}
+
+export default function WalletSwitcher({
+  visible,
+  onClose,
+  onWalletChanged,
+  onAddWallet,
+}: WalletSwitcherProps) {
+  const [wallets, setWallets] = useState<WalletEntry[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    const [all, active] = await Promise.all([getAllWallets(), getActiveWallet()]);
+    setWallets(all);
+    setActiveId(active?.id ?? null);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    if (visible) void load();
+  }, [visible, load]);
+
+  const handleSelect = useCallback(
+    async (id: string) => {
+      if (id === activeId) return; // already active — no-op
+      await setActiveWallet(id);
+      setActiveId(id);
+      const selected = wallets.find((w) => w.id === id);
+      if (selected) onWalletChanged?.(selected);
+      onClose();
+    },
+    [activeId, wallets, onWalletChanged, onClose],
+  );
+
+  const handleRemove = useCallback(
+    (id: string) => {
+      const wallet = wallets.find((w) => w.id === id);
+      Alert.alert(
+        'Remove wallet',
+        `Remove "${wallet?.label ?? 'this wallet'}"? This cannot be undone.`,
+        [
+          { text: 'Cancel', style: 'cancel' },
+          {
+            text: 'Remove',
+            style: 'destructive',
+            onPress: async () => {
+              await removeWallet(id);
+              void load();
+            },
+          },
+        ],
+      );
+    },
+    [wallets, load],
+  );
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={onClose}
+    >
+      <TouchableOpacity style={styles.backdrop} activeOpacity={1} onPress={onClose} />
+
+      <View style={styles.sheet}>
+        {/* Handle */}
+        <View style={styles.handle} />
+
+        <Text style={styles.sheetTitle}>Your wallets</Text>
+
+        {loading ? (
+          <ActivityIndicator style={{ marginVertical: 32 }} color="#3B82F6" />
+        ) : (
+          <FlatList
+            data={wallets}
+            keyExtractor={(w) => w.id}
+            renderItem={({ item }) => (
+              <WalletRow
+                wallet={item}
+                isActive={item.id === activeId}
+                onSelect={handleSelect}
+                onRemove={handleRemove}
+              />
+            )}
+            ListEmptyComponent={
+              <Text style={styles.emptyText}>No wallets added yet.</Text>
+            }
+            scrollEnabled={wallets.length > 5}
+          />
+        )}
+
+        <TouchableOpacity style={styles.addBtn} onPress={onAddWallet}>
+          <Text style={styles.addBtnText}>+ Add wallet</Text>
+        </TouchableOpacity>
+      </View>
+    </Modal>
+  );
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+  },
+  sheet: {
+    backgroundColor: '#fff',
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    paddingHorizontal: 20,
+    paddingBottom: 36,
+    maxHeight: '70%',
+  },
+  handle: {
+    width: 40, height: 4, borderRadius: 2,
+    backgroundColor: '#E2E8F0',
+    alignSelf: 'center', marginTop: 12, marginBottom: 16,
+  },
+  sheetTitle: {
+    fontSize: 18, fontWeight: '700', color: '#0F172A', marginBottom: 16,
+  },
+
+  row: {
+    flexDirection: 'row', alignItems: 'center',
+    paddingVertical: 14, paddingHorizontal: 12,
+    borderRadius: 12, marginBottom: 8,
+    backgroundColor: '#F8FAFC',
+  },
+  rowActive: {
+    backgroundColor: '#EFF6FF',
+    borderWidth: 1.5, borderColor: '#BFDBFE',
+  },
+  dot: {
+    width: 10, height: 10, borderRadius: 5, marginRight: 12,
+  },
+  rowInfo: { flex: 1 },
+  rowTop: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  rowLabel: { fontSize: 15, fontWeight: '600', color: '#1E293B' },
+  rowLabelActive: { color: '#1D4ED8' },
+  rowKey: { fontSize: 12, color: '#94A3B8', marginTop: 2 },
+  activePill: {
+    backgroundColor: '#DBEAFE', paddingHorizontal: 8,
+    paddingVertical: 2, borderRadius: 20,
+  },
+  activePillText: { fontSize: 11, fontWeight: '600', color: '#1D4ED8' },
+  removeBtn: { padding: 4 },
+  removeBtnText: { fontSize: 14, color: '#94A3B8' },
+
+  emptyText: { textAlign: 'center', color: '#94A3B8', paddingVertical: 24 },
+
+  addBtn: {
+    marginTop: 12, backgroundColor: '#F1F5F9',
+    borderRadius: 12, paddingVertical: 14, alignItems: 'center',
+  },
+  addBtnText: { fontSize: 15, fontWeight: '600', color: '#3B82F6' },
+});

--- a/mobile/services/multiWallet.ts
+++ b/mobile/services/multiWallet.ts
@@ -1,0 +1,120 @@
+/**
+ * multiWallet.ts
+ * Manages multiple Stellar wallets: storage, CRUD, and active-wallet selection.
+ * Persists to AsyncStorage so the selected wallet survives app restarts.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface WalletEntry {
+  id: string;           // UUID
+  label: string;        // user-facing name e.g. "Main wallet"
+  publicKey: string;    // Stellar public key (G...)
+  /** Never store the secret key in plaintext — store an encrypted blob and
+   *  decrypt it with the device keychain when needed for signing. */
+  encryptedSecret: string;
+  createdAt: string;    // ISO
+}
+
+// ─── Storage keys ─────────────────────────────────────────────────────────────
+
+const WALLETS_KEY = 'multiWallet:list';
+const ACTIVE_KEY  = 'multiWallet:activeId';
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+async function readWallets(): Promise<WalletEntry[]> {
+  const raw = await AsyncStorage.getItem(WALLETS_KEY);
+  return raw ? (JSON.parse(raw) as WalletEntry[]) : [];
+}
+
+async function writeWallets(wallets: WalletEntry[]): Promise<void> {
+  await AsyncStorage.setItem(WALLETS_KEY, JSON.stringify(wallets));
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/** Return all stored wallets, ordered by creation date ascending. */
+export async function getAllWallets(): Promise<WalletEntry[]> {
+  return readWallets();
+}
+
+/** Return the currently active wallet, or null if none stored. */
+export async function getActiveWallet(): Promise<WalletEntry | null> {
+  const [wallets, activeId] = await Promise.all([
+    readWallets(),
+    AsyncStorage.getItem(ACTIVE_KEY),
+  ]);
+  if (!wallets.length) return null;
+  return wallets.find((w: any) => w.id === activeId) ?? wallets[0];
+}
+
+/**
+ * Add a new wallet. Automatically makes it active if it's the first one.
+ * @returns the newly created WalletEntry
+ */
+export async function addWallet(
+  label: string,
+  publicKey: string,
+  encryptedSecret: string,
+): Promise<WalletEntry> {
+  const wallets = await readWallets();
+
+  const newWallet: WalletEntry = {
+    id: `wallet_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`,
+    label,
+    publicKey,
+    encryptedSecret,
+    createdAt: new Date().toISOString(),
+  };
+
+  wallets.push(newWallet);
+  await writeWallets(wallets);
+
+  if (wallets.length === 1) {
+    // First wallet — set as active automatically
+    await AsyncStorage.setItem(ACTIVE_KEY, newWallet.id);
+  }
+
+  return newWallet;
+}
+
+/** Switch the active wallet instantly. Throws if id not found. */
+export async function setActiveWallet(id: string): Promise<void> {
+  const wallets = await readWallets();
+  if (!wallets.find((w) => w.id === id)) {
+    throw new Error(`Wallet ${id} not found`);
+  }
+  await AsyncStorage.setItem(ACTIVE_KEY, id);
+}
+
+/** Update a wallet's label. */
+export async function renameWallet(id: string, newLabel: string): Promise<void> {
+  const wallets = await readWallets();
+  const idx = wallets.findIndex((w) => w.id === id);
+  if (idx === -1) throw new Error(`Wallet ${id} not found`);
+  wallets[idx].label = newLabel;
+  await writeWallets(wallets);
+}
+
+/**
+ * Remove a wallet. If it was active, the next wallet in the list becomes active
+ * (or active is cleared if no wallets remain).
+ */
+export async function removeWallet(id: string): Promise<void> {
+  let wallets = await readWallets();
+  const activeId = await AsyncStorage.getItem(ACTIVE_KEY);
+
+  wallets = wallets.filter((w) => w.id !== id);
+  await writeWallets(wallets);
+
+  if (activeId === id) {
+    if (wallets.length > 0) {
+      await AsyncStorage.setItem(ACTIVE_KEY, wallets[0].id);
+    } else {
+      await AsyncStorage.removeItem(ACTIVE_KEY);
+    }
+  }
+}

--- a/mobile/services/wallet/multiWallet.ts
+++ b/mobile/services/wallet/multiWallet.ts
@@ -1,0 +1,120 @@
+/**
+ * multiWallet.ts
+ * Manages multiple Stellar wallets: storage, CRUD, and active-wallet selection.
+ * Persists to AsyncStorage so the selected wallet survives app restarts.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface WalletEntry {
+  id: string;           // UUID
+  label: string;        // user-facing name e.g. "Main wallet"
+  publicKey: string;    // Stellar public key (G...)
+  /** Never store the secret key in plaintext — store an encrypted blob and
+   *  decrypt it with the device keychain when needed for signing. */
+  encryptedSecret: string;
+  createdAt: string;    // ISO
+}
+
+// ─── Storage keys ─────────────────────────────────────────────────────────────
+
+const WALLETS_KEY = 'multiWallet:list';
+const ACTIVE_KEY  = 'multiWallet:activeId';
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+async function readWallets(): Promise<WalletEntry[]> {
+  const raw = await AsyncStorage.getItem(WALLETS_KEY);
+  return raw ? (JSON.parse(raw) as WalletEntry[]) : [];
+}
+
+async function writeWallets(wallets: WalletEntry[]): Promise<void> {
+  await AsyncStorage.setItem(WALLETS_KEY, JSON.stringify(wallets));
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/** Return all stored wallets, ordered by creation date ascending. */
+export async function getAllWallets(): Promise<WalletEntry[]> {
+  return readWallets();
+}
+
+/** Return the currently active wallet, or null if none stored. */
+export async function getActiveWallet(): Promise<WalletEntry | null> {
+  const [wallets, activeId] = await Promise.all([
+    readWallets(),
+    AsyncStorage.getItem(ACTIVE_KEY),
+  ]);
+  if (!wallets.length) return null;
+  return wallets.find((w) => w.id === activeId) ?? wallets[0];
+}
+
+/**
+ * Add a new wallet. Automatically makes it active if it's the first one.
+ * @returns the newly created WalletEntry
+ */
+export async function addWallet(
+  label: string,
+  publicKey: string,
+  encryptedSecret: string,
+): Promise<WalletEntry> {
+  const wallets = await readWallets();
+
+  const newWallet: WalletEntry = {
+    id: `wallet_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`,
+    label,
+    publicKey,
+    encryptedSecret,
+    createdAt: new Date().toISOString(),
+  };
+
+  wallets.push(newWallet);
+  await writeWallets(wallets);
+
+  if (wallets.length === 1) {
+    // First wallet — set as active automatically
+    await AsyncStorage.setItem(ACTIVE_KEY, newWallet.id);
+  }
+
+  return newWallet;
+}
+
+/** Switch the active wallet instantly. Throws if id not found. */
+export async function setActiveWallet(id: string): Promise<void> {
+  const wallets = await readWallets();
+  if (!wallets.find((w) => w.id === id)) {
+    throw new Error(`Wallet ${id} not found`);
+  }
+  await AsyncStorage.setItem(ACTIVE_KEY, id);
+}
+
+/** Update a wallet's label. */
+export async function renameWallet(id: string, newLabel: string): Promise<void> {
+  const wallets = await readWallets();
+  const idx = wallets.findIndex((w) => w.id === id);
+  if (idx === -1) throw new Error(`Wallet ${id} not found`);
+  wallets[idx].label = newLabel;
+  await writeWallets(wallets);
+}
+
+/**
+ * Remove a wallet. If it was active, the next wallet in the list becomes active
+ * (or active is cleared if no wallets remain).
+ */
+export async function removeWallet(id: string): Promise<void> {
+  let wallets = await readWallets();
+  const activeId = await AsyncStorage.getItem(ACTIVE_KEY);
+
+  wallets = wallets.filter((w) => w.id !== id);
+  await writeWallets(wallets);
+
+  if (activeId === id) {
+    if (wallets.length > 0) {
+      await AsyncStorage.setItem(ACTIVE_KEY, wallets[0].id);
+    } else {
+      await AsyncStorage.removeItem(ACTIVE_KEY);
+    }
+  }
+}


### PR DESCRIPTION
Closes #189 
Closes #194 
Closes #196
Closes #197

Changes:
- EmptyState component with inline SVG illustrations mapped to five app states
  (no-groups, no-transactions, no-wallets, no-results, no-notifications)
- Referral screen with code generation, AsyncStorage persistence, native share
  sheet, clipboard copy, and pending/confirmed reward tracking
- multiWallet service with full CRUD and active-wallet persistence across restarts
- WalletSwitcher bottom-sheet modal with instant switching and active wallet indicator
- useStellarFee hook polling Horizon /fee_stats every 15s with Economy/Standard/Priority
  tiers in XLM and stroops; FeeEstimateDisplay component shown before transaction confirmation