### PR TITLE
feat(sdk): add get_group_count binding for Registry contract

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,12 +1,25 @@
 {
-  "name": "sdk",
+  "name": "@esustellar/sdk",
   "version": "1.0.0",
-  "main": "index.js",
+  "description": "TypeScript SDK for interacting with EsuStellar Soroban smart contracts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "build": "tsc",
+    "test": "jest",
+    "test:coverage": "jest --coverage",
+    "lint": "tsc --noEmit"
   },
-  "keywords": [],
+  "keywords": ["stellar", "soroban", "sdk", "esustellar"],
   "author": "",
-  "license": "ISC",
-  "description": ""
+  "license": "MIT",
+  "dependencies": {
+    "@stellar/stellar-sdk": "^14.4.3"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.12",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.4",
+    "typescript": "^5.3.3"
+  }
 }

--- a/packages/sdk/src/registry/__tests__/get-group-count.test.ts
+++ b/packages/sdk/src/registry/__tests__/get-group-count.test.ts
@@ -1,0 +1,144 @@
+import { getGroupCount, SdkConfig } from "../get-group-count";
+
+jest.mock("@stellar/stellar-sdk", () => {
+  const TransactionBuilderMock: any = jest.fn().mockImplementation(() => ({
+    addOperation: jest.fn().mockReturnThis(),
+    setTimeout: jest.fn().mockReturnThis(),
+    build: jest.fn().mockReturnValue({ toXDR: jest.fn().mockReturnValue("mock-xdr") }),
+  }));
+  TransactionBuilderMock.fromXDR = jest.fn();
+
+  return {
+    Contract: jest.fn().mockImplementation(() => ({
+      call: jest.fn().mockReturnValue("mock-op"),
+    })),
+    Account: jest.fn().mockImplementation(() => ({})),
+    BASE_FEE: "100",
+    TransactionBuilder: TransactionBuilderMock,
+    rpc: {
+      Server: jest.fn(),
+      Api: {
+        isSimulationError: jest.fn(),
+        GetTransactionStatus: { NOT_FOUND: "NOT_FOUND", SUCCESS: "SUCCESS" },
+      },
+    },
+    scValToNative: jest.fn(),
+    nativeToScVal: jest.fn().mockReturnValue("mock-scval"),
+  };
+});
+
+const config: SdkConfig = {
+  contractId: "CREGISTRYCONTRACTID000000000000000000000000000000000000",
+  rpcUrl: "https://soroban-testnet.stellar.org",
+  networkPassphrase: "Test SDF Network ; September 2015",
+};
+
+function getSdk() {
+  return jest.requireMock("@stellar/stellar-sdk") as any;
+}
+
+function makeMockServer(overrides: Record<string, jest.Mock> = {}) {
+  const mockServer = { simulateTransaction: jest.fn(), ...overrides };
+  getSdk().rpc.Server.mockImplementation(() => mockServer);
+  return mockServer;
+}
+
+describe("getGroupCount", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getSdk().rpc.Api.isSimulationError.mockReturnValue(false);
+  });
+
+  it("returns 0 when no groups have been registered", async () => {
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({
+      result: { retval: "mock-retval" },
+    });
+    getSdk().scValToNative.mockReturnValueOnce(0);
+
+    const count = await getGroupCount(config);
+
+    expect(count).toBe(0);
+  });
+
+  it("returns the correct count after one registration", async () => {
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({
+      result: { retval: "mock-retval" },
+    });
+    getSdk().scValToNative.mockReturnValueOnce(1);
+
+    const count = await getGroupCount(config);
+
+    expect(count).toBe(1);
+  });
+
+  it("count increments with each register_group call (simulated via successive calls)", async () => {
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction
+      .mockResolvedValueOnce({ result: { retval: "r1" } })
+      .mockResolvedValueOnce({ result: { retval: "r2" } })
+      .mockResolvedValueOnce({ result: { retval: "r3" } });
+
+    getSdk().scValToNative
+      .mockReturnValueOnce(1)
+      .mockReturnValueOnce(2)
+      .mockReturnValueOnce(3);
+
+    const c1 = await getGroupCount(config);
+    const c2 = await getGroupCount(config);
+    const c3 = await getGroupCount(config);
+
+    expect(c1).toBe(1);
+    expect(c2).toBe(2);
+    expect(c3).toBe(3);
+  });
+
+  it("maps u32 to a JavaScript number", async () => {
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({
+      result: { retval: "mock-retval" },
+    });
+    getSdk().scValToNative.mockReturnValueOnce(42);
+
+    const count = await getGroupCount(config);
+
+    expect(typeof count).toBe("number");
+    expect(count).toBe(42);
+  });
+
+  it("calls get_group_count on the correct contract", async () => {
+    const { Contract } = getSdk();
+    const mockCall = jest.fn().mockReturnValue("mock-op");
+    Contract.mockImplementationOnce(() => ({ call: mockCall }));
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({
+      result: { retval: "mock-retval" },
+    });
+    getSdk().scValToNative.mockReturnValueOnce(5);
+
+    await getGroupCount(config);
+
+    expect(Contract).toHaveBeenCalledWith(config.contractId);
+    expect(mockCall).toHaveBeenCalledWith("get_group_count");
+  });
+
+  it("throws on simulation error", async () => {
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({ error: "HostError" });
+    getSdk().rpc.Api.isSimulationError.mockReturnValueOnce(true);
+
+    await expect(getGroupCount(config)).rejects.toThrow(
+      "Registry contract simulation error: HostError",
+    );
+  });
+
+  it("throws when simulation result is empty", async () => {
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({ result: null });
+
+    await expect(getGroupCount(config)).rejects.toThrow(
+      "Simulation returned empty result",
+    );
+  });
+});

--- a/packages/sdk/src/registry/get-group-count.ts
+++ b/packages/sdk/src/registry/get-group-count.ts
@@ -1,0 +1,70 @@
+import {
+  Contract,
+  scValToNative,
+  TransactionBuilder,
+  BASE_FEE,
+  rpc,
+  Account,
+} from "@stellar/stellar-sdk";
+
+const DUMMY_ACCOUNT =
+  "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+export interface SdkConfig {
+  /** Registry contract ID (Stellar address). */
+  contractId: string;
+  /** Soroban RPC endpoint URL. */
+  rpcUrl: string;
+  /** Network passphrase, e.g. "Test SDF Network ; September 2015". */
+  networkPassphrase: string;
+  /** Optional Stellar address used as the simulation source. Defaults to a dummy account. */
+  sourceAccount?: string;
+}
+
+/**
+ * Returns the total number of groups registered in the Registry contract.
+ * Maps the on-chain `u32` return type to a JavaScript `number`.
+ *
+ * This is a read-only simulation — no transaction is submitted and no auth is required.
+ * The count increments each time `register_group` is successfully called on-chain.
+ *
+ * @throws {Error} If the simulation fails or returns an empty result.
+ *
+ * @example
+ * ```ts
+ * const count = await getGroupCount({
+ *   contractId: "CREGISTRY...",
+ *   rpcUrl: "https://soroban-testnet.stellar.org",
+ *   networkPassphrase: "Test SDF Network ; September 2015",
+ * });
+ * console.log(`${count} groups registered`);
+ * ```
+ */
+export async function getGroupCount(config: SdkConfig): Promise<number> {
+  const { contractId, rpcUrl, networkPassphrase } = config;
+  const source = config.sourceAccount ?? DUMMY_ACCOUNT;
+
+  const server = new rpc.Server(rpcUrl, { allowHttp: true });
+  const contract = new Contract(contractId);
+  const account = new Account(source, "0");
+
+  const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase })
+    .addOperation(contract.call("get_group_count"))
+    .setTimeout(30)
+    .build();
+
+  const result = await server.simulateTransaction(tx as any);
+
+  if (rpc.Api.isSimulationError(result)) {
+    throw new Error(
+      `Registry contract simulation error: ${(result as any).error}`,
+    );
+  }
+
+  const simResult = result as any;
+  if (!("result" in simResult) || simResult.result == null) {
+    throw new Error("Simulation returned empty result");
+  }
+
+  return Number(scValToNative(simResult.result.retval));
+}


### PR DESCRIPTION
## Summary

- Adds `getGroupCount()` SDK binding at `packages/sdk/src/registry/get-group-count.ts`
- Maps on-chain `u32` return type to a JS `number`
- 7 unit tests in `packages/sdk/src/registry/__tests__/get-group-count.test.ts`

## Test plan
- [ ] Returns 0 when no groups registered
- [ ] Returns correct count after registrations
- [ ] Count increments with each `register_group` call (simulated via successive SDK calls)
- [ ] Return value is a JS `number`
- [ ] Simulation error propagated
- [ ] Empty result throws

Closes #370