### PR TITLE
feat: standardize logging across mobile application (#225)

### DIFF
--- a/mobile/services/logger/index.ts
+++ b/mobile/services/logger/index.ts
@@ -1,2 +1,41 @@
-export { logger } from '../services/logger';
-export type { LogLevel } from '../services/logger';
+// Define safe logging levels
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+// Determine if environment is production
+const IS_PROD = process.env.NODE_ENV === 'production';
+
+class Logger {
+  private formatMessage(level: LogLevel, message: string, context?: Record<string, any>): string {
+    const timestamp = new Date().toISOString();
+    const contextString = context ? ` | Context: ${JSON.stringify(context)}` : '';
+    return `[${timestamp}] [${level.toUpperCase()}]: ${message}${contextString}`;
+  }
+
+  // Safe debugging: logs only if NOT in production
+  debug(message: string, context?: Record<string, any>): void {
+    if (!IS_PROD) {
+      console.log(this.formatMessage('debug', message, context));
+    }
+  }
+
+  info(message: string, context?: Record<string, any>): void {
+    if (!IS_PROD) {
+      console.info(this.formatMessage('info', message, context));
+    }
+  }
+
+  warn(message: string, context?: Record<string, any>): void {
+    console.warn(this.formatMessage('warn', message, context));
+  }
+
+  error(message: string, error?: Error, context?: Record<string, any>): void {
+    const extendedContext = {
+      ...context,
+      errorMessage: error?.message,
+      errorStack: error?.stack,
+    };
+    console.error(this.formatMessage('error', message, extendedContext));
+  }
+}
+
+export const logger = new Logger();


### PR DESCRIPTION
Closes #225

### Overview
This PR addresses issue #225 by introducing a standardized, centralized logging utility inside the mobile application layer. 

### Changes Made

- Created a robust `Logger` utility class inside `mobile/services/logger/index.ts`.
- Integrated strict environment checking (`NODE_ENV`) to ensure `debug` and `info` logs are completely disabled in production environments.
- Formatted log message outputs to include level types, timestamps, and optional context structures to simplify troubleshooting.


