### PR TITLE
feat(sdk): add get_all_groups binding for Registry contract

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,12 +1,25 @@
 {
-  "name": "sdk",
+  "name": "@esustellar/sdk",
   "version": "1.0.0",
-  "main": "index.js",
+  "description": "TypeScript SDK for interacting with EsuStellar Soroban smart contracts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "build": "tsc",
+    "test": "jest",
+    "test:coverage": "jest --coverage",
+    "lint": "tsc --noEmit"
   },
-  "keywords": [],
+  "keywords": ["stellar", "soroban", "sdk", "esustellar"],
   "author": "",
-  "license": "ISC",
-  "description": ""
+  "license": "MIT",
+  "dependencies": {
+    "@stellar/stellar-sdk": "^14.4.3"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.12",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.4",
+    "typescript": "^5.3.3"
+  }
 }

--- a/packages/sdk/src/registry/__tests__/get-all-groups.test.ts
+++ b/packages/sdk/src/registry/__tests__/get-all-groups.test.ts
@@ -1,0 +1,161 @@
+import { getAllGroups, SdkConfig } from "../get-all-groups";
+
+jest.mock("@stellar/stellar-sdk", () => {
+  const TransactionBuilderMock: any = jest.fn().mockImplementation(() => ({
+    addOperation: jest.fn().mockReturnThis(),
+    setTimeout: jest.fn().mockReturnThis(),
+    build: jest.fn().mockReturnValue({ toXDR: jest.fn().mockReturnValue("mock-xdr") }),
+  }));
+  TransactionBuilderMock.fromXDR = jest.fn();
+
+  return {
+    Contract: jest.fn().mockImplementation(() => ({
+      call: jest.fn().mockReturnValue("mock-op"),
+    })),
+    Account: jest.fn().mockImplementation(() => ({})),
+    BASE_FEE: "100",
+    TransactionBuilder: TransactionBuilderMock,
+    rpc: {
+      Server: jest.fn(),
+      Api: {
+        isSimulationError: jest.fn(),
+        GetTransactionStatus: { NOT_FOUND: "NOT_FOUND", SUCCESS: "SUCCESS" },
+      },
+    },
+    scValToNative: jest.fn(),
+    nativeToScVal: jest.fn().mockReturnValue("mock-scval"),
+  };
+});
+
+const config: SdkConfig = {
+  contractId: "CREGISTRYCONTRACTID000000000000000000000000000000000000",
+  rpcUrl: "https://soroban-testnet.stellar.org",
+  networkPassphrase: "Test SDF Network ; September 2015",
+};
+
+const ADDR1 = "CSAVINGS001000000000000000000000000000000000000000000000";
+const ADDR2 = "CSAVINGS002000000000000000000000000000000000000000000000";
+const ADDR3 = "CSAVINGS003000000000000000000000000000000000000000000000";
+
+function getSdk() {
+  return jest.requireMock("@stellar/stellar-sdk") as any;
+}
+
+function makeMockServer(overrides: Record<string, jest.Mock> = {}) {
+  const mockServer = { simulateTransaction: jest.fn(), ...overrides };
+  getSdk().rpc.Server.mockImplementation(() => mockServer);
+  return mockServer;
+}
+
+describe("getAllGroups", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getSdk().rpc.Api.isSimulationError.mockReturnValue(false);
+  });
+
+  it("returns an empty array when no groups are registered", async () => {
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({
+      result: { retval: "mock-retval" },
+    });
+    getSdk().scValToNative.mockReturnValueOnce([]);
+
+    const result = await getAllGroups(config);
+
+    expect(result).toEqual([]);
+  });
+
+  it("returns a list of contract addresses for registered groups", async () => {
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({
+      result: { retval: "mock-retval" },
+    });
+    getSdk().scValToNative.mockReturnValueOnce([ADDR1, ADDR2]);
+
+    const result = await getAllGroups(config);
+
+    expect(result).toEqual([ADDR1, ADDR2]);
+  });
+
+  it("list grows after each register_group call (simulated via successive calls)", async () => {
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction
+      .mockResolvedValueOnce({ result: { retval: "r1" } })
+      .mockResolvedValueOnce({ result: { retval: "r2" } })
+      .mockResolvedValueOnce({ result: { retval: "r3" } });
+
+    getSdk().scValToNative
+      .mockReturnValueOnce([ADDR1])
+      .mockReturnValueOnce([ADDR1, ADDR2])
+      .mockReturnValueOnce([ADDR1, ADDR2, ADDR3]);
+
+    const list1 = await getAllGroups(config);
+    const list2 = await getAllGroups(config);
+    const list3 = await getAllGroups(config);
+
+    expect(list1).toHaveLength(1);
+    expect(list2).toHaveLength(2);
+    expect(list3).toHaveLength(3);
+    expect(list3).toContain(ADDR3);
+  });
+
+  it("includes both public and private group addresses", async () => {
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({
+      result: { retval: "mock-retval" },
+    });
+    getSdk().scValToNative.mockReturnValueOnce([ADDR1, ADDR2]);
+
+    const result = await getAllGroups(config);
+
+    // Both addresses returned — public/private distinction is not filtered here
+    expect(result).toHaveLength(2);
+  });
+
+  it("maps Address values to strings", async () => {
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({
+      result: { retval: "mock-retval" },
+    });
+    getSdk().scValToNative.mockReturnValueOnce([ADDR1]);
+
+    const result = await getAllGroups(config);
+
+    expect(typeof result[0]).toBe("string");
+  });
+
+  it("calls get_all_groups on the correct contract", async () => {
+    const { Contract } = getSdk();
+    const mockCall = jest.fn().mockReturnValue("mock-op");
+    Contract.mockImplementationOnce(() => ({ call: mockCall }));
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({
+      result: { retval: "mock-retval" },
+    });
+    getSdk().scValToNative.mockReturnValueOnce([]);
+
+    await getAllGroups(config);
+
+    expect(Contract).toHaveBeenCalledWith(config.contractId);
+    expect(mockCall).toHaveBeenCalledWith("get_all_groups");
+  });
+
+  it("throws on simulation error", async () => {
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({ error: "HostError" });
+    getSdk().rpc.Api.isSimulationError.mockReturnValueOnce(true);
+
+    await expect(getAllGroups(config)).rejects.toThrow(
+      "Registry contract simulation error: HostError",
+    );
+  });
+
+  it("throws when simulation result is empty", async () => {
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({ result: null });
+
+    await expect(getAllGroups(config)).rejects.toThrow(
+      "Simulation returned empty result",
+    );
+  });
+});

--- a/packages/sdk/src/registry/get-all-groups.ts
+++ b/packages/sdk/src/registry/get-all-groups.ts
@@ -1,0 +1,73 @@
+import {
+  Contract,
+  scValToNative,
+  TransactionBuilder,
+  BASE_FEE,
+  rpc,
+  Account,
+} from "@stellar/stellar-sdk";
+
+const DUMMY_ACCOUNT =
+  "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+export interface SdkConfig {
+  /** Registry contract ID (Stellar address). */
+  contractId: string;
+  /** Soroban RPC endpoint URL. */
+  rpcUrl: string;
+  /** Network passphrase, e.g. "Test SDF Network ; September 2015". */
+  networkPassphrase: string;
+  /** Optional Stellar address used as the simulation source. Defaults to a dummy account. */
+  sourceAccount?: string;
+}
+
+/**
+ * Returns all registered group contract addresses (both public and private).
+ * Maps the on-chain `Vec<Address>` return type to a `string[]`.
+ *
+ * This is a read-only simulation — no transaction is submitted and no auth is required.
+ * The returned list grows by one each time `register_group` is successfully called.
+ *
+ * For public-only groups use `getAllPublicGroups`. For full metadata use `getAllGroupsInfo`.
+ *
+ * @throws {Error} If the simulation fails or returns an empty result.
+ *
+ * @example
+ * ```ts
+ * const addresses = await getAllGroups({
+ *   contractId: "CREGISTRY...",
+ *   rpcUrl: "https://soroban-testnet.stellar.org",
+ *   networkPassphrase: "Test SDF Network ; September 2015",
+ * });
+ * console.log(addresses[0]); // "CSAVINGSCONTRACT..."
+ * ```
+ */
+export async function getAllGroups(config: SdkConfig): Promise<string[]> {
+  const { contractId, rpcUrl, networkPassphrase } = config;
+  const source = config.sourceAccount ?? DUMMY_ACCOUNT;
+
+  const server = new rpc.Server(rpcUrl, { allowHttp: true });
+  const contract = new Contract(contractId);
+  const account = new Account(source, "0");
+
+  const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase })
+    .addOperation(contract.call("get_all_groups"))
+    .setTimeout(30)
+    .build();
+
+  const result = await server.simulateTransaction(tx as any);
+
+  if (rpc.Api.isSimulationError(result)) {
+    throw new Error(
+      `Registry contract simulation error: ${(result as any).error}`,
+    );
+  }
+
+  const simResult = result as any;
+  if (!simResult.result?.retval) {
+    throw new Error("Simulation returned empty result");
+  }
+
+  const raw = scValToNative(simResult.result.retval) as string[];
+  return raw.map(String);
+}


### PR DESCRIPTION
## Summary

- Adds `getAllGroups()` SDK binding at `packages/sdk/src/registry/get-all-groups.ts`
- Maps `Vec<Address>` return type to `string[]` — includes both public and private groups
- 8 unit tests assert empty list, list growth after registrations, string type, and error handling

Closes #371