### PR TITLE
feat(mobile): implement #304, #299, #275, #286

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -23,6 +23,7 @@ import { getRouteFromNotificationData } from '../services/notifications/notifica
 import { queryClient } from '../services/queryClient';
 import { biometricService } from '../services/security';
 import { logger } from '../services/logger';
+import { registerBackgroundSyncScheduler } from '../services/sync/scheduler';
 
 const ONBOARDING_KEY = 'onboardingComplete';
 const BIOMETRIC_LOCK_KEY = 'biometricLockEnabled';
@@ -113,6 +114,11 @@ function RootLayoutContent() {
     const initialize = async () => {
       await loadLanguage();
       logger.info('RootLayout', 'App initializing');
+
+      // Register background sync scheduler (#299)
+      registerBackgroundSyncScheduler().catch((err) =>
+        logger.warn('RootLayout', 'Background sync registration failed', err),
+      );
 
       const onboardingComplete = await AsyncStorage.getItem(ONBOARDING_KEY);
 

--- a/mobile/app/legal/terms.tsx
+++ b/mobile/app/legal/terms.tsx
@@ -1,22 +1,69 @@
 import React from 'react';
-import { ScrollView, Text, StyleSheet } from 'react-native';
+import { SafeAreaView, ScrollView, Text, StyleSheet, View } from 'react-native';
+
+const SECTIONS = [
+  {
+    heading: '1. Acceptance of Terms',
+    body: 'By accessing or using the EsuStellar application, you agree to be bound by these Terms of Service. If you do not agree to these terms, you may not use the application.',
+  },
+  {
+    heading: '2. Description of Service',
+    body: 'EsuStellar provides a decentralised savings group platform built on the Stellar blockchain. Users can create or join rotating savings groups, make contributions, and receive payouts according to a predetermined schedule.',
+  },
+  {
+    heading: '3. Eligibility',
+    body: 'You must be at least 18 years of age and capable of forming a binding agreement. You are responsible for ensuring your use complies with applicable local laws and regulations.',
+  },
+  {
+    heading: '4. Wallet and Account Security',
+    body: 'You are solely responsible for maintaining the confidentiality and security of your Stellar wallet credentials, recovery phrases, and PINs. EsuStellar cannot recover lost keys or reverse unauthorised transactions.',
+  },
+  {
+    heading: '5. Contributions and Payouts',
+    body: 'All contributions are recorded on-chain and subject to the group\'s agreed schedule. Failure to contribute on time may result in penalties as defined by the group rules. Payouts are distributed automatically in rotating order.',
+  },
+  {
+    heading: '6. Prohibited Conduct',
+    body: 'You agree not to: use the platform for money laundering or illegal activities; attempt to exploit smart contract vulnerabilities; impersonate other users; or interfere with the normal operation of the platform.',
+  },
+  {
+    heading: '7. Limitation of Liability',
+    body: 'EsuStellar is provided "as is" without warranties of any kind. We are not liable for losses resulting from blockchain network failures, smart contract bugs, wallet compromises, or actions of other group members.',
+  },
+  {
+    heading: '8. Modifications',
+    body: 'We reserve the right to update these terms at any time. Continued use of the application after changes constitutes acceptance of the revised terms.',
+  },
+  {
+    heading: '9. Contact',
+    body: 'For questions regarding these terms, reach out to support@esustellar.app.',
+  },
+];
 
 export default function TermsScreen() {
   return (
-    <ScrollView contentContainerStyle={styles.container}>
-      <Text style={styles.title}>Terms of Service</Text>
-      <Text style={styles.content}>
-        Welcome to EsuStellar. By using this app, you agree to comply with all
-        platform rules, contribution guidelines, and Stellar transaction policies.
-        Users are responsible for maintaining account security and lawful use of
-        the platform.
-      </Text>
-    </ScrollView>
+    <SafeAreaView style={styles.safe}>
+      <ScrollView contentContainerStyle={styles.container}>
+        <Text style={styles.title}>Terms of Service</Text>
+        <Text style={styles.lastUpdated}>Last updated: May 2026</Text>
+
+        {SECTIONS.map((section) => (
+          <View key={section.heading} style={styles.section}>
+            <Text style={styles.heading}>{section.heading}</Text>
+            <Text style={styles.body}>{section.body}</Text>
+          </View>
+        ))}
+      </ScrollView>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { padding: 20 },
-  title: { fontSize: 24, fontWeight: '700', marginBottom: 16 },
-  content: { fontSize: 16, lineHeight: 24 },
+  safe: { flex: 1, backgroundColor: '#0F172A' },
+  container: { padding: 24, paddingBottom: 48 },
+  title: { fontSize: 26, fontWeight: '800', color: '#F8FAFC', marginBottom: 4 },
+  lastUpdated: { fontSize: 13, color: '#64748B', marginBottom: 24 },
+  section: { marginBottom: 20 },
+  heading: { fontSize: 16, fontWeight: '700', color: '#E2E8F0', marginBottom: 6 },
+  body: { fontSize: 15, lineHeight: 22, color: '#94A3B8' },
 });

--- a/mobile/app/onboarding/index.tsx
+++ b/mobile/app/onboarding/index.tsx
@@ -142,6 +142,18 @@ export default function OnboardingScreen() {
         </Text>
       </Pressable>
 
+      {isLastStep && (
+        <Pressable
+          accessibilityRole="link"
+          onPress={() => router.push('/legal/terms')}
+          style={styles.termsLink}
+        >
+          <Text style={styles.termsLinkText}>
+            By continuing, you agree to our Terms of Service
+          </Text>
+        </Pressable>
+      )}
+
       <Modal
         animationType="slide"
         onRequestClose={() => setShowNotificationPrompt(false)}
@@ -267,6 +279,15 @@ const styles = StyleSheet.create({
     color: '#475569',
     fontSize: 15,
     fontWeight: '700',
+  },
+  termsLink: {
+    alignItems: 'center',
+    marginTop: 16,
+  },
+  termsLinkText: {
+    color: '#818CF8',
+    fontSize: 13,
+    textDecorationLine: 'underline',
   },
   modalBackdrop: {
     backgroundColor: 'rgba(15, 23, 42, 0.72)',

--- a/mobile/app/settings/index.tsx
+++ b/mobile/app/settings/index.tsx
@@ -42,6 +42,7 @@ import {
   setHapticsEnabled as persistHapticsEnabled,
   triggerHapticFeedback,
 } from '../../services/haptics';
+import { getJSEngine } from '../../utils/hermes';
 
 const BIOMETRIC_LOCK_KEY = 'biometricLockEnabled';
 const WALLET_ADDRESS =
@@ -433,8 +434,29 @@ export default function SettingsScreen() {
             { backgroundColor: colors.card, borderColor: colors.border },
           ]}
         >
+          <Text style={[styles.sectionTitle, { color: colors.text }]}>
+            Legal
+          </Text>
+          <Button onPress={() => router.push('/legal/terms')}>
+            Terms of Service
+          </Button>
+          <Button onPress={() => router.push('/legal/privacy')}>
+            Privacy Policy
+          </Button>
+        </View>
+
+        {/* Version */}
+        <View
+          style={[
+            styles.section,
+            { backgroundColor: colors.card, borderColor: colors.border },
+          ]}
+        >
           <Text style={[styles.helperText, { color: colors.subtext }]}>
             Version: {Constants.expoConfig?.version}
+          </Text>
+          <Text style={[styles.helperText, { color: colors.subtext }]}>
+            JS Engine: {getJSEngine()}
           </Text>
         </View>
 

--- a/mobile/utils/hermes.ts
+++ b/mobile/utils/hermes.ts
@@ -1,0 +1,25 @@
+/**
+ * Hermes Engine Runtime Verification (#286)
+ *
+ * Confirms that Hermes is the active JS engine at runtime.
+ * `global.HermesInternal` is only defined when Hermes is active.
+ */
+
+declare global {
+  // eslint-disable-next-line no-var
+  var HermesInternal: Record<string, unknown> | undefined;
+}
+
+/**
+ * Returns true if the app is running on the Hermes JS engine.
+ */
+export function isHermesEnabled(): boolean {
+  return typeof global.HermesInternal !== 'undefined' && global.HermesInternal != null;
+}
+
+/**
+ * Returns a human-readable label for the active JS engine.
+ */
+export function getJSEngine(): string {
+  return isHermesEnabled() ? 'Hermes' : 'JavaScriptCore';
+}


### PR DESCRIPTION
#304 - Add terms of service screen
- Enhanced terms.tsx with comprehensive ToS content (9 sections)
- Added terms link in onboarding flow (last slide)
- Added Legal section in settings with Terms + Privacy links

#299 - Schedule background sync jobs
- Scheduler already implemented in services/sync/scheduler.ts
- Integrated registerBackgroundSyncScheduler() call on app startup in _layout.tsx
- Uses expo-background-fetch with 30min minimum interval and local throttle

#275 - Handle foreground push notification display
- Already implemented: setNotificationHandler with shouldShowAlert: true
- NotificationBanner component shows title, body, close button
- 3-second auto-dismiss with navigation on tap
- Banner positioned with zIndex 100, doesn't block interaction

#286 - Add Hermes engine and enable it
- Hermes already configured in app.json (root, ios, android)
- Added runtime verification utility (utils/hermes.ts)
- Surfaced JS engine info in settings screen for confirmation

closes #304
closes #299
closes #275
closes #286