### PR TITLE
feat: create walletStore with persistence and exported type

### DIFF
--- a/mobile/stores/index.ts
+++ b/mobile/stores/index.ts
@@ -3,3 +3,4 @@ export type { Group } from './useGroupStore';
 export { useGroupsStore } from './groupsStore';
 export { useUserStore } from './userStore';
 export { useWalletStore } from './walletStore';
+export type { WalletState } from './walletStore';

--- a/mobile/stores/walletStore.ts
+++ b/mobile/stores/walletStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-interface WalletState {
+export interface WalletState {
   address: string | null;
   isConnecting: boolean;
   connect: (address: string) => void;


### PR DESCRIPTION
## Summary
- Export `WalletState` interface from `walletStore.ts` so callers can type-annotate store slices
- Re-export `WalletState` via `stores/index.ts` for single-import ergonomics
- Address is persisted to `AsyncStorage` via `zustand/middleware` `persist`

## Implementation Plan
The store and its actions were already in place. This PR exports the `WalletState` type and threads it through `index.ts`, fulfilling the TypeScript acceptance criterion.

Closes #259