### PR TITLE
feat: improve dark mode consistency across shared UI

### DIFF
--- a/mobile/components/ui/Button.tsx
+++ b/mobile/components/ui/Button.tsx
@@ -7,6 +7,7 @@ import {
   ViewStyle,
 } from 'react-native';
 import { triggerHapticFeedback } from '../../utils/haptics';
+import { useTheme } from '../../context/ThemeContext';
 
 type Variant = 'primary' | 'secondary' | 'outline' | 'ghost';
 type Size = 'sm' | 'md' | 'lg';
@@ -21,27 +22,6 @@ interface ButtonProps {
   style?: ViewStyle;
   children: React.ReactNode;
 }
-
-const bg: Record<Variant, string> = {
-  primary: '#6366F1',
-  secondary: '#1E293B',
-  outline: 'transparent',
-  ghost: 'transparent',
-};
-
-const border: Record<Variant, string> = {
-  primary: '#6366F1',
-  secondary: '#1E293B',
-  outline: '#6366F1',
-  ghost: 'transparent',
-};
-
-const textColor: Record<Variant, string> = {
-  primary: '#fff',
-  secondary: '#fff',
-  outline: '#6366F1',
-  ghost: '#6366F1',
-};
 
 const padding: Record<Size, ViewStyle> = {
   sm: { paddingVertical: 6, paddingHorizontal: 12 },
@@ -61,7 +41,31 @@ const Button = React.memo<ButtonProps>(({
   style,
   children,
 }) => {
+  const { colors, resolvedColorScheme } = useTheme();
   const isDisabled = disabled || loading;
+  const secondaryBg = resolvedColorScheme === 'dark' ? '#1F2937' : '#1E293B';
+  const onAccentText = resolvedColorScheme === 'dark' ? '#0B1220' : '#FFFFFF';
+
+  const bg: Record<Variant, string> = {
+    primary: colors.accent,
+    secondary: secondaryBg,
+    outline: 'transparent',
+    ghost: 'transparent',
+  };
+
+  const border: Record<Variant, string> = {
+    primary: colors.accent,
+    secondary: secondaryBg,
+    outline: colors.accent,
+    ghost: 'transparent',
+  };
+
+  const textColor: Record<Variant, string> = {
+    primary: onAccentText,
+    secondary: '#FFFFFF',
+    outline: colors.accent,
+    ghost: colors.accent,
+  };
 
   const handlePress = useCallback(() => {
     if (!isDisabled && onPress) {

--- a/mobile/components/ui/Card.tsx
+++ b/mobile/components/ui/Card.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Pressable, StyleSheet, ViewStyle } from 'react-native';
+import { useTheme } from '../../context/ThemeContext';
 
 interface Props {
   children: React.ReactNode;
@@ -8,7 +9,18 @@ interface Props {
 }
 
 const Card = React.memo<Props>(({ children, style, onPress }) => {
-  const content = <View style={[styles.card, style]}>{children}</View>;
+  const { colors } = useTheme();
+  const content = (
+    <View
+      style={[
+        styles.card,
+        { backgroundColor: colors.card, borderColor: colors.border },
+        style,
+      ]}
+    >
+      {children}
+    </View>
+  );
 
   if (onPress) {
     return (
@@ -27,9 +39,7 @@ export { Card };
 
 const styles = StyleSheet.create({
   card: {
-    backgroundColor: '#1E293B',
     borderWidth: 1,
-    borderColor: '#334155',
     borderRadius: 12,
     padding: 16,
   },


### PR DESCRIPTION
Closes #248

## Summary
- make  derive accent/border/text colors from ThemeContext instead of hardcoded values
- make shared  component use theme card and border colors in both light and dark modes
- preserve existing theme preference behavior (system/manual + persisted setting)

## Testing
- npm run lint (pre-existing repo-wide lint failures)
- npm run test -- --watchAll=false (watchman permission failure)
- npm run build (root dependencies missing; tsc not found)