### PR TITLE
feat: create groupsStore for caching groups list data

### DIFF
--- a/mobile/__tests__/groupsStore.test.ts
+++ b/mobile/__tests__/groupsStore.test.ts
@@ -1,0 +1,29 @@
+import { useGroupsStore } from '@/stores/groupsStore';
+
+beforeEach(() => {
+  useGroupsStore.setState({ groups: [], isLoading: false, lastFetched: null });
+});
+
+describe('groupsStore', () => {
+  it('setGroups stores groups and records lastFetched', () => {
+    const groups = [{ id: '1', name: 'Alpha' }] as any[];
+    useGroupsStore.getState().setGroups(groups);
+    expect(useGroupsStore.getState().groups).toHaveLength(1);
+    expect(useGroupsStore.getState().lastFetched).not.toBeNull();
+  });
+
+  it('setLoading toggles the isLoading flag', () => {
+    useGroupsStore.getState().setLoading(true);
+    expect(useGroupsStore.getState().isLoading).toBe(true);
+    useGroupsStore.getState().setLoading(false);
+    expect(useGroupsStore.getState().isLoading).toBe(false);
+  });
+
+  it('reset clears all state to initial values', () => {
+    useGroupsStore.getState().setGroups([{ id: '2', name: 'Beta' }] as any[]);
+    useGroupsStore.getState().reset();
+    expect(useGroupsStore.getState().groups).toHaveLength(0);
+    expect(useGroupsStore.getState().isLoading).toBe(false);
+    expect(useGroupsStore.getState().lastFetched).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `mobile/__tests__/groupsStore.test.ts` covering `setGroups`, `setLoading`, and `reset`
- Verifies `lastFetched` is set on `setGroups` and cleared on `reset`
- Uses Jest with the existing `react-native` preset and `@/` path alias

## Implementation Plan
`groupsStore.ts` implements the required state/actions. This PR adds the missing test suite, completing the acceptance criteria.

Closes #260