### PR TITLE
feat(sdk): add get_all_public_groups binding for Registry contract

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,12 +1,25 @@
 {
-  "name": "sdk",
+  "name": "@esustellar/sdk",
   "version": "1.0.0",
-  "main": "index.js",
+  "description": "TypeScript SDK for interacting with EsuStellar Soroban smart contracts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "build": "tsc",
+    "test": "jest",
+    "test:coverage": "jest --coverage",
+    "lint": "tsc --noEmit"
   },
-  "keywords": [],
+  "keywords": ["stellar", "soroban", "sdk", "esustellar"],
   "author": "",
-  "license": "ISC",
-  "description": ""
+  "license": "MIT",
+  "dependencies": {
+    "@stellar/stellar-sdk": "^14.4.3"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.12",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.4",
+    "typescript": "^5.3.3"
+  }
 }

--- a/packages/sdk/src/registry/__tests__/get-all-public-groups.test.ts
+++ b/packages/sdk/src/registry/__tests__/get-all-public-groups.test.ts
@@ -1,0 +1,182 @@
+import { getAllPublicGroups, GroupInfo, SdkConfig } from "../get-all-public-groups";
+
+jest.mock("@stellar/stellar-sdk", () => {
+  const TransactionBuilderMock: any = jest.fn().mockImplementation(() => ({
+    addOperation: jest.fn().mockReturnThis(),
+    setTimeout: jest.fn().mockReturnThis(),
+    build: jest.fn().mockReturnValue({ toXDR: jest.fn().mockReturnValue("mock-xdr") }),
+  }));
+  TransactionBuilderMock.fromXDR = jest.fn();
+
+  return {
+    Contract: jest.fn().mockImplementation(() => ({
+      call: jest.fn().mockReturnValue("mock-op"),
+    })),
+    Account: jest.fn().mockImplementation(() => ({})),
+    BASE_FEE: "100",
+    TransactionBuilder: TransactionBuilderMock,
+    rpc: {
+      Server: jest.fn(),
+      Api: {
+        isSimulationError: jest.fn(),
+        GetTransactionStatus: { NOT_FOUND: "NOT_FOUND", SUCCESS: "SUCCESS" },
+      },
+    },
+    scValToNative: jest.fn(),
+    nativeToScVal: jest.fn().mockReturnValue("mock-scval"),
+  };
+});
+
+const config: SdkConfig = {
+  contractId: "CREGISTRYCONTRACTID000000000000000000000000000000000000",
+  rpcUrl: "https://soroban-testnet.stellar.org",
+  networkPassphrase: "Test SDF Network ; September 2015",
+};
+
+function getSdk() {
+  return jest.requireMock("@stellar/stellar-sdk") as any;
+}
+
+function makeMockServer(overrides: Record<string, jest.Mock> = {}) {
+  const mockServer = { simulateTransaction: jest.fn(), ...overrides };
+  getSdk().rpc.Server.mockImplementation(() => mockServer);
+  return mockServer;
+}
+
+const PUBLIC_GROUP = {
+  contract_address: "CSAVINGS001",
+  group_id: "group-001",
+  name: "Public Savings Circle",
+  admin: "GADMIN001",
+  is_public: true,
+  created_at: BigInt(1717200000),
+  total_members: 5,
+};
+
+const PRIVATE_GROUP = {
+  contract_address: "CSAVINGS002",
+  group_id: "group-002",
+  name: "Private Circle",
+  admin: "GADMIN002",
+  is_public: false,
+  created_at: BigInt(1717200100),
+  total_members: 3,
+};
+
+describe("getAllPublicGroups", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getSdk().rpc.Api.isSimulationError.mockReturnValue(false);
+  });
+
+  it("returns only public groups from the registry", async () => {
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({
+      result: { retval: "mock-retval" },
+    });
+    // Contract filters — only returns public groups
+    getSdk().scValToNative.mockReturnValueOnce([PUBLIC_GROUP]);
+
+    const result = await getAllPublicGroups(config);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].isPublic).toBe(true);
+    expect(result[0].groupId).toBe("group-001");
+  });
+
+  it("returns empty array when no public groups are registered", async () => {
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({
+      result: { retval: "mock-retval" },
+    });
+    getSdk().scValToNative.mockReturnValueOnce([]);
+
+    const result = await getAllPublicGroups(config);
+
+    expect(result).toEqual([]);
+  });
+
+  it("private groups are not present in the response (filtered by contract)", async () => {
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({
+      result: { retval: "mock-retval" },
+    });
+    // The on-chain function only returns public groups; private group absent
+    getSdk().scValToNative.mockReturnValueOnce([PUBLIC_GROUP]);
+
+    const result = await getAllPublicGroups(config);
+
+    const privateFound = result.find((g) => !g.isPublic);
+    expect(privateFound).toBeUndefined();
+  });
+
+  it("maps GroupInfo fields correctly", async () => {
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({
+      result: { retval: "mock-retval" },
+    });
+    getSdk().scValToNative.mockReturnValueOnce([PUBLIC_GROUP]);
+
+    const [group] = await getAllPublicGroups(config);
+
+    const expected: GroupInfo = {
+      contractAddress: "CSAVINGS001",
+      groupId: "group-001",
+      name: "Public Savings Circle",
+      admin: "GADMIN001",
+      isPublic: true,
+      createdAt: 1717200000,
+      totalMembers: 5,
+    };
+    expect(group).toEqual(expected);
+  });
+
+  it("maps multiple public groups correctly", async () => {
+    const second = { ...PUBLIC_GROUP, group_id: "group-003", name: "Group 3" };
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({
+      result: { retval: "mock-retval" },
+    });
+    getSdk().scValToNative.mockReturnValueOnce([PUBLIC_GROUP, second]);
+
+    const result = await getAllPublicGroups(config);
+
+    expect(result).toHaveLength(2);
+    expect(result.every((g) => g.isPublic)).toBe(true);
+  });
+
+  it("calls get_all_public_groups on the contract", async () => {
+    const { Contract } = getSdk();
+    const mockCall = jest.fn().mockReturnValue("mock-op");
+    Contract.mockImplementationOnce(() => ({ call: mockCall }));
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({
+      result: { retval: "mock-retval" },
+    });
+    getSdk().scValToNative.mockReturnValueOnce([]);
+
+    await getAllPublicGroups(config);
+
+    expect(Contract).toHaveBeenCalledWith(config.contractId);
+    expect(mockCall).toHaveBeenCalledWith("get_all_public_groups");
+  });
+
+  it("throws on simulation error", async () => {
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({ error: "OutOfGas" });
+    getSdk().rpc.Api.isSimulationError.mockReturnValueOnce(true);
+
+    await expect(getAllPublicGroups(config)).rejects.toThrow(
+      "Registry contract simulation error: OutOfGas",
+    );
+  });
+
+  it("throws when simulation result is empty", async () => {
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({ result: null });
+
+    await expect(getAllPublicGroups(config)).rejects.toThrow(
+      "Simulation returned empty result",
+    );
+  });
+});

--- a/packages/sdk/src/registry/get-all-public-groups.ts
+++ b/packages/sdk/src/registry/get-all-public-groups.ts
@@ -1,0 +1,101 @@
+import {
+  Contract,
+  scValToNative,
+  TransactionBuilder,
+  BASE_FEE,
+  rpc,
+  Account,
+} from "@stellar/stellar-sdk";
+
+const DUMMY_ACCOUNT =
+  "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+export interface SdkConfig {
+  /** Registry contract ID (Stellar address). */
+  contractId: string;
+  /** Soroban RPC endpoint URL. */
+  rpcUrl: string;
+  /** Network passphrase, e.g. "Test SDF Network ; September 2015". */
+  networkPassphrase: string;
+  /** Optional Stellar address used as the simulation source. Defaults to a dummy account. */
+  sourceAccount?: string;
+}
+
+/** Mirrors the `GroupInfo` struct from the Registry contract. */
+export interface GroupInfo {
+  contractAddress: string;
+  groupId: string;
+  name: string;
+  admin: string;
+  isPublic: boolean;
+  /** Unix timestamp (seconds) when the group was registered. */
+  createdAt: number;
+  totalMembers: number;
+}
+
+/**
+ * Returns full `GroupInfo` for all **public** groups registered in the Registry contract.
+ * Private groups (`is_public: false`) are excluded by the contract itself.
+ *
+ * This is a read-only simulation — no transaction is submitted and no auth is required.
+ *
+ * @throws {Error} If the simulation fails or returns an empty result.
+ *
+ * @example
+ * ```ts
+ * const publicGroups = await getAllPublicGroups({
+ *   contractId: "CREGISTRY...",
+ *   rpcUrl: "https://soroban-testnet.stellar.org",
+ *   networkPassphrase: "Test SDF Network ; September 2015",
+ * });
+ * // All returned groups are guaranteed to have isPublic === true
+ * ```
+ */
+export async function getAllPublicGroups(
+  config: SdkConfig,
+): Promise<GroupInfo[]> {
+  const { contractId, rpcUrl, networkPassphrase } = config;
+  const source = config.sourceAccount ?? DUMMY_ACCOUNT;
+
+  const server = new rpc.Server(rpcUrl, { allowHttp: true });
+  const contract = new Contract(contractId);
+  const account = new Account(source, "0");
+
+  const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase })
+    .addOperation(contract.call("get_all_public_groups"))
+    .setTimeout(30)
+    .build();
+
+  const result = await server.simulateTransaction(tx as any);
+
+  if (rpc.Api.isSimulationError(result)) {
+    throw new Error(
+      `Registry contract simulation error: ${(result as any).error}`,
+    );
+  }
+
+  const simResult = result as any;
+  if (!simResult.result?.retval) {
+    throw new Error("Simulation returned empty result");
+  }
+
+  const raw = scValToNative(simResult.result.retval) as Array<{
+    contract_address: string;
+    group_id: string;
+    name: string;
+    admin: string;
+    is_public: boolean;
+    created_at: bigint | number;
+    total_members: number;
+  }>;
+
+  return raw.map((g) => ({
+    contractAddress: String(g.contract_address),
+    groupId: String(g.group_id),
+    name: String(g.name),
+    admin: String(g.admin),
+    isPublic: Boolean(g.is_public),
+    createdAt: Number(g.created_at),
+    totalMembers: Number(g.total_members),
+  }));
+}


### PR DESCRIPTION
## Summary

- Adds `getAllPublicGroups()` SDK binding at `packages/sdk/src/registry/get-all-public-groups.ts`
- Maps `Vec<GroupInfo>` return type — only public groups are returned (filtered on-chain)
- Unit tests in `packages/sdk/src/registry/__tests__/get-all-public-groups.test.ts` assert only public groups are returned, correct field mapping, multi-group responses, and simulation errors

## Test plan
- [ ] Success: only public groups returned
- [ ] Empty array when no public groups exist
- [ ] Simulation error propagated correctly

Closes #244