### PR TITLE
feat(sdk): add contribute binding for Savings contract

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,12 +1,25 @@
 {
-  "name": "sdk",
+  "name": "@esustellar/sdk",
   "version": "1.0.0",
-  "main": "index.js",
+  "description": "TypeScript SDK for interacting with EsuStellar Soroban smart contracts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "build": "tsc",
+    "test": "jest",
+    "test:coverage": "jest --coverage",
+    "lint": "tsc --noEmit"
   },
-  "keywords": [],
+  "keywords": ["stellar", "soroban", "sdk", "esustellar"],
   "author": "",
-  "license": "ISC",
-  "description": ""
+  "license": "MIT",
+  "dependencies": {
+    "@stellar/stellar-sdk": "^14.4.3"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.12",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.4",
+    "typescript": "^5.3.3"
+  }
 }

--- a/packages/sdk/src/savings/__tests__/contribute.test.ts
+++ b/packages/sdk/src/savings/__tests__/contribute.test.ts
@@ -1,0 +1,217 @@
+import { contribute, WriteConfig } from "../contribute";
+
+jest.mock("@stellar/stellar-sdk", () => {
+  const TransactionBuilderMock: any = jest.fn().mockImplementation(() => ({
+    addOperation: jest.fn().mockReturnThis(),
+    setTimeout: jest.fn().mockReturnThis(),
+    build: jest.fn().mockReturnValue({
+      toXDR: jest.fn().mockReturnValue("built-xdr"),
+    }),
+  }));
+  TransactionBuilderMock.fromXDR = jest.fn().mockReturnValue("prepared-tx-obj");
+
+  return {
+    Contract: jest.fn().mockImplementation(() => ({
+      call: jest.fn().mockReturnValue("mock-op"),
+    })),
+    BASE_FEE: "100",
+    TransactionBuilder: TransactionBuilderMock,
+    rpc: {
+      Server: jest.fn(),
+      Api: {
+        isSimulationError: jest.fn(),
+        GetTransactionStatus: { NOT_FOUND: "NOT_FOUND", SUCCESS: "SUCCESS" },
+      },
+    },
+    nativeToScVal: jest.fn().mockReturnValue("mock-scval"),
+  };
+});
+
+function getSdk() {
+  return jest.requireMock("@stellar/stellar-sdk") as any;
+}
+
+function makeMockServer(overrides: Record<string, jest.Mock> = {}) {
+  const mockServer = {
+    getAccount: jest.fn().mockResolvedValue({ id: "GPUBKEY", sequence: "100" }),
+    prepareTransaction: jest.fn().mockResolvedValue({
+      toXDR: jest.fn().mockReturnValue("prepared-xdr"),
+    }),
+    sendTransaction: jest.fn().mockResolvedValue({ status: "PENDING", hash: "txhash123" }),
+    getTransaction: jest.fn().mockResolvedValue({ status: "SUCCESS" }),
+    ...overrides,
+  };
+  getSdk().rpc.Server.mockImplementation(() => mockServer);
+  return mockServer;
+}
+
+const signTransaction = jest.fn().mockResolvedValue("signed-xdr");
+
+const config: WriteConfig = {
+  contractId: "CSAVINGSCONTRACTID00000000000000000000000000000000000",
+  rpcUrl: "https://soroban-testnet.stellar.org",
+  networkPassphrase: "Test SDF Network ; September 2015",
+  publicKey: "GMEMBER000000000000000000000000000000000000000000000000",
+  signTransaction,
+};
+
+const GROUP_ID = "ajo-001";
+
+describe("contribute", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    signTransaction.mockResolvedValue("signed-xdr");
+  });
+
+  it("returns the successful transaction response on a valid contribution", async () => {
+    const mockServer = makeMockServer();
+
+    const result = await contribute(config, GROUP_ID);
+
+    expect(result).toEqual({ status: "SUCCESS" });
+    expect(mockServer.sendTransaction).toHaveBeenCalledTimes(1);
+    expect(mockServer.getTransaction).toHaveBeenCalledWith("txhash123");
+  });
+
+  it("calls contribute with member address and group_id (no amount param)", async () => {
+    const { Contract, nativeToScVal } = getSdk();
+    const mockCall = jest.fn().mockReturnValue("mock-op");
+    Contract.mockImplementationOnce(() => ({ call: mockCall }));
+    makeMockServer();
+
+    await contribute(config, GROUP_ID);
+
+    expect(mockCall).toHaveBeenCalledWith(
+      "contribute",
+      expect.anything(), // member
+      expect.anything(), // group_id
+    );
+    // Exactly two nativeToScVal calls — no amount
+    expect(nativeToScVal).toHaveBeenCalledWith(config.publicKey, { type: "address" });
+    expect(nativeToScVal).toHaveBeenCalledWith(GROUP_ID, { type: "string" });
+    expect(nativeToScVal).not.toHaveBeenCalledWith(expect.anything(), { type: "i128" });
+  });
+
+  it("passes the signed XDR to fromXDR", async () => {
+    makeMockServer();
+    const { TransactionBuilder } = getSdk();
+
+    await contribute(config, GROUP_ID);
+
+    expect(signTransaction).toHaveBeenCalledWith("prepared-xdr");
+    expect(TransactionBuilder.fromXDR).toHaveBeenCalledWith(
+      "signed-xdr",
+      config.networkPassphrase,
+    );
+  });
+
+  it("throws GroupNotFound when the group does not exist", async () => {
+    makeMockServer({
+      prepareTransaction: jest.fn().mockRejectedValueOnce(
+        new Error("HostError: Error(Contract, #4)"),
+      ),
+    });
+
+    await expect(contribute(config, "nonexistent-group")).rejects.toThrow(
+      "HostError: Error(Contract, #4)",
+    );
+  });
+
+  it("throws GroupNotActive when the group has not started or has completed", async () => {
+    makeMockServer({
+      prepareTransaction: jest.fn().mockRejectedValueOnce(
+        new Error("HostError: Error(Contract, #8)"),
+      ),
+    });
+
+    await expect(contribute(config, GROUP_ID)).rejects.toThrow(
+      "HostError: Error(Contract, #8)",
+    );
+  });
+
+  it("throws NotMember when caller is not in the group", async () => {
+    makeMockServer({
+      prepareTransaction: jest.fn().mockRejectedValueOnce(
+        new Error("HostError: Error(Contract, #9)"),
+      ),
+    });
+
+    await expect(contribute(config, GROUP_ID)).rejects.toThrow(
+      "HostError: Error(Contract, #9)",
+    );
+  });
+
+  it("throws MemberDefaulted when the caller has defaulted", async () => {
+    makeMockServer({
+      prepareTransaction: jest.fn().mockRejectedValueOnce(
+        new Error("HostError: Error(Contract, #10)"),
+      ),
+    });
+
+    await expect(contribute(config, GROUP_ID)).rejects.toThrow(
+      "HostError: Error(Contract, #10)",
+    );
+  });
+
+  it("throws AlreadyPaidThisRound on a double-pay attempt", async () => {
+    makeMockServer({
+      prepareTransaction: jest.fn().mockRejectedValueOnce(
+        new Error("HostError: Error(Contract, #11)"),
+      ),
+    });
+
+    await expect(contribute(config, GROUP_ID)).rejects.toThrow(
+      "HostError: Error(Contract, #11)",
+    );
+  });
+
+  it("throws PaymentWindowClosed when the round grace period has expired", async () => {
+    makeMockServer({
+      prepareTransaction: jest.fn().mockRejectedValueOnce(
+        new Error("HostError: Error(Contract, #12)"),
+      ),
+    });
+
+    await expect(contribute(config, GROUP_ID)).rejects.toThrow(
+      "HostError: Error(Contract, #12)",
+    );
+  });
+
+  it("throws when the network does not accept the transaction", async () => {
+    makeMockServer({
+      sendTransaction: jest.fn().mockResolvedValueOnce({ status: "ERROR", hash: "h" }),
+    });
+
+    await expect(contribute(config, GROUP_ID)).rejects.toThrow(
+      "Transaction not accepted by network: ERROR",
+    );
+  });
+
+  it("throws when the confirmed transaction has a FAILED status", async () => {
+    makeMockServer({
+      getTransaction: jest.fn().mockResolvedValueOnce({ status: "FAILED" }),
+    });
+
+    await expect(contribute(config, GROUP_ID)).rejects.toThrow(
+      "contribute transaction failed: FAILED",
+    );
+  });
+
+  it("polls until getTransaction leaves NOT_FOUND", async () => {
+    const getTransaction = jest
+      .fn()
+      .mockResolvedValueOnce({ status: "NOT_FOUND" })
+      .mockResolvedValueOnce({ status: "SUCCESS" });
+
+    makeMockServer({ getTransaction });
+
+    jest.useFakeTimers();
+    const promise = contribute(config, GROUP_ID);
+    await jest.runAllTimersAsync();
+    const result = await promise;
+    jest.useRealTimers();
+
+    expect(getTransaction).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ status: "SUCCESS" });
+  });
+});

--- a/packages/sdk/src/savings/contribute.ts
+++ b/packages/sdk/src/savings/contribute.ts
@@ -1,0 +1,91 @@
+import {
+  Contract,
+  nativeToScVal,
+  TransactionBuilder,
+  BASE_FEE,
+  rpc,
+} from "@stellar/stellar-sdk";
+
+export interface SdkConfig {
+  /** Savings contract ID (Stellar address). */
+  contractId: string;
+  /** Soroban RPC endpoint URL. */
+  rpcUrl: string;
+  /** Network passphrase, e.g. "Test SDF Network ; September 2015". */
+  networkPassphrase: string;
+}
+
+export interface WriteConfig extends SdkConfig {
+  /** Stellar public key of the contributing member. */
+  publicKey: string;
+  /** Callback that signs the transaction XDR and returns the signed XDR string. */
+  signTransaction: (xdr: string) => Promise<string>;
+}
+
+/**
+ * Records the caller's contribution for the current round of a savings group.
+ *
+ * The contribution amount is fixed on-chain at group creation — no amount
+ * parameter is accepted here.
+ *
+ * **Error variants surfaced by the contract:**
+ * - `GroupNotFound` — no group exists for the given `groupId`
+ * - `GroupNotActive` — group is not in `Active` status (rounds not yet started or completed)
+ * - `NotMember` — caller is not a member of this group
+ * - `MemberDefaulted` — caller has previously defaulted and cannot contribute
+ * - `AlreadyPaidThisRound` — caller has already contributed in the current round
+ * - `PaymentWindowClosed` — the grace period for this round has expired
+ *
+ * @throws {Error} On contract validation failure, transaction rejection, or RPC error.
+ *
+ * @example
+ * ```ts
+ * await contribute(
+ *   { contractId, rpcUrl, networkPassphrase, publicKey, signTransaction },
+ *   "ajo-001",
+ * );
+ * ```
+ */
+export async function contribute(
+  config: WriteConfig,
+  groupId: string,
+): Promise<rpc.Api.GetSuccessfulTransactionResponse> {
+  const { contractId, rpcUrl, networkPassphrase, publicKey, signTransaction } = config;
+
+  const server = new rpc.Server(rpcUrl, { allowHttp: true });
+  const contract = new Contract(contractId);
+  const account = await server.getAccount(publicKey);
+
+  let tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase })
+    .addOperation(
+      contract.call(
+        "contribute",
+        nativeToScVal(publicKey, { type: "address" }),
+        nativeToScVal(groupId, { type: "string" }),
+      ),
+    )
+    .setTimeout(30)
+    .build();
+
+  tx = await server.prepareTransaction(tx as any);
+
+  const signedXdr = await signTransaction((tx as any).toXDR());
+  const preparedTx = TransactionBuilder.fromXDR(signedXdr, networkPassphrase);
+
+  const sendResp = await server.sendTransaction(preparedTx as any);
+  if (sendResp.status !== "PENDING") {
+    throw new Error(`Transaction not accepted by network: ${sendResp.status}`);
+  }
+
+  let getResp = await server.getTransaction(sendResp.hash);
+  while (getResp.status === rpc.Api.GetTransactionStatus.NOT_FOUND) {
+    await new Promise((r) => setTimeout(r, 1000));
+    getResp = await server.getTransaction(sendResp.hash);
+  }
+
+  if (getResp.status === rpc.Api.GetTransactionStatus.SUCCESS) {
+    return getResp as rpc.Api.GetSuccessfulTransactionResponse;
+  }
+
+  throw new Error(`contribute transaction failed: ${getResp.status}`);
+}


### PR DESCRIPTION
## Summary

- Adds `contribute()` SDK binding at `packages/sdk/src/savings/contribute.ts`
- Maps input params: `member` (derived from `publicKey`) and `group_id` — **no amount param** (contribution amount is fixed on-chain at group creation)
- Maps all error variants: `GroupNotFound` (#4), `GroupNotActive` (#8), `NotMember` (#9), `MemberDefaulted` (#10), `AlreadyPaidThisRound` (#11), `PaymentWindowClosed` (#12)
- Unit tests in `packages/sdk/src/savings/__tests__/contribute.test.ts`

## Test plan

- [ ] Success path: full transaction flow → SUCCESS
- [ ] `GroupNotFound`: `prepareTransaction` rejects
- [ ] `GroupNotActive`: group not yet started or completed
- [ ] `NotMember`: non-member caller
- [ ] `MemberDefaulted`: previously defaulted member
- [ ] `AlreadyPaidThisRound`: double-pay attempt
- [ ] `PaymentWindowClosed`: grace period expired
- [ ] Non-PENDING `sendTransaction` throws
- [ ] FAILED confirmed transaction throws
- [ ] NOT_FOUND polling resolves correctly

Closes #375