### PR TITLE
feat: set up Zustand global state with store documentation

### DIFF
--- a/mobile/stores/README.md
+++ b/mobile/stores/README.md
@@ -1,0 +1,19 @@
+# Stores
+
+Zustand stores for global state management across the mobile app.
+
+## Pattern
+
+Each store is created with `create<T>()` from `zustand`. Stores that need cross-session
+persistence use the `persist` middleware backed by `AsyncStorage`. All stores are
+re-exported from `index.ts` so components import from a single path:
+`import { useWalletStore } from '@/stores'`.
+
+## Available Stores
+
+| Export | File | Purpose |
+|---|---|---|
+| `useWalletStore` | `walletStore.ts` | Wallet address and connection state |
+| `useGroupsStore` | `groupsStore.ts` | Cached groups list with loading state |
+| `useUserStore` | `userStore.ts` | Authenticated user profile |
+| `useGroupStore` | `useGroupStore.ts` | Active group context |


### PR DESCRIPTION
## Summary
- Add `mobile/stores/README.md` documenting the pattern, persist strategy, and store inventory
- `zustand ^4.5.2` is already installed; store files and `index.ts` are in place
- Completes the documentation requirement from the acceptance criteria

## Implementation Plan
All store files were set up progressively. The missing piece was a README explaining the Zustand pattern for new contributors.

Closes #258