### PR TITLE
feat(mobile): set up notifications, TransactionItem, history & success screens

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -19,11 +19,13 @@
       "adaptiveIcon": {
         "backgroundColor": "#0F172A"
       },
-      "jsEngine": "hermes"
+      "jsEngine": "hermes",
+      "useNextNotificationsApi": true
     },
     "plugins": [
       "expo-router",
-      "expo-localization"
+      "expo-localization",
+      "expo-notifications"
     ],
     "scheme": "esustellar"
   }


### PR DESCRIPTION
## Summary

Resolves 4 open mobile issues in one PR.

### Changes

**#273 – Set up Expo Notifications**
- Added `expo-notifications` to the `plugins` array in `mobile/app.json`
- Added `android.useNextNotificationsApi: true` in `mobile/app.json`
- `mobile/services/notifications.ts` implements `registerForPushNotificationsAsync()` (requests permission, returns Expo push token, logs it on app start) and `scheduleLocalNotification(title, body, trigger)`

**#272 – TransactionItem component**
- `mobile/components/transactions/TransactionItem.tsx`: typed props (`type`, `description`, `amount`, `date`), type icons (↑ red / ↓ green / − grey), `formatXLM` amount, relative date helper, wrapped in `React.memo`
- `mobile/components/transactions/index.ts`: re-exports component and type

**#270 – Transaction history screen**
- `mobile/app/transactions/index.tsx`: `FlatList` with `TransactionItem` rows, pull-to-refresh, `onEndReached` pagination, `ActivityIndicator` loading state, `EmptyState` when list is empty

**#269 – Transaction success screen**
- `mobile/app/transaction/success.tsx`: accepts `txHash` route param, displays truncated hash, 'View on Stellar Expert' link via `Linking.openURL`, 'Done' button navigates to `/(tabs)` with `router.replace`, back gesture disabled via `Stack.Screen gestureEnabled: false`

## Testing

- All screens render without runtime errors
- Pull-to-refresh and pagination work on the history screen
- Explorer link opens the correct Stellar Expert URL
- Back gesture is disabled on the success screen

Closes #269
Closes #270
Closes #272
Closes #273