### PR TITLE
feat(mobile): add avatarUri and clearUser to userStore

### DIFF
--- a/mobile/__tests__/userStore.test.ts
+++ b/mobile/__tests__/userStore.test.ts
@@ -1,0 +1,31 @@
+import { useUserStore } from '../stores/userStore';
+
+describe('useUserStore', () => {
+  beforeEach(() =>
+    useUserStore.setState({ displayName: '', theme: 'system', avatarUri: null }),
+  );
+
+  it('sets display name', () => {
+    useUserStore.getState().setDisplayName('Alice');
+    expect(useUserStore.getState().displayName).toBe('Alice');
+  });
+
+  it('sets theme', () => {
+    useUserStore.getState().setTheme('dark');
+    expect(useUserStore.getState().theme).toBe('dark');
+  });
+
+  it('sets avatarUri', () => {
+    useUserStore.getState().setAvatarUri('file://avatar.png');
+    expect(useUserStore.getState().avatarUri).toBe('file://avatar.png');
+  });
+
+  it('clearUser resets all fields', () => {
+    useUserStore.getState().setDisplayName('Bob');
+    useUserStore.getState().setTheme('light');
+    useUserStore.getState().clearUser();
+    expect(useUserStore.getState().displayName).toBe('');
+    expect(useUserStore.getState().theme).toBe('system');
+    expect(useUserStore.getState().avatarUri).toBeNull();
+  });
+});

--- a/mobile/stores/userStore.ts
+++ b/mobile/stores/userStore.ts
@@ -5,8 +5,11 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 interface UserState {
   displayName: string;
   theme: 'dark' | 'light' | 'system';
+  avatarUri: string | null;
   setDisplayName: (name: string) => void;
   setTheme: (theme: 'dark' | 'light' | 'system') => void;
+  setAvatarUri: (uri: string | null) => void;
+  clearUser: () => void;
 }
 
 export const useUserStore = create<UserState>()(
@@ -14,8 +17,11 @@ export const useUserStore = create<UserState>()(
     (set) => ({
       displayName: '',
       theme: 'system',
+      avatarUri: null,
       setDisplayName: (name) => set({ displayName: name }),
       setTheme: (theme) => set({ theme }),
+      setAvatarUri: (uri) => set({ avatarUri: uri }),
+      clearUser: () => set({ displayName: '', theme: 'system', avatarUri: null }),
     }),
     {
       name: 'esustellar-user',


### PR DESCRIPTION
## Summary
Extends userStore with avatarUri state and a clearUser action for logout flows, plus unit tests.

## Changes
- mobile/stores/userStore.ts: added avatarUri, setAvatarUri, and clearUser (resets all fields to defaults)
- mobile/__tests__/userStore.test.ts: unit tests for all actions including clearUser

## Rollback
Revert userStore.ts to the previous version and delete the test file.

closes #262