### PR TITLE
Feat/issue277

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -7,6 +7,7 @@ import {
   ActivityIndicator,
   AppState,
   AppStateStatus,
+  Pressable,
   StyleSheet,
   Text,
   View,
@@ -61,6 +62,10 @@ function RootLayoutContent() {
       setLocked(false);
     }
   }, []);
+
+  const openPinFallback = useCallback(() => {
+    router.push('/security/enter-pin?reason=biometric-fallback');
+  }, [router]);
 
   useEffect(() => {
     const subscription = AppState.addEventListener(
@@ -221,6 +226,9 @@ function RootLayoutContent() {
           <Text style={styles.lockHint} onPress={promptBiometric}>
             {t('lock.tapToUnlock')}
           </Text>
+          <Pressable style={styles.lockButton} onPress={openPinFallback}>
+            <Text style={styles.lockButtonText}>Use PIN</Text>
+          </Pressable>
         </View>
       )}
     </View>

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -59,6 +59,7 @@ function RootLayoutContent() {
 
     const result = await biometricService.authenticate(
       t('lock.biometricPrompt', { appName: t('common.appName') }),
+      true,
     );
 
     if (result.success) {
@@ -67,6 +68,7 @@ function RootLayoutContent() {
   }, [t]);
 
   const openPinFallback = useCallback(() => {
+    setLocked(false);
     router.push('/security/enter-pin?reason=biometric-fallback');
   }, [router]);
 
@@ -85,12 +87,14 @@ function RootLayoutContent() {
           nextState === 'active' &&
           (prev === 'background' || prev === 'inactive')
         ) {
-          setMasked(false);
           const enabled = await AsyncStorage.getItem(BIOMETRIC_LOCK_KEY);
 
           if (enabled === 'true') {
             setLocked(true);
+            setMasked(false);
             await promptBiometric();
+          } else {
+            setMasked(false);
           }
         }
       },

--- a/mobile/app/settings/index.tsx
+++ b/mobile/app/settings/index.tsx
@@ -357,7 +357,7 @@ export default function SettingsScreen() {
           </Button>
         </View>
 
-        {/* Simple Lock Toggle */}
+        {/* Biometric Lock */}
         <View
           style={[
             styles.section,
@@ -365,11 +365,15 @@ export default function SettingsScreen() {
           ]}
         >
           <Text style={[styles.sectionTitle, { color: colors.text }]}>
-            Biometric Lock
+            Use Biometric Lock
+          </Text>
+          <Text style={[styles.helperText, { color: colors.subtext }]}>
+            Protect the app when it returns from the background.
           </Text>
           <Switch
             value={biometricEnabledLocal}
             onValueChange={handleLocalToggle}
+            disabled={biometricCap.status !== SecurityStatus.AVAILABLE}
           />
         </View>
 
@@ -479,3 +483,4 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
   },
 });
+

--- a/mobile/app/settings/index.tsx
+++ b/mobile/app/settings/index.tsx
@@ -162,6 +162,11 @@ export default function SettingsScreen() {
 
   const handleLocalToggle = async (value: boolean) => {
     if (value) {
+      if (biometricCap.status !== SecurityStatus.AVAILABLE) {
+        Alert.alert('Unavailable', 'Set up biometrics first.');
+        return;
+      }
+
       const result = await biometricService.authenticate('Enable lock');
       if (!result.success) return;
     }


### PR DESCRIPTION
Closes #277
 Install expo-local-authentication
 On app foreground event, check if biometric is enrolled and supported
 If enrolled, show a biometric prompt before allowing access to the app
 Add a 'Use Biometric Lock' toggle in Settings that enables or disables this feature
 Store the toggle state in AsyncStorage
 Show a fallback 'Enter PIN' option if biometric fails
 
 Closes #281