### PR TITLE
feat: add Detox e2e Jest configuration

### DIFF
--- a/mobile/e2e/jest.config.js
+++ b/mobile/e2e/jest.config.js
@@ -1,0 +1,13 @@
+/** @type {import('@jest/types').Config.InitialOptions} */
+module.exports = {
+  testEnvironment: 'node',
+  testRunner: 'jest-circus/runner',
+  testTimeout: 120000,
+  testRegex: '\.test\.js$',
+  reporters: ['detox/runners/jest/reporter'],
+  globalSetup: 'detox/runners/jest/globalSetup',
+  globalTeardown: 'detox/runners/jest/globalTeardown',
+  testEnvironmentOptions: {
+    eventListeners: ['detox/runners/jest/testEnvironmentListener'],
+  },
+};


### PR DESCRIPTION
## Summary
- Add `mobile/e2e/jest.config.js` — missing config referenced by `.detoxrc.js`
- Configures Jest runner, 120s timeout, Detox reporters and environment listeners
- Enables `detox test --configuration ios.sim.debug` to resolve the onboarding test suite

## Implementation Plan
`.detoxrc.js` already specifies `e2e/jest.config.js` as the runner config. This PR adds that file so the Detox CLI resolves correctly.

Closes #257