### PR TITLE
feat(mobile): persist notificationsStore with AsyncStorage

### DIFF
--- a/mobile/__tests__/notificationsStore.test.ts
+++ b/mobile/__tests__/notificationsStore.test.ts
@@ -1,0 +1,27 @@
+import { useNotificationsStore } from '../stores/notificationsStore';
+import type { Notification } from '../types/notification';
+
+const n1: Notification = { id: '1', title: 'Test', message: 'Hello', read: false, createdAt: '2024-01-01' };
+const n2: Notification = { id: '2', title: 'Test 2', message: 'World', read: true, createdAt: '2024-01-02' };
+
+describe('useNotificationsStore', () => {
+  beforeEach(() => useNotificationsStore.setState({ notifications: [], unreadCount: 0 }));
+
+  it('sets notifications and computes unreadCount', () => {
+    useNotificationsStore.getState().setNotifications([n1, n2]);
+    expect(useNotificationsStore.getState().unreadCount).toBe(1);
+  });
+
+  it('markRead decrements unreadCount', () => {
+    useNotificationsStore.getState().setNotifications([n1, n2]);
+    useNotificationsStore.getState().markRead('1');
+    expect(useNotificationsStore.getState().unreadCount).toBe(0);
+  });
+
+  it('markAllRead resets unreadCount to 0', () => {
+    useNotificationsStore.getState().setNotifications([n1, n2]);
+    useNotificationsStore.getState().markAllRead();
+    expect(useNotificationsStore.getState().unreadCount).toBe(0);
+    expect(useNotificationsStore.getState().notifications.every((n) => n.read)).toBe(true);
+  });
+});

--- a/mobile/stores/notificationsStore.ts
+++ b/mobile/stores/notificationsStore.ts
@@ -1,4 +1,6 @@
 import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Notification } from '../types/notification';
 
 type NotificationsState = {
@@ -10,38 +12,41 @@ type NotificationsState = {
   markAllRead: () => void;
 };
 
-export const useNotificationsStore = create<NotificationsState>((set) => ({
-  notifications: [],
-  unreadCount: 0,
+export const useNotificationsStore = create<NotificationsState>()(
+  persist(
+    (set) => ({
+      notifications: [],
+      unreadCount: 0,
 
-  setNotifications: (items) =>
-    set(() => ({
-      notifications: items,
-      unreadCount: items.filter((n) => !n.read).length,
-    })),
+      setNotifications: (items) =>
+        set(() => ({
+          notifications: items,
+          unreadCount: items.filter((n) => !n.read).length,
+        })),
 
-  markRead: (id) =>
-    set((state) => {
-      const updated = state.notifications.map((n) =>
-        n.id === id ? { ...n, read: true } : n
-      );
+      markRead: (id) =>
+        set((state) => {
+          const updated = state.notifications.map((n) =>
+            n.id === id ? { ...n, read: true } : n,
+          );
+          return { notifications: updated, unreadCount: updated.filter((n) => !n.read).length };
+        }),
 
-      return {
-        notifications: updated,
-        unreadCount: updated.filter((n) => !n.read).length,
-      };
+      markAllRead: () =>
+        set((state) => ({
+          notifications: state.notifications.map((n) => ({ ...n, read: true })),
+          unreadCount: 0,
+        })),
     }),
-
-  markAllRead: () =>
-    set((state) => {
-      const updated = state.notifications.map((n) => ({
-        ...n,
-        read: true,
-      }));
-
-      return {
-        notifications: updated,
-        unreadCount: 0,
-      };
-    }),
-}));
+    {
+      name: 'esustellar-notifications',
+      storage: createJSONStorage(() => AsyncStorage),
+      partialize: (state) => ({ notifications: state.notifications }),
+      onRehydrateStorage: () => (state) => {
+        if (state) {
+          state.unreadCount = state.notifications.filter((n) => !n.read).length;
+        }
+      },
+    },
+  ),
+);


### PR DESCRIPTION
## Summary
Adds persist middleware to notificationsStore so unread notifications survive app restarts, and adds unit tests.

## Changes
- mobile/stores/notificationsStore.ts: wrapped with Zustand persist middleware using AsyncStorage; unreadCount is recomputed on rehydration
- mobile/__tests__/notificationsStore.test.ts: unit tests for setNotifications, markRead, markAllRead

## Rollback
Revert notificationsStore.ts to the non-persisted version and delete the test file.

closes #261