### PR TITLE
feat(sdk): add create_group binding for Savings contract

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,12 +1,25 @@
 {
-  "name": "sdk",
+  "name": "@esustellar/sdk",
   "version": "1.0.0",
-  "main": "index.js",
+  "description": "TypeScript SDK for interacting with EsuStellar Soroban smart contracts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "build": "tsc",
+    "test": "jest",
+    "test:coverage": "jest --coverage",
+    "lint": "tsc --noEmit"
   },
-  "keywords": [],
+  "keywords": ["stellar", "soroban", "sdk", "esustellar"],
   "author": "",
-  "license": "ISC",
-  "description": ""
+  "license": "MIT",
+  "dependencies": {
+    "@stellar/stellar-sdk": "^14.4.3"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.12",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.4",
+    "typescript": "^5.3.3"
+  }
 }

--- a/packages/sdk/src/savings/__tests__/create-group.test.ts
+++ b/packages/sdk/src/savings/__tests__/create-group.test.ts
@@ -1,0 +1,206 @@
+import { createGroup, WriteConfig, CreateGroupParams } from "../create-group";
+
+jest.mock("@stellar/stellar-sdk", () => {
+  const TransactionBuilderMock: any = jest.fn().mockImplementation(() => ({
+    addOperation: jest.fn().mockReturnThis(),
+    setTimeout: jest.fn().mockReturnThis(),
+    build: jest.fn().mockReturnValue({
+      toXDR: jest.fn().mockReturnValue("built-xdr"),
+    }),
+  }));
+  TransactionBuilderMock.fromXDR = jest.fn().mockReturnValue("prepared-tx-obj");
+
+  return {
+    Contract: jest.fn().mockImplementation(() => ({
+      call: jest.fn().mockReturnValue("mock-op"),
+    })),
+    BASE_FEE: "100",
+    TransactionBuilder: TransactionBuilderMock,
+    rpc: {
+      Server: jest.fn(),
+      Api: {
+        isSimulationError: jest.fn(),
+        GetTransactionStatus: { NOT_FOUND: "NOT_FOUND", SUCCESS: "SUCCESS" },
+      },
+    },
+    nativeToScVal: jest.fn().mockReturnValue("mock-scval"),
+    xdr: {
+      ScVal: {
+        scvVec: jest.fn().mockReturnValue("mock-scvec"),
+        scvSymbol: jest.fn().mockReturnValue("mock-symbol"),
+      },
+    },
+  };
+});
+
+function getSdk() {
+  return jest.requireMock("@stellar/stellar-sdk") as any;
+}
+
+function makeMockServer(overrides: Record<string, jest.Mock> = {}) {
+  const mockServer = {
+    getAccount: jest.fn().mockResolvedValue({ id: "GPUBKEY", sequence: "100" }),
+    prepareTransaction: jest.fn().mockResolvedValue({
+      toXDR: jest.fn().mockReturnValue("prepared-xdr"),
+    }),
+    sendTransaction: jest.fn().mockResolvedValue({ status: "PENDING", hash: "txhash123" }),
+    getTransaction: jest.fn().mockResolvedValue({ status: "SUCCESS" }),
+    ...overrides,
+  };
+  getSdk().rpc.Server.mockImplementation(() => mockServer);
+  return mockServer;
+}
+
+const signTransaction = jest.fn().mockResolvedValue("signed-xdr");
+
+const config: WriteConfig = {
+  contractId: "CSAVINGSCONTRACTID00000000000000000000000000000000000",
+  rpcUrl: "https://soroban-testnet.stellar.org",
+  networkPassphrase: "Test SDF Network ; September 2015",
+  publicKey: "GADMIN0000000000000000000000000000000000000000000000000",
+  signTransaction,
+};
+
+const validParams: CreateGroupParams = {
+  admin: "GADMIN0000000000000000000000000000000000000000000000000",
+  groupId: "ajo-001",
+  name: "Lagos Ajo Circle",
+  contributionAmount: 50_000_000n,
+  totalMembers: 6,
+  frequency: "Monthly",
+  startTimestamp: BigInt(Math.floor(Date.now() / 1000) + 86400),
+  isPublic: true,
+};
+
+describe("createGroup", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    signTransaction.mockResolvedValue("signed-xdr");
+  });
+
+  it("returns the successful transaction response on valid input", async () => {
+    const mockServer = makeMockServer();
+
+    const result = await createGroup(config, validParams);
+
+    expect(result).toEqual({ status: "SUCCESS" });
+    expect(mockServer.sendTransaction).toHaveBeenCalledTimes(1);
+    expect(mockServer.getTransaction).toHaveBeenCalledWith("txhash123");
+  });
+
+  it("passes the signed XDR to fromXDR and submits the prepared transaction", async () => {
+    makeMockServer();
+    const { TransactionBuilder } = getSdk();
+
+    await createGroup(config, validParams);
+
+    expect(signTransaction).toHaveBeenCalledWith("prepared-xdr");
+    expect(TransactionBuilder.fromXDR).toHaveBeenCalledWith(
+      "signed-xdr",
+      config.networkPassphrase,
+    );
+  });
+
+  it("calls create_group with all required parameters", async () => {
+    const { Contract, nativeToScVal, xdr } = getSdk();
+    const mockCall = jest.fn().mockReturnValue("mock-op");
+    Contract.mockImplementationOnce(() => ({ call: mockCall }));
+    makeMockServer();
+
+    await createGroup(config, validParams);
+
+    expect(mockCall).toHaveBeenCalledWith(
+      "create_group",
+      expect.anything(), // admin
+      expect.anything(), // groupId
+      expect.anything(), // name
+      expect.anything(), // contributionAmount
+      expect.anything(), // totalMembers
+      expect.anything(), // frequency (scvVec)
+      expect.anything(), // startTimestamp
+      expect.anything(), // isPublic
+    );
+    expect(nativeToScVal).toHaveBeenCalledWith(validParams.admin, { type: "address" });
+    expect(nativeToScVal).toHaveBeenCalledWith(validParams.groupId, { type: "string" });
+    expect(nativeToScVal).toHaveBeenCalledWith(validParams.contributionAmount, { type: "i128" });
+    expect(nativeToScVal).toHaveBeenCalledWith(validParams.totalMembers, { type: "u32" });
+    expect(nativeToScVal).toHaveBeenCalledWith(validParams.startTimestamp, { type: "u64" });
+    expect(nativeToScVal).toHaveBeenCalledWith(validParams.isPublic, { type: "bool" });
+    expect(xdr.ScVal.scvSymbol).toHaveBeenCalledWith(validParams.frequency);
+  });
+
+  it("throws ContributionTooLow when prepareTransaction rejects with that error", async () => {
+    makeMockServer({
+      prepareTransaction: jest.fn().mockRejectedValueOnce(
+        new Error("HostError: Error(Contract, #1)"),
+      ),
+    });
+
+    await expect(createGroup(config, { ...validParams, contributionAmount: 100n })).rejects.toThrow(
+      "HostError: Error(Contract, #1)",
+    );
+  });
+
+  it("throws InvalidMemberCount when prepareTransaction rejects with that error", async () => {
+    makeMockServer({
+      prepareTransaction: jest.fn().mockRejectedValueOnce(
+        new Error("HostError: Error(Contract, #2)"),
+      ),
+    });
+
+    await expect(createGroup(config, { ...validParams, totalMembers: 2 })).rejects.toThrow(
+      "HostError: Error(Contract, #2)",
+    );
+  });
+
+  it("throws StartDateMustBeFuture when prepareTransaction rejects with that error", async () => {
+    makeMockServer({
+      prepareTransaction: jest.fn().mockRejectedValueOnce(
+        new Error("HostError: Error(Contract, #3)"),
+      ),
+    });
+
+    await expect(
+      createGroup(config, { ...validParams, startTimestamp: 1000n }),
+    ).rejects.toThrow("HostError: Error(Contract, #3)");
+  });
+
+  it("throws when the network does not accept the transaction (non-PENDING status)", async () => {
+    makeMockServer({
+      sendTransaction: jest.fn().mockResolvedValueOnce({ status: "ERROR", hash: "txhash123" }),
+    });
+
+    await expect(createGroup(config, validParams)).rejects.toThrow(
+      "Transaction not accepted by network: ERROR",
+    );
+  });
+
+  it("throws when the confirmed transaction has a FAILED status", async () => {
+    makeMockServer({
+      getTransaction: jest.fn().mockResolvedValueOnce({ status: "FAILED" }),
+    });
+
+    await expect(createGroup(config, validParams)).rejects.toThrow(
+      "create_group transaction failed: FAILED",
+    );
+  });
+
+  it("polls getTransaction until it leaves NOT_FOUND state", async () => {
+    const getTransaction = jest
+      .fn()
+      .mockResolvedValueOnce({ status: "NOT_FOUND" })
+      .mockResolvedValueOnce({ status: "SUCCESS" });
+
+    makeMockServer({ getTransaction });
+
+    jest.useFakeTimers();
+    const promise = createGroup(config, validParams);
+    // Advance past the 1s poll delay twice to let the while loop resolve
+    await jest.runAllTimersAsync();
+    const result = await promise;
+    jest.useRealTimers();
+
+    expect(getTransaction).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ status: "SUCCESS" });
+  });
+});

--- a/packages/sdk/src/savings/create-group.ts
+++ b/packages/sdk/src/savings/create-group.ts
@@ -1,0 +1,144 @@
+import {
+  Contract,
+  nativeToScVal,
+  TransactionBuilder,
+  BASE_FEE,
+  rpc,
+  xdr,
+} from "@stellar/stellar-sdk";
+
+export type Frequency = "Weekly" | "BiWeekly" | "Monthly";
+export type GroupStatus = "Open" | "Active" | "Completed" | "Paused";
+
+export interface SdkConfig {
+  /** Savings contract ID (Stellar address). */
+  contractId: string;
+  /** Soroban RPC endpoint URL. */
+  rpcUrl: string;
+  /** Network passphrase, e.g. "Test SDF Network ; September 2015". */
+  networkPassphrase: string;
+}
+
+export interface WriteConfig extends SdkConfig {
+  /** Caller's Stellar public key — must be the group admin. */
+  publicKey: string;
+  /** Callback that signs the transaction XDR and returns the signed XDR string. */
+  signTransaction: (xdr: string) => Promise<string>;
+}
+
+export interface CreateGroupParams {
+  /** Admin Stellar address — auto-joins and requires auth. */
+  admin: string;
+  /** Unique identifier for this group (on-chain string key). */
+  groupId: string;
+  /** Human-readable name. */
+  name: string;
+  /** Contribution amount in stroops (minimum 10_000_000 = 10 XLM). */
+  contributionAmount: bigint;
+  /** Number of members — must be between 3 and 20 inclusive. */
+  totalMembers: number;
+  /** Round cadence. */
+  frequency: Frequency;
+  /** Unix timestamp (seconds) for when the first round starts — must be in the future. */
+  startTimestamp: bigint;
+  /** Whether the group appears in public discovery listings. */
+  isPublic: boolean;
+}
+
+/** Mirrors the `SavingsGroup` struct returned by `create_group`. */
+export interface SavingsGroup {
+  groupId: string;
+  admin: string;
+  name: string;
+  contributionAmount: bigint;
+  totalMembers: number;
+  frequency: Frequency;
+  startTimestamp: bigint;
+  status: GroupStatus;
+  isPublic: boolean;
+  currentRound: number;
+  platformFeePercent: number;
+}
+
+/**
+ * Creates a new savings group on-chain.
+ *
+ * The caller must be the group admin and provide a `signTransaction` callback.
+ * The admin is automatically added as the first member on-chain.
+ *
+ * **Error variants surfaced by the contract:**
+ * - `ContributionTooLow` — `contributionAmount` < 10 XLM (10_000_000 stroops)
+ * - `InvalidMemberCount` — `totalMembers` not in [3, 20]
+ * - `StartDateMustBeFuture` — `startTimestamp` ≤ current ledger timestamp
+ *
+ * @throws {Error} On contract validation failure, transaction rejection, or RPC error.
+ *
+ * @example
+ * ```ts
+ * const result = await createGroup(
+ *   { contractId, rpcUrl, networkPassphrase, publicKey, signTransaction },
+ *   {
+ *     admin: publicKey,
+ *     groupId: "ajo-001",
+ *     name: "Lagos Ajo Circle",
+ *     contributionAmount: 50_000_000n,
+ *     totalMembers: 6,
+ *     frequency: "Monthly",
+ *     startTimestamp: BigInt(Math.floor(Date.now() / 1000) + 86400),
+ *     isPublic: true,
+ *   },
+ * );
+ * ```
+ */
+export async function createGroup(
+  config: WriteConfig,
+  params: CreateGroupParams,
+): Promise<rpc.Api.GetSuccessfulTransactionResponse> {
+  const { contractId, rpcUrl, networkPassphrase, publicKey, signTransaction } = config;
+
+  const server = new rpc.Server(rpcUrl, { allowHttp: true });
+  const contract = new Contract(contractId);
+  const account = await server.getAccount(publicKey);
+
+  // Soroban enum variant must be encoded as a single-element Vec<Symbol>.
+  const frequencyScVal = xdr.ScVal.scvVec([xdr.ScVal.scvSymbol(params.frequency)]);
+
+  let tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase })
+    .addOperation(
+      contract.call(
+        "create_group",
+        nativeToScVal(params.admin, { type: "address" }),
+        nativeToScVal(params.groupId, { type: "string" }),
+        nativeToScVal(params.name, { type: "string" }),
+        nativeToScVal(params.contributionAmount, { type: "i128" }),
+        nativeToScVal(params.totalMembers, { type: "u32" }),
+        frequencyScVal,
+        nativeToScVal(params.startTimestamp, { type: "u64" }),
+        nativeToScVal(params.isPublic, { type: "bool" }),
+      ),
+    )
+    .setTimeout(30)
+    .build();
+
+  tx = await server.prepareTransaction(tx as any);
+
+  const signedXdr = await signTransaction((tx as any).toXDR());
+  const preparedTx = TransactionBuilder.fromXDR(signedXdr, networkPassphrase);
+
+  const sendResp = await server.sendTransaction(preparedTx as any);
+  if (sendResp.status !== "PENDING") {
+    throw new Error(`Transaction not accepted by network: ${sendResp.status}`);
+  }
+
+  let getResp = await server.getTransaction(sendResp.hash);
+  while (getResp.status === rpc.Api.GetTransactionStatus.NOT_FOUND) {
+    await new Promise((r) => setTimeout(r, 1000));
+    getResp = await server.getTransaction(sendResp.hash);
+  }
+
+  if (getResp.status === rpc.Api.GetTransactionStatus.SUCCESS) {
+    return getResp as rpc.Api.GetSuccessfulTransactionResponse;
+  }
+
+  throw new Error(`create_group transaction failed: ${getResp.status}`);
+}


### PR DESCRIPTION
## Summary

- Adds `createGroup()` SDK binding at `packages/sdk/src/savings/create-group.ts`
- Maps all input params: `admin`, `group_id`, `name`, `contribution_amount`, `total_members`, `frequency`, `start_timestamp`, `is_public`
- Maps `SavingsGroup` return type and `Frequency`/`GroupStatus` enums
- Maps all error variants: `ContributionTooLow` (#1), `InvalidMemberCount` (#2), `StartDateMustBeFuture` (#3) — these surface as thrown errors from `prepareTransaction` (Soroban simulation)
- Unit tests in `packages/sdk/src/savings/__tests__/create-group.test.ts`

## Test plan

- [ ] Success path: full transaction flow (prepareTransaction → sign → sendTransaction → getTransaction → SUCCESS)
- [ ] `ContributionTooLow`: `prepareTransaction` rejects with contract error #1
- [ ] `InvalidMemberCount`: `prepareTransaction` rejects with contract error #2
- [ ] `StartDateMustBeFuture`: `prepareTransaction` rejects with contract error #3
- [ ] Non-PENDING `sendTransaction` response throws
- [ ] FAILED confirmed transaction throws
- [ ] NOT_FOUND polling: `getTransaction` returns NOT_FOUND then SUCCESS

Closes #373