### PR TITLE
feat(mobile): add Testnet/Mainnet network switching

### DIFF
--- a/mobile/components/NetworkBadge.tsx
+++ b/mobile/components/NetworkBadge.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { useNetworkStore } from "../stores/networkStore";
+
+/**
+ * Compact badge that displays the active Stellar network.
+ * Renders nothing on Mainnet to avoid cluttering the production UI.
+ * Drop it in the app header or settings screen.
+ *
+ * @example
+ * // In your header component:
+ * <NetworkBadge />
+ */
+export default function NetworkBadge() {
+  const { activeNetwork } = useNetworkStore();
+
+  if (activeNetwork === "mainnet") return null;
+
+  return (
+    <View style={styles.badge} testID="network-badge">
+      <Text style={styles.label}>TESTNET</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  badge: {
+    backgroundColor: "#F59E0B",
+    borderRadius: 4,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    alignSelf: "flex-start",
+  },
+  label: {
+    color: "#1C1917",
+    fontSize: 10,
+    fontWeight: "700",
+    letterSpacing: 0.5,
+  },
+});

--- a/mobile/services/stellar/network.ts
+++ b/mobile/services/stellar/network.ts
@@ -1,0 +1,127 @@
+/**
+ * Stellar Network Switching Service
+ *
+ * Provides runtime switching between Testnet and Mainnet with
+ * configuration for all network-dependent endpoints.
+ */
+
+export type StellarNetwork = "testnet" | "mainnet";
+
+export interface NetworkConfig {
+  network: StellarNetwork;
+  rpcUrl: string;
+  horizonUrl: string;
+  networkPassphrase: string;
+  /** Human-readable label shown in the UI. */
+  label: string;
+}
+
+export const NETWORK_CONFIGS: Record<StellarNetwork, NetworkConfig> = {
+  testnet: {
+    network: "testnet",
+    rpcUrl: "https://soroban-testnet.stellar.org",
+    horizonUrl: "https://horizon-testnet.stellar.org",
+    networkPassphrase: "Test SDF Network ; September 2015",
+    label: "Testnet",
+  },
+  mainnet: {
+    network: "mainnet",
+    rpcUrl: "https://soroban.stellar.org",
+    horizonUrl: "https://horizon.stellar.org",
+    networkPassphrase: "Public Global Stellar Network ; September 2015",
+    label: "Mainnet",
+  },
+};
+
+export type NetworkSwitchListener = (config: NetworkConfig) => void;
+
+/**
+ * Singleton service that holds the active network configuration and
+ * notifies registered listeners when the network changes.
+ *
+ * Use `NetworkService.getInstance()` to get the shared instance.
+ * Persist the choice via `useNetworkStore` (Zustand + AsyncStorage).
+ */
+export class NetworkService {
+  private static instance: NetworkService;
+  private activeConfig: NetworkConfig;
+  private listeners: Set<NetworkSwitchListener> = new Set();
+
+  private constructor(initialNetwork: StellarNetwork = "testnet") {
+    this.activeConfig = NETWORK_CONFIGS[initialNetwork];
+  }
+
+  static getInstance(initialNetwork?: StellarNetwork): NetworkService {
+    if (!NetworkService.instance) {
+      NetworkService.instance = new NetworkService(initialNetwork);
+    }
+    return NetworkService.instance;
+  }
+
+  /** Returns the full configuration for the currently active network. */
+  getActiveConfig(): NetworkConfig {
+    return this.activeConfig;
+  }
+
+  /** Returns the currently active network name. */
+  getActiveNetwork(): StellarNetwork {
+    return this.activeConfig.network;
+  }
+
+  /** Returns true when the app is connected to Testnet. */
+  isTestnet(): boolean {
+    return this.activeConfig.network === "testnet";
+  }
+
+  /** Returns true when the app is connected to Mainnet. */
+  isMainnet(): boolean {
+    return this.activeConfig.network === "mainnet";
+  }
+
+  /**
+   * Switches the active network and notifies all listeners.
+   * @returns The new active `NetworkConfig`.
+   */
+  switchNetwork(network: StellarNetwork): NetworkConfig {
+    if (network === this.activeConfig.network) {
+      return this.activeConfig;
+    }
+
+    this.activeConfig = NETWORK_CONFIGS[network];
+    this.notifyListeners();
+    return this.activeConfig;
+  }
+
+  /**
+   * Registers a callback that fires whenever the network changes.
+   * @returns An unsubscribe function.
+   */
+  onNetworkChange(listener: NetworkSwitchListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  private notifyListeners(): void {
+    this.listeners.forEach((l) => l(this.activeConfig));
+  }
+
+  /** Resets the singleton — intended for testing only. */
+  static _reset(): void {
+    NetworkService.instance = undefined as any;
+  }
+}
+
+/** Convenience accessor for the current RPC URL. */
+export function getActiveRpcUrl(): string {
+  return NetworkService.getInstance().getActiveConfig().rpcUrl;
+}
+
+/** Convenience accessor for the current Horizon URL. */
+export function getActiveHorizonUrl(): string {
+  return NetworkService.getInstance().getActiveConfig().horizonUrl;
+}
+
+/** Convenience accessor for the current network passphrase. */
+export function getActiveNetworkPassphrase(): string {
+  return NetworkService.getInstance().getActiveConfig().networkPassphrase;
+}

--- a/mobile/stores/networkStore.ts
+++ b/mobile/stores/networkStore.ts
@@ -1,0 +1,39 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { NetworkService, StellarNetwork, NetworkConfig, NETWORK_CONFIGS } from "../services/stellar/network";
+
+export interface NetworkState {
+  /** The persisted network preference. */
+  activeNetwork: StellarNetwork;
+  /** Full config derived from activeNetwork. */
+  config: NetworkConfig;
+  /** Switch to a different network and persist the choice. */
+  switchNetwork: (network: StellarNetwork) => void;
+}
+
+export const useNetworkStore = create<NetworkState>()(
+  persist(
+    (set) => ({
+      activeNetwork: "testnet",
+      config: NETWORK_CONFIGS.testnet,
+
+      switchNetwork: (network: StellarNetwork) => {
+        const config = NetworkService.getInstance().switchNetwork(network);
+        set({ activeNetwork: network, config });
+      },
+    }),
+    {
+      name: "esustellar-network",
+      storage: createJSONStorage(() => AsyncStorage),
+      partialize: (state) => ({ activeNetwork: state.activeNetwork }),
+      onRehydrateStorage: () => (state) => {
+        if (state?.activeNetwork) {
+          // Re-apply persisted network to the service singleton on app start.
+          NetworkService.getInstance().switchNetwork(state.activeNetwork);
+          state.config = NETWORK_CONFIGS[state.activeNetwork];
+        }
+      },
+    },
+  ),
+);


### PR DESCRIPTION
## Summary

- Creates `mobile/services/stellar/network.ts` — `NetworkService` singleton with `switchNetwork()`, listener callbacks, and convenience accessors (`getActiveRpcUrl`, `getActiveHorizonUrl`, `getActiveNetworkPassphrase`)
- Creates `mobile/stores/networkStore.ts` — Zustand store persisted via AsyncStorage; `onRehydrateStorage` re-applies the saved network to the service singleton on app start so all API calls use the correct endpoints immediately
- Creates `mobile/components/NetworkBadge.tsx` — compact badge shown in header on Testnet, invisible on Mainnet

## How to integrate network toggle in Settings
Import `useNetworkStore` and call `switchNetwork('mainnet')` / `switchNetwork('testnet')` from a toggle in `SettingsScreenContent`. Drop `<NetworkBadge />` in the app header.

## Test plan
- [ ] Switching network updates `config.rpcUrl` and `config.horizonUrl`
- [ ] Persisted choice survives app restart (AsyncStorage)
- [ ] NetworkBadge visible on Testnet, hidden on Mainnet
- [ ] All API calls through `getActiveRpcUrl()` hit the correct endpoint

Closes #314