### PR TITLE
test: strengthen GroupCard and ProgressBar component tests

### DIFF
--- a/mobile/__tests__/components/GroupCard.test.tsx
+++ b/mobile/__tests__/components/GroupCard.test.tsx
@@ -15,8 +15,11 @@ describe('GroupCard', () => {
   });
 
   it('renders status badge', () => {
-    const { getByText } = render(<GroupCard {...baseProps} />);
+    const { getByText, rerender } = render(<GroupCard {...baseProps} />);
     expect(getByText('active')).toBeTruthy();
+
+    rerender(<GroupCard {...baseProps} status="pending" />);
+    expect(getByText('pending')).toBeTruthy();
   });
 
   it('renders contribution amount', () => {

--- a/mobile/__tests__/components/ProgressBar.test.tsx
+++ b/mobile/__tests__/components/ProgressBar.test.tsx
@@ -40,6 +40,14 @@ describe('ProgressBar', () => {
     expect(getByText('50% funded')).toBeTruthy();
   });
 
+  it('renders a partial fill for values inside [0, 1]', () => {
+    const { getByTestId } = render(<ProgressBar progress={0.375} />);
+    const fill = getByTestId('progress-fill');
+    expect(fill.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ width: '37.5%' })]),
+    );
+  });
+
   it('does not render label when not provided', () => {
     const { queryByText } = render(<ProgressBar progress={0.5} />);
     expect(queryByText('50% funded')).toBeNull();


### PR DESCRIPTION
Closes #256

## Summary
- extend GroupCard test coverage to assert status badge behavior across status updates
- add ProgressBar assertion for partial in-range values to complement empty/full/clamp cases
- keep tests focused on display logic and prop handling for both components

## Testing
- npm test -- --watchman=false --runTestsByPath __tests__/components/GroupCard.test.tsx __tests__/components/ProgressBar.test.tsx: pass
- npm test -- --watchman=false: pass
- npm run lint: fails with pre-existing repo-wide lint issues unrelated to this change
- npm run build (repo root): fails because shared workspace build cannot find tsc (pre-existing dependency/setup issue)