### PR TITLE
feat(sdk): add get_all_groups_info binding for Registry contract

### DIFF
--- a/packages/sdk/jest.config.js
+++ b/packages/sdk/jest.config.js
@@ -1,0 +1,8 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testMatch: ["**/__tests__/**/*.test.ts"],
+  moduleFileExtensions: ["ts", "js"],
+  clearMocks: true,
+};

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,12 +1,25 @@
 {
-  "name": "sdk",
+  "name": "@esustellar/sdk",
   "version": "1.0.0",
-  "main": "index.js",
+  "description": "TypeScript SDK for interacting with EsuStellar Soroban smart contracts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "build": "tsc",
+    "test": "jest",
+    "test:coverage": "jest --coverage",
+    "lint": "tsc --noEmit"
   },
-  "keywords": [],
+  "keywords": ["stellar", "soroban", "sdk", "esustellar"],
   "author": "",
-  "license": "ISC",
-  "description": ""
+  "license": "MIT",
+  "dependencies": {
+    "@stellar/stellar-sdk": "^14.4.3"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.12",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.4",
+    "typescript": "^5.3.3"
+  }
 }

--- a/packages/sdk/src/registry/__tests__/get-all-groups-info.test.ts
+++ b/packages/sdk/src/registry/__tests__/get-all-groups-info.test.ts
@@ -1,0 +1,180 @@
+import { getAllGroupsInfo, GroupInfo, SdkConfig } from "../get-all-groups-info";
+
+jest.mock("@stellar/stellar-sdk", () => {
+  const TransactionBuilderMock: any = jest.fn().mockImplementation(() => ({
+    addOperation: jest.fn().mockReturnThis(),
+    setTimeout: jest.fn().mockReturnThis(),
+    build: jest.fn().mockReturnValue({ toXDR: jest.fn().mockReturnValue("mock-xdr") }),
+  }));
+  TransactionBuilderMock.fromXDR = jest.fn();
+
+  return {
+    Contract: jest.fn().mockImplementation(() => ({
+      call: jest.fn().mockReturnValue("mock-op"),
+    })),
+    Account: jest.fn().mockImplementation(() => ({})),
+    BASE_FEE: "100",
+    TransactionBuilder: TransactionBuilderMock,
+    rpc: {
+      Server: jest.fn(),
+      Api: {
+        isSimulationError: jest.fn(),
+        GetTransactionStatus: { NOT_FOUND: "NOT_FOUND", SUCCESS: "SUCCESS" },
+      },
+    },
+    scValToNative: jest.fn(),
+    nativeToScVal: jest.fn().mockReturnValue("mock-scval"),
+  };
+});
+
+const config: SdkConfig = {
+  contractId: "CREGISTRYCONTRACTID000000000000000000000000000000000000",
+  rpcUrl: "https://soroban-testnet.stellar.org",
+  networkPassphrase: "Test SDF Network ; September 2015",
+};
+
+function getSdk() {
+  return jest.requireMock("@stellar/stellar-sdk") as any;
+}
+
+function makeMockServer(overrides: Record<string, jest.Mock> = {}) {
+  const mockServer = {
+    simulateTransaction: jest.fn(),
+    ...overrides,
+  };
+  getSdk().rpc.Server.mockImplementation(() => mockServer);
+  return mockServer;
+}
+
+const RAW_GROUP = {
+  contract_address: "CSAVINGSADDR000000000000000000000000000000000000000000",
+  group_id: "group-001",
+  name: "Test Savings Group",
+  admin: "GADMIN0000000000000000000000000000000000000000000000000",
+  is_public: true,
+  created_at: BigInt(1717200000),
+  total_members: 5,
+};
+
+const EXPECTED_GROUP: GroupInfo = {
+  contractAddress: "CSAVINGSADDR000000000000000000000000000000000000000000",
+  groupId: "group-001",
+  name: "Test Savings Group",
+  admin: "GADMIN0000000000000000000000000000000000000000000000000",
+  isPublic: true,
+  createdAt: 1717200000,
+  totalMembers: 5,
+};
+
+describe("getAllGroupsInfo", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getSdk().rpc.Api.isSimulationError.mockReturnValue(false);
+  });
+
+  it("returns mapped GroupInfo array matching registered data", async () => {
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({
+      result: { retval: "mock-retval" },
+    });
+    getSdk().scValToNative.mockReturnValueOnce([RAW_GROUP]);
+
+    const result = await getAllGroupsInfo(config);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(EXPECTED_GROUP);
+  });
+
+  it("returns an empty array when no groups are registered", async () => {
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({
+      result: { retval: "mock-retval" },
+    });
+    getSdk().scValToNative.mockReturnValueOnce([]);
+
+    const result = await getAllGroupsInfo(config);
+
+    expect(result).toEqual([]);
+  });
+
+  it("maps multiple groups correctly", async () => {
+    const second = { ...RAW_GROUP, group_id: "group-002", name: "Group 2", is_public: false };
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({
+      result: { retval: "mock-retval" },
+    });
+    getSdk().scValToNative.mockReturnValueOnce([RAW_GROUP, second]);
+
+    const result = await getAllGroupsInfo(config);
+
+    expect(result).toHaveLength(2);
+    expect(result[1].groupId).toBe("group-002");
+    expect(result[1].isPublic).toBe(false);
+  });
+
+  it("uses the provided sourceAccount in the simulation", async () => {
+    const { Account } = getSdk();
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({
+      result: { retval: "mock-retval" },
+    });
+    getSdk().scValToNative.mockReturnValueOnce([]);
+
+    await getAllGroupsInfo({ ...config, sourceAccount: "GCUSTOM_ACCOUNT" });
+
+    expect(Account).toHaveBeenCalledWith("GCUSTOM_ACCOUNT", "0");
+  });
+
+  it("falls back to the dummy account when sourceAccount is omitted", async () => {
+    const { Account } = getSdk();
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({
+      result: { retval: "mock-retval" },
+    });
+    getSdk().scValToNative.mockReturnValueOnce([]);
+
+    await getAllGroupsInfo(config);
+
+    expect(Account).toHaveBeenCalledWith(
+      "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+      "0",
+    );
+  });
+
+  it("throws when the simulation returns an error", async () => {
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({ error: "HostError: OutOfGas" });
+    getSdk().rpc.Api.isSimulationError.mockReturnValueOnce(true);
+
+    await expect(getAllGroupsInfo(config)).rejects.toThrow(
+      "Registry contract simulation error: HostError: OutOfGas",
+    );
+  });
+
+  it("throws when simulation result is empty", async () => {
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({ result: null });
+
+    await expect(getAllGroupsInfo(config)).rejects.toThrow(
+      "Simulation returned empty result",
+    );
+  });
+
+  it("invokes get_all_groups_info on the correct contract", async () => {
+    const { Contract } = getSdk();
+    const mockCallReturn = "mock-op-call";
+    const mockContractInstance = { call: jest.fn().mockReturnValue(mockCallReturn) };
+    Contract.mockImplementationOnce(() => mockContractInstance);
+
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({
+      result: { retval: "mock-retval" },
+    });
+    getSdk().scValToNative.mockReturnValueOnce([]);
+
+    await getAllGroupsInfo(config);
+
+    expect(Contract).toHaveBeenCalledWith(config.contractId);
+    expect(mockContractInstance.call).toHaveBeenCalledWith("get_all_groups_info");
+  });
+});

--- a/packages/sdk/src/registry/get-all-groups-info.ts
+++ b/packages/sdk/src/registry/get-all-groups-info.ts
@@ -1,0 +1,102 @@
+import {
+  Contract,
+  nativeToScVal,
+  scValToNative,
+  TransactionBuilder,
+  BASE_FEE,
+  rpc,
+  Account,
+} from "@stellar/stellar-sdk";
+
+// Fallback account used for read-only simulations when no publicKey is provided.
+const DUMMY_ACCOUNT =
+  "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+export interface SdkConfig {
+  /** Registry contract ID (Stellar address). */
+  contractId: string;
+  /** Soroban RPC endpoint URL. */
+  rpcUrl: string;
+  /** Network passphrase, e.g. "Test SDF Network ; September 2015". */
+  networkPassphrase: string;
+  /** Optional Stellar address used as the simulation source. Defaults to a dummy account. */
+  sourceAccount?: string;
+}
+
+/** Mirrors the `GroupInfo` struct from the Registry contract. */
+export interface GroupInfo {
+  contractAddress: string;
+  groupId: string;
+  name: string;
+  admin: string;
+  isPublic: boolean;
+  /** Unix timestamp (seconds) when the group was registered. */
+  createdAt: number;
+  totalMembers: number;
+}
+
+/**
+ * Fetches full `GroupInfo` metadata for every group registered in the Registry contract.
+ *
+ * This is a read-only simulation — no transaction is submitted and no auth is required.
+ *
+ * @throws {Error} If the simulation fails or returns an empty result.
+ *
+ * @example
+ * ```ts
+ * const groups = await getAllGroupsInfo({
+ *   contractId: "CREGISTRY...",
+ *   rpcUrl: "https://soroban-testnet.stellar.org",
+ *   networkPassphrase: "Test SDF Network ; September 2015",
+ * });
+ * console.log(groups[0].name); // "My Savings Group"
+ * ```
+ */
+export async function getAllGroupsInfo(
+  config: SdkConfig,
+): Promise<GroupInfo[]> {
+  const { contractId, rpcUrl, networkPassphrase } = config;
+  const source = config.sourceAccount ?? DUMMY_ACCOUNT;
+
+  const server = new rpc.Server(rpcUrl, { allowHttp: true });
+  const contract = new Contract(contractId);
+  const account = new Account(source, "0");
+
+  const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase })
+    .addOperation(contract.call("get_all_groups_info"))
+    .setTimeout(30)
+    .build();
+
+  const result = await server.simulateTransaction(tx as any);
+
+  if (rpc.Api.isSimulationError(result)) {
+    throw new Error(
+      `Registry contract simulation error: ${(result as any).error}`,
+    );
+  }
+
+  const simResult = result as any;
+  if (!simResult.result?.retval) {
+    throw new Error("Simulation returned empty result");
+  }
+
+  const raw = scValToNative(simResult.result.retval) as Array<{
+    contract_address: string;
+    group_id: string;
+    name: string;
+    admin: string;
+    is_public: boolean;
+    created_at: bigint | number;
+    total_members: number;
+  }>;
+
+  return raw.map((g) => ({
+    contractAddress: String(g.contract_address),
+    groupId: String(g.group_id),
+    name: String(g.name),
+    admin: String(g.admin),
+    isPublic: Boolean(g.is_public),
+    createdAt: Number(g.created_at),
+    totalMembers: Number(g.total_members),
+  }));
+}

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "moduleResolution": "node"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/__tests__/**"]
+}


### PR DESCRIPTION
## Summary

- Adds `getAllGroupsInfo()` SDK binding at `packages/sdk/src/registry/get-all-groups-info.ts`
- Maps all `GroupInfo` struct fields (`contract_address`, `group_id`, `name`, `admin`, `is_public`, `created_at`, `total_members`) to typed SDK types with camelCase naming
- Unit tests in `packages/sdk/src/registry/__tests__/get-all-groups-info.test.ts` assert returned structs match registered data, cover empty results, multi-group responses, and simulation errors
- Includes SDK tooling bootstrap: `package.json` (ts-jest, TypeScript), `tsconfig.json`, `jest.config.js`

## Implementation notes

- Read-only simulation — no transaction submitted, no auth required
- Falls back to a well-known dummy account when no `sourceAccount` is provided (consistent with web app pattern)
- Errors from the RPC simulation are surfaced as descriptive `Error` instances

## Test plan

- [ ] `cd packages/sdk && npm install && npm test` — all tests pass
- [ ] `npm run lint` — no TypeScript errors

Closes #372