### PR TITLE
feat(mobile): improve create group step 1 with name char count

### DIFF
--- a/mobile/app/groups/create/index.tsx
+++ b/mobile/app/groups/create/index.tsx
@@ -1,11 +1,5 @@
 import React, { useState } from 'react';
-import {
-  View,
-  Text,
-  ScrollView,
-  StyleSheet,
-  TouchableOpacity,
-} from 'react-native';
+import { View, Text, ScrollView, StyleSheet, TouchableOpacity } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
@@ -57,6 +51,7 @@ export default function CreateGroupStep1() {
           error={nameError}
           maxLength={MAX_NAME}
         />
+        <Text style={styles.charCount}>{name.length}/{MAX_NAME}</Text>
 
         <TextInput
           label="Description (optional)"


### PR DESCRIPTION
## Summary
Improves the create group Step 1 screen to show a character count below the Group Name field.

## Changes
- mobile/app/groups/create/index.tsx: added name.length/MAX_NAME character count below the name input

## Acceptance Criteria
- Validation fires on Next press
- Character limit enforced (max 50 name, max 200 description)
- Next navigates to Step 2 passing name and description
- Screen renders without errors

closes #263