### PR TITLE
feat: improve mobile environment variable handling

### DIFF
--- a/mobile/__tests__/envConfig.test.ts
+++ b/mobile/__tests__/envConfig.test.ts
@@ -1,0 +1,18 @@
+import { resolveEnvironment } from '../config/env';
+
+describe('resolveEnvironment', () => {
+  it('prefers EXPO_PUBLIC_ENV when valid', () => {
+    expect(resolveEnvironment('staging', 'production')).toBe('staging');
+    expect(resolveEnvironment('production', 'development')).toBe('production');
+  });
+
+  it('falls back to NODE_ENV when EXPO_PUBLIC_ENV is missing', () => {
+    expect(resolveEnvironment(undefined, 'production')).toBe('production');
+    expect(resolveEnvironment(undefined, 'staging')).toBe('staging');
+  });
+
+  it('defaults to development for unknown values', () => {
+    expect(resolveEnvironment('invalid', 'invalid')).toBe('development');
+    expect(resolveEnvironment(undefined, undefined)).toBe('development');
+  });
+});

--- a/mobile/config/env.ts
+++ b/mobile/config/env.ts
@@ -39,16 +39,47 @@ function requireEnv(key: string): string {
   return value;
 }
 
+function validateUrl(value: string, key: string): string {
+  try {
+    // eslint-disable-next-line no-new
+    new URL(value);
+    return value;
+  } catch {
+    throw new Error(`[config] ${key} must be a valid URL. Received: "${value}"`);
+  }
+}
+
+function validateNetwork(value: string): string {
+  if (value === 'testnet' || value === 'mainnet') {
+    return value;
+  }
+
+  throw new Error(
+    `[config] EXPO_PUBLIC_STELLAR_NETWORK must be "testnet" or "mainnet". Received: "${value}"`,
+  );
+}
+
 function parseEnvironment(raw: string | undefined): Environment {
   if (raw === 'staging' || raw === 'production') return raw;
+  if (raw === 'development') return raw;
   return 'development';
 }
 
+export function resolveEnvironment(
+  expoPublicEnv: string | undefined,
+  nodeEnv: string | undefined,
+): Environment {
+  return parseEnvironment(expoPublicEnv ?? nodeEnv);
+}
+
 const config: AppConfig = {
-  env: parseEnvironment(process.env.EXPO_PUBLIC_ENV),
-  apiUrl: requireEnv('EXPO_PUBLIC_API_URL'),
-  stellarNetwork: requireEnv('EXPO_PUBLIC_STELLAR_NETWORK'),
-  stellarHorizonUrl: requireEnv('EXPO_PUBLIC_STELLAR_HORIZON_URL'),
+  env: resolveEnvironment(process.env.EXPO_PUBLIC_ENV, process.env.NODE_ENV),
+  apiUrl: validateUrl(requireEnv('EXPO_PUBLIC_API_URL'), 'EXPO_PUBLIC_API_URL'),
+  stellarNetwork: validateNetwork(requireEnv('EXPO_PUBLIC_STELLAR_NETWORK')),
+  stellarHorizonUrl: validateUrl(
+    requireEnv('EXPO_PUBLIC_STELLAR_HORIZON_URL'),
+    'EXPO_PUBLIC_STELLAR_HORIZON_URL',
+  ),
   stellarNetworkPassphrase: requireEnv('EXPO_PUBLIC_STELLAR_NETWORK_PASSPHRASE'),
 };
 


### PR DESCRIPTION
Closes #246

## Summary
- strengthen environment resolution by falling back from EXPO_PUBLIC_ENV to NODE_ENV
- add strict validation for API/Horizon URLs and Stellar network values
- add unit tests for environment resolution behavior

## Testing
- npm run lint (fails due pre-existing repo lint issues unrelated to this change)
- npm run test -- --watchAll=false (fails in this environment due watchman permission error)
- npm run build (fails because root workspace dependencies are not installed: missing tsc in shared workspace)