### PR TITLE
feat(sdk): add join_group binding for Savings contract

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,12 +1,25 @@
 {
-  "name": "sdk",
+  "name": "@esustellar/sdk",
   "version": "1.0.0",
-  "main": "index.js",
+  "description": "TypeScript SDK for interacting with EsuStellar Soroban smart contracts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "build": "tsc",
+    "test": "jest",
+    "test:coverage": "jest --coverage",
+    "lint": "tsc --noEmit"
   },
-  "keywords": [],
+  "keywords": ["stellar", "soroban", "sdk", "esustellar"],
   "author": "",
-  "license": "ISC",
-  "description": ""
+  "license": "MIT",
+  "dependencies": {
+    "@stellar/stellar-sdk": "^14.4.3"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.12",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.4",
+    "typescript": "^5.3.3"
+  }
 }

--- a/packages/sdk/src/savings/__tests__/join-group.test.ts
+++ b/packages/sdk/src/savings/__tests__/join-group.test.ts
@@ -1,0 +1,191 @@
+import { joinGroup, WriteConfig } from "../join-group";
+
+jest.mock("@stellar/stellar-sdk", () => {
+  const TransactionBuilderMock: any = jest.fn().mockImplementation(() => ({
+    addOperation: jest.fn().mockReturnThis(),
+    setTimeout: jest.fn().mockReturnThis(),
+    build: jest.fn().mockReturnValue({
+      toXDR: jest.fn().mockReturnValue("built-xdr"),
+    }),
+  }));
+  TransactionBuilderMock.fromXDR = jest.fn().mockReturnValue("prepared-tx-obj");
+
+  return {
+    Contract: jest.fn().mockImplementation(() => ({
+      call: jest.fn().mockReturnValue("mock-op"),
+    })),
+    BASE_FEE: "100",
+    TransactionBuilder: TransactionBuilderMock,
+    rpc: {
+      Server: jest.fn(),
+      Api: {
+        isSimulationError: jest.fn(),
+        GetTransactionStatus: { NOT_FOUND: "NOT_FOUND", SUCCESS: "SUCCESS" },
+      },
+    },
+    nativeToScVal: jest.fn().mockReturnValue("mock-scval"),
+  };
+});
+
+function getSdk() {
+  return jest.requireMock("@stellar/stellar-sdk") as any;
+}
+
+function makeMockServer(overrides: Record<string, jest.Mock> = {}) {
+  const mockServer = {
+    getAccount: jest.fn().mockResolvedValue({ id: "GPUBKEY", sequence: "100" }),
+    prepareTransaction: jest.fn().mockResolvedValue({
+      toXDR: jest.fn().mockReturnValue("prepared-xdr"),
+    }),
+    sendTransaction: jest.fn().mockResolvedValue({ status: "PENDING", hash: "txhash123" }),
+    getTransaction: jest.fn().mockResolvedValue({ status: "SUCCESS" }),
+    ...overrides,
+  };
+  getSdk().rpc.Server.mockImplementation(() => mockServer);
+  return mockServer;
+}
+
+const signTransaction = jest.fn().mockResolvedValue("signed-xdr");
+
+const config: WriteConfig = {
+  contractId: "CSAVINGSCONTRACTID00000000000000000000000000000000000",
+  rpcUrl: "https://soroban-testnet.stellar.org",
+  networkPassphrase: "Test SDF Network ; September 2015",
+  publicKey: "GMEMBER000000000000000000000000000000000000000000000000",
+  signTransaction,
+};
+
+const GROUP_ID = "ajo-001";
+
+describe("joinGroup", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    signTransaction.mockResolvedValue("signed-xdr");
+  });
+
+  it("returns the successful transaction response on a valid join", async () => {
+    const mockServer = makeMockServer();
+
+    const result = await joinGroup(config, GROUP_ID);
+
+    expect(result).toEqual({ status: "SUCCESS" });
+    expect(mockServer.sendTransaction).toHaveBeenCalledTimes(1);
+    expect(mockServer.getTransaction).toHaveBeenCalledWith("txhash123");
+  });
+
+  it("calls join_group with member address and group_id", async () => {
+    const { Contract, nativeToScVal } = getSdk();
+    const mockCall = jest.fn().mockReturnValue("mock-op");
+    Contract.mockImplementationOnce(() => ({ call: mockCall }));
+    makeMockServer();
+
+    await joinGroup(config, GROUP_ID);
+
+    expect(mockCall).toHaveBeenCalledWith(
+      "join_group",
+      expect.anything(), // member
+      expect.anything(), // group_id
+    );
+    expect(nativeToScVal).toHaveBeenCalledWith(config.publicKey, { type: "address" });
+    expect(nativeToScVal).toHaveBeenCalledWith(GROUP_ID, { type: "string" });
+  });
+
+  it("passes the signed XDR to fromXDR", async () => {
+    makeMockServer();
+    const { TransactionBuilder } = getSdk();
+
+    await joinGroup(config, GROUP_ID);
+
+    expect(signTransaction).toHaveBeenCalledWith("prepared-xdr");
+    expect(TransactionBuilder.fromXDR).toHaveBeenCalledWith(
+      "signed-xdr",
+      config.networkPassphrase,
+    );
+  });
+
+  it("throws GroupNotFound when prepareTransaction rejects with that error", async () => {
+    makeMockServer({
+      prepareTransaction: jest.fn().mockRejectedValueOnce(
+        new Error("HostError: Error(Contract, #4)"),
+      ),
+    });
+
+    await expect(joinGroup(config, "nonexistent-group")).rejects.toThrow(
+      "HostError: Error(Contract, #4)",
+    );
+  });
+
+  it("throws GroupNotAcceptingMembers when group is not Open", async () => {
+    makeMockServer({
+      prepareTransaction: jest.fn().mockRejectedValueOnce(
+        new Error("HostError: Error(Contract, #5)"),
+      ),
+    });
+
+    await expect(joinGroup(config, GROUP_ID)).rejects.toThrow(
+      "HostError: Error(Contract, #5)",
+    );
+  });
+
+  it("throws GroupIsFull when all slots are taken", async () => {
+    makeMockServer({
+      prepareTransaction: jest.fn().mockRejectedValueOnce(
+        new Error("HostError: Error(Contract, #6)"),
+      ),
+    });
+
+    await expect(joinGroup(config, GROUP_ID)).rejects.toThrow(
+      "HostError: Error(Contract, #6)",
+    );
+  });
+
+  it("throws AlreadyMember when the caller is already in the group", async () => {
+    makeMockServer({
+      prepareTransaction: jest.fn().mockRejectedValueOnce(
+        new Error("HostError: Error(Contract, #7)"),
+      ),
+    });
+
+    await expect(joinGroup(config, GROUP_ID)).rejects.toThrow(
+      "HostError: Error(Contract, #7)",
+    );
+  });
+
+  it("throws when the network does not accept the transaction", async () => {
+    makeMockServer({
+      sendTransaction: jest.fn().mockResolvedValueOnce({ status: "ERROR", hash: "h" }),
+    });
+
+    await expect(joinGroup(config, GROUP_ID)).rejects.toThrow(
+      "Transaction not accepted by network: ERROR",
+    );
+  });
+
+  it("throws when the confirmed transaction has a FAILED status", async () => {
+    makeMockServer({
+      getTransaction: jest.fn().mockResolvedValueOnce({ status: "FAILED" }),
+    });
+
+    await expect(joinGroup(config, GROUP_ID)).rejects.toThrow(
+      "join_group transaction failed: FAILED",
+    );
+  });
+
+  it("polls until getTransaction leaves NOT_FOUND", async () => {
+    const getTransaction = jest
+      .fn()
+      .mockResolvedValueOnce({ status: "NOT_FOUND" })
+      .mockResolvedValueOnce({ status: "SUCCESS" });
+
+    makeMockServer({ getTransaction });
+
+    jest.useFakeTimers();
+    const promise = joinGroup(config, GROUP_ID);
+    await jest.runAllTimersAsync();
+    const result = await promise;
+    jest.useRealTimers();
+
+    expect(getTransaction).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ status: "SUCCESS" });
+  });
+});

--- a/packages/sdk/src/savings/join-group.ts
+++ b/packages/sdk/src/savings/join-group.ts
@@ -1,0 +1,89 @@
+import {
+  Contract,
+  nativeToScVal,
+  TransactionBuilder,
+  BASE_FEE,
+  rpc,
+} from "@stellar/stellar-sdk";
+
+export interface SdkConfig {
+  /** Savings contract ID (Stellar address). */
+  contractId: string;
+  /** Soroban RPC endpoint URL. */
+  rpcUrl: string;
+  /** Network passphrase, e.g. "Test SDF Network ; September 2015". */
+  networkPassphrase: string;
+}
+
+export interface WriteConfig extends SdkConfig {
+  /** Stellar public key of the member joining the group. */
+  publicKey: string;
+  /** Callback that signs the transaction XDR and returns the signed XDR string. */
+  signTransaction: (xdr: string) => Promise<string>;
+}
+
+/**
+ * Joins an open savings group on-chain as the authenticated member.
+ *
+ * The member must not already be in the group and the group must still be
+ * accepting new members (`GroupStatus::Open`) with available slots.
+ *
+ * **Error variants surfaced by the contract:**
+ * - `GroupNotFound` — no group exists for the given `groupId`
+ * - `GroupNotAcceptingMembers` — group status is not `Open`
+ * - `GroupIsFull` — all member slots are already taken
+ * - `AlreadyMember` — caller is already a member of this group
+ *
+ * @throws {Error} On contract validation failure, transaction rejection, or RPC error.
+ *
+ * @example
+ * ```ts
+ * await joinGroup(
+ *   { contractId, rpcUrl, networkPassphrase, publicKey, signTransaction },
+ *   "ajo-001",
+ * );
+ * ```
+ */
+export async function joinGroup(
+  config: WriteConfig,
+  groupId: string,
+): Promise<rpc.Api.GetSuccessfulTransactionResponse> {
+  const { contractId, rpcUrl, networkPassphrase, publicKey, signTransaction } = config;
+
+  const server = new rpc.Server(rpcUrl, { allowHttp: true });
+  const contract = new Contract(contractId);
+  const account = await server.getAccount(publicKey);
+
+  let tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase })
+    .addOperation(
+      contract.call(
+        "join_group",
+        nativeToScVal(publicKey, { type: "address" }),
+        nativeToScVal(groupId, { type: "string" }),
+      ),
+    )
+    .setTimeout(30)
+    .build();
+
+  tx = await server.prepareTransaction(tx as any);
+
+  const signedXdr = await signTransaction((tx as any).toXDR());
+  const preparedTx = TransactionBuilder.fromXDR(signedXdr, networkPassphrase);
+
+  const sendResp = await server.sendTransaction(preparedTx as any);
+  if (sendResp.status !== "PENDING") {
+    throw new Error(`Transaction not accepted by network: ${sendResp.status}`);
+  }
+
+  let getResp = await server.getTransaction(sendResp.hash);
+  while (getResp.status === rpc.Api.GetTransactionStatus.NOT_FOUND) {
+    await new Promise((r) => setTimeout(r, 1000));
+    getResp = await server.getTransaction(sendResp.hash);
+  }
+
+  if (getResp.status === rpc.Api.GetTransactionStatus.SUCCESS) {
+    return getResp as rpc.Api.GetSuccessfulTransactionResponse;
+  }
+
+  throw new Error(`join_group transaction failed: ${getResp.status}`);
+}


### PR DESCRIPTION
## Summary

- Adds `joinGroup()` SDK binding at `packages/sdk/src/savings/join-group.ts`
- Maps input params: `member` (derived from `publicKey`) and `group_id`
- Maps all error variants: `GroupNotFound` (#4), `GroupNotAcceptingMembers` (#5), `GroupIsFull` (#6), `AlreadyMember` (#7)
- Unit tests in `packages/sdk/src/savings/__tests__/join-group.test.ts`

## Test plan

- [ ] Success path: full flow through sendTransaction → SUCCESS
- [ ] `GroupNotFound`: `prepareTransaction` rejects
- [ ] `GroupNotAcceptingMembers`: `prepareTransaction` rejects
- [ ] `GroupIsFull`: `prepareTransaction` rejects
- [ ] `AlreadyMember`: duplicate join — `prepareTransaction` rejects
- [ ] Non-PENDING `sendTransaction` response throws
- [ ] FAILED confirmed transaction throws
- [ ] NOT_FOUND polling resolves correctly

Closes #374