### PR TITLE
test: complete UI primitive assertions for Button/TextInput/Avatar

### DIFF
--- a/mobile/__tests__/components/Button.test.tsx
+++ b/mobile/__tests__/components/Button.test.tsx
@@ -22,18 +22,27 @@ describe('Button', () => {
     expect(onPress).not.toHaveBeenCalled();
   });
 
-  it('renders primary variant without error', () => {
+  it('applies primary variant styles', () => {
     const { getByText } = render(<Button variant="primary">Primary</Button>);
-    expect(getByText('Primary')).toBeTruthy();
+    const pressable = getByText('Primary').parent?.parent;
+    expect(pressable?.props.style).toEqual(
+      expect.objectContaining({ backgroundColor: '#6366F1', borderColor: '#6366F1' }),
+    );
   });
 
-  it('renders secondary variant without error', () => {
+  it('applies secondary variant styles', () => {
     const { getByText } = render(<Button variant="secondary">Secondary</Button>);
-    expect(getByText('Secondary')).toBeTruthy();
+    const pressable = getByText('Secondary').parent?.parent;
+    expect(pressable?.props.style).toEqual(
+      expect.objectContaining({ backgroundColor: '#1E293B', borderColor: '#1E293B' }),
+    );
   });
 
-  it('renders outline variant without error', () => {
+  it('applies outline variant styles', () => {
     const { getByText } = render(<Button variant="outline">Outline</Button>);
-    expect(getByText('Outline')).toBeTruthy();
+    const pressable = getByText('Outline').parent?.parent;
+    expect(pressable?.props.style).toEqual(
+      expect.objectContaining({ backgroundColor: 'transparent', borderColor: '#6366F1' }),
+    );
   });
 });


### PR DESCRIPTION
Closes #255

## Summary
- keep existing Button/TextInput/Avatar component test coverage and add explicit style assertions for Button variants
- verify Button onPress/disabled behavior remains covered
- retain explicit (non-snapshot) assertions for TextInput and Avatar rendering behavior

## Testing
- npm test -- --watchman=false --runTestsByPath __tests__/components/Button.test.tsx __tests__/components/TextInput.test.tsx __tests__/components/Avatar.test.tsx: pass
- npm test -- --watchman=false: pass
- npm run lint: fails with pre-existing repo-wide lint issues unrelated to this change
- npm run build (repo root): fails because shared workspace build cannot find tsc (pre-existing dependency/setup issue)