### PR TITLE
feat(sdk): add get_group_info binding for Registry contract

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,12 +1,25 @@
 {
-  "name": "sdk",
+  "name": "@esustellar/sdk",
   "version": "1.0.0",
-  "main": "index.js",
+  "description": "TypeScript SDK for interacting with EsuStellar Soroban smart contracts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "build": "tsc",
+    "test": "jest",
+    "test:coverage": "jest --coverage",
+    "lint": "tsc --noEmit"
   },
-  "keywords": [],
+  "keywords": ["stellar", "soroban", "sdk", "esustellar"],
   "author": "",
-  "license": "ISC",
-  "description": ""
+  "license": "MIT",
+  "dependencies": {
+    "@stellar/stellar-sdk": "^14.4.3"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.12",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.4",
+    "typescript": "^5.3.3"
+  }
 }

--- a/packages/sdk/src/registry/__tests__/get-group-info.test.ts
+++ b/packages/sdk/src/registry/__tests__/get-group-info.test.ts
@@ -1,0 +1,170 @@
+import { getGroupInfo, GroupInfo, SdkConfig } from "../get-group-info";
+
+jest.mock("@stellar/stellar-sdk", () => {
+  const TransactionBuilderMock: any = jest.fn().mockImplementation(() => ({
+    addOperation: jest.fn().mockReturnThis(),
+    setTimeout: jest.fn().mockReturnThis(),
+    build: jest.fn().mockReturnValue({ toXDR: jest.fn().mockReturnValue("mock-xdr") }),
+  }));
+  TransactionBuilderMock.fromXDR = jest.fn();
+
+  return {
+    Contract: jest.fn().mockImplementation(() => ({
+      call: jest.fn().mockReturnValue("mock-op"),
+    })),
+    Account: jest.fn().mockImplementation(() => ({})),
+    BASE_FEE: "100",
+    TransactionBuilder: TransactionBuilderMock,
+    rpc: {
+      Server: jest.fn(),
+      Api: {
+        isSimulationError: jest.fn(),
+        GetTransactionStatus: { NOT_FOUND: "NOT_FOUND", SUCCESS: "SUCCESS" },
+      },
+    },
+    scValToNative: jest.fn(),
+    nativeToScVal: jest.fn().mockReturnValue("mock-scval"),
+  };
+});
+
+const config: SdkConfig = {
+  contractId: "CREGISTRYCONTRACTID000000000000000000000000000000000000",
+  rpcUrl: "https://soroban-testnet.stellar.org",
+  networkPassphrase: "Test SDF Network ; September 2015",
+};
+
+const CONTRACT_ADDRESS = "CSAVINGSCONTRACTID00000000000000000000000000000000000";
+
+function getSdk() {
+  return jest.requireMock("@stellar/stellar-sdk") as any;
+}
+
+function makeMockServer(overrides: Record<string, jest.Mock> = {}) {
+  const mockServer = { simulateTransaction: jest.fn(), ...overrides };
+  getSdk().rpc.Server.mockImplementation(() => mockServer);
+  return mockServer;
+}
+
+const RAW_GROUP_INFO = {
+  contract_address: CONTRACT_ADDRESS,
+  group_id: "ajo-001",
+  name: "Lagos Ajo Circle",
+  admin: "GADMIN000000000000000000000000000000000000000000000000",
+  is_public: true,
+  created_at: BigInt(1717200000),
+  total_members: 6,
+};
+
+const EXPECTED: GroupInfo = {
+  contractAddress: CONTRACT_ADDRESS,
+  groupId: "ajo-001",
+  name: "Lagos Ajo Circle",
+  admin: "GADMIN000000000000000000000000000000000000000000000000",
+  isPublic: true,
+  createdAt: 1717200000,
+  totalMembers: 6,
+};
+
+describe("getGroupInfo", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getSdk().rpc.Api.isSimulationError.mockReturnValue(false);
+  });
+
+  it("returns mapped GroupInfo for a registered group", async () => {
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({
+      result: { retval: "mock-retval" },
+    });
+    getSdk().scValToNative.mockReturnValueOnce(RAW_GROUP_INFO);
+
+    const result = await getGroupInfo(config, CONTRACT_ADDRESS);
+
+    expect(result).toEqual(EXPECTED);
+  });
+
+  it("passes the contract address as an address ScVal", async () => {
+    const { nativeToScVal, Contract } = getSdk();
+    const mockCall = jest.fn().mockReturnValue("mock-op");
+    Contract.mockImplementationOnce(() => ({ call: mockCall }));
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({
+      result: { retval: "mock-retval" },
+    });
+    getSdk().scValToNative.mockReturnValueOnce(RAW_GROUP_INFO);
+
+    await getGroupInfo(config, CONTRACT_ADDRESS);
+
+    expect(nativeToScVal).toHaveBeenCalledWith(CONTRACT_ADDRESS, { type: "address" });
+    expect(mockCall).toHaveBeenCalledWith("get_group_info", expect.anything());
+  });
+
+  it("maps a private group correctly", async () => {
+    const privateRaw = { ...RAW_GROUP_INFO, is_public: false };
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({
+      result: { retval: "mock-retval" },
+    });
+    getSdk().scValToNative.mockReturnValueOnce(privateRaw);
+
+    const result = await getGroupInfo(config, CONTRACT_ADDRESS);
+
+    expect(result.isPublic).toBe(false);
+  });
+
+  it("throws GroupNotFound when the simulation error contains error code #2", async () => {
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({
+      error: "HostError: Error(Contract, #2)",
+    });
+    getSdk().rpc.Api.isSimulationError.mockReturnValueOnce(true);
+
+    await expect(getGroupInfo(config, "CNONEXISTENT")).rejects.toThrow(
+      "GroupNotFound: no group registered at CNONEXISTENT",
+    );
+  });
+
+  it("throws GroupNotFound when the simulation error says not found", async () => {
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({
+      error: "contract error: group not found",
+    });
+    getSdk().rpc.Api.isSimulationError.mockReturnValueOnce(true);
+
+    await expect(getGroupInfo(config, "CNONEXISTENT")).rejects.toThrow(
+      "GroupNotFound",
+    );
+  });
+
+  it("throws a generic error for non-GroupNotFound simulation errors", async () => {
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({ error: "OutOfGas" });
+    getSdk().rpc.Api.isSimulationError.mockReturnValueOnce(true);
+
+    await expect(getGroupInfo(config, CONTRACT_ADDRESS)).rejects.toThrow(
+      "Registry contract simulation error: OutOfGas",
+    );
+  });
+
+  it("throws when simulation result is empty", async () => {
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({ result: null });
+
+    await expect(getGroupInfo(config, CONTRACT_ADDRESS)).rejects.toThrow(
+      "Simulation returned empty result",
+    );
+  });
+
+  it("uses the provided sourceAccount", async () => {
+    const { Account } = getSdk();
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({
+      result: { retval: "mock-retval" },
+    });
+    getSdk().scValToNative.mockReturnValueOnce(RAW_GROUP_INFO);
+
+    await getGroupInfo({ ...config, sourceAccount: "GCUSTOM" }, CONTRACT_ADDRESS);
+
+    expect(Account).toHaveBeenCalledWith("GCUSTOM", "0");
+  });
+});

--- a/packages/sdk/src/registry/get-group-info.ts
+++ b/packages/sdk/src/registry/get-group-info.ts
@@ -1,0 +1,112 @@
+import {
+  Contract,
+  nativeToScVal,
+  scValToNative,
+  TransactionBuilder,
+  BASE_FEE,
+  rpc,
+  Account,
+} from "@stellar/stellar-sdk";
+
+const DUMMY_ACCOUNT =
+  "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+export interface SdkConfig {
+  /** Registry contract ID (Stellar address). */
+  contractId: string;
+  /** Soroban RPC endpoint URL. */
+  rpcUrl: string;
+  /** Network passphrase, e.g. "Test SDF Network ; September 2015". */
+  networkPassphrase: string;
+  /** Optional Stellar address used as the simulation source. Defaults to a dummy account. */
+  sourceAccount?: string;
+}
+
+/** Mirrors the `GroupInfo` struct from the Registry contract. */
+export interface GroupInfo {
+  contractAddress: string;
+  groupId: string;
+  name: string;
+  admin: string;
+  isPublic: boolean;
+  /** Unix timestamp (seconds) when the group was registered. */
+  createdAt: number;
+  totalMembers: number;
+}
+
+/**
+ * Retrieves all registry metadata for a single group by its contract address.
+ *
+ * This is a read-only simulation — no transaction is submitted and no auth is required.
+ *
+ * **Error variants surfaced by the contract:**
+ * - `GroupNotFound` — no group is registered at `contractAddress`
+ *
+ * @throws {Error} If the group is not found, the simulation fails, or the result is empty.
+ *
+ * @example
+ * ```ts
+ * const info = await getGroupInfo({
+ *   contractId: "CREGISTRY...",
+ *   rpcUrl: "https://soroban-testnet.stellar.org",
+ *   networkPassphrase: "Test SDF Network ; September 2015",
+ * }, "CSAVINGSCONTRACT...");
+ * console.log(info.name); // "My Ajo Circle"
+ * ```
+ */
+export async function getGroupInfo(
+  config: SdkConfig,
+  contractAddress: string,
+): Promise<GroupInfo> {
+  const { contractId, rpcUrl, networkPassphrase } = config;
+  const source = config.sourceAccount ?? DUMMY_ACCOUNT;
+
+  const server = new rpc.Server(rpcUrl, { allowHttp: true });
+  const contract = new Contract(contractId);
+  const account = new Account(source, "0");
+
+  const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase })
+    .addOperation(
+      contract.call(
+        "get_group_info",
+        nativeToScVal(contractAddress, { type: "address" }),
+      ),
+    )
+    .setTimeout(30)
+    .build();
+
+  const result = await server.simulateTransaction(tx as any);
+
+  if (rpc.Api.isSimulationError(result)) {
+    const errMsg = (result as any).error as string;
+    if (errMsg?.includes("#2") || errMsg?.toLowerCase().includes("not found")) {
+      throw new Error(`GroupNotFound: no group registered at ${contractAddress}`);
+    }
+    throw new Error(`Registry contract simulation error: ${errMsg}`);
+  }
+
+  const simResult = result as any;
+  if (!simResult.result?.retval) {
+    throw new Error("Simulation returned empty result");
+  }
+
+  const g = scValToNative(simResult.result.retval) as {
+    contract_address: string;
+    group_id: string;
+    name: string;
+    admin: string;
+    is_public: boolean;
+    created_at: bigint | number;
+    total_members: number;
+  };
+
+  return {
+    contractAddress: String(g.contract_address),
+    groupId: String(g.group_id),
+    name: String(g.name),
+    admin: String(g.admin),
+    isPublic: Boolean(g.is_public),
+    createdAt: Number(g.created_at),
+    totalMembers: Number(g.total_members),
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `getGroupInfo(config, contractAddress)` at `packages/sdk/src/registry/get-group-info.ts`
- Passes `contractAddress` as an `address` ScVal to the contract
- Maps `GroupNotFound` error variant (contract error #2) with a descriptive message
- Maps all `GroupInfo` struct fields to camelCase SDK types
- 7 unit tests in `packages/sdk/src/registry/__tests__/get-group-info.test.ts`

## Test plan
- [ ] Returns correct GroupInfo for registered group
- [ ] GroupNotFound thrown for error code #2
- [ ] GroupNotFound thrown for 'not found' message
- [ ] Generic simulation error propagated
- [ ] Empty result throws

Closes #245