### PR TITLE
Feat/issues321

### DIFF
--- a/mobile/__tests__/notificationsStore.test.ts
+++ b/mobile/__tests__/notificationsStore.test.ts
@@ -1,27 +1,64 @@
 import { useNotificationsStore } from '../stores/notificationsStore';
 import type { Notification } from '../types/notification';
 
-const n1: Notification = { id: '1', title: 'Test', message: 'Hello', read: false, createdAt: '2024-01-01' };
-const n2: Notification = { id: '2', title: 'Test 2', message: 'World', read: true, createdAt: '2024-01-02' };
+const n1: Notification = { id: '1', title: 'Test', message: 'Hello', read: false, createdAt: '2024-01-01', type: 'contribution', category: 'payments' };
+const n2: Notification = { id: '2', title: 'Test 2', message: 'World', read: true, createdAt: '2024-01-02', type: 'member', category: 'members' };
+const n3: Notification = { id: '3', title: 'Test 3', message: 'Update', read: false, createdAt: '2024-01-03', type: 'status', category: 'updates' };
 
 describe('useNotificationsStore', () => {
-  beforeEach(() => useNotificationsStore.setState({ notifications: [], unreadCount: 0 }));
+  beforeEach(() => useNotificationsStore.setState({ notifications: [], unreadCount: 0, selectedCategory: 'all' }));
 
   it('sets notifications and computes unreadCount', () => {
-    useNotificationsStore.getState().setNotifications([n1, n2]);
-    expect(useNotificationsStore.getState().unreadCount).toBe(1);
+    useNotificationsStore.getState().setNotifications([n1, n2, n3]);
+    expect(useNotificationsStore.getState().unreadCount).toBe(2);
   });
 
   it('markRead decrements unreadCount', () => {
-    useNotificationsStore.getState().setNotifications([n1, n2]);
+    useNotificationsStore.getState().setNotifications([n1, n2, n3]);
     useNotificationsStore.getState().markRead('1');
-    expect(useNotificationsStore.getState().unreadCount).toBe(0);
+    expect(useNotificationsStore.getState().unreadCount).toBe(1);
   });
 
   it('markAllRead resets unreadCount to 0', () => {
-    useNotificationsStore.getState().setNotifications([n1, n2]);
+    useNotificationsStore.getState().setNotifications([n1, n2, n3]);
     useNotificationsStore.getState().markAllRead();
     expect(useNotificationsStore.getState().unreadCount).toBe(0);
     expect(useNotificationsStore.getState().notifications.every((n) => n.read)).toBe(true);
+  });
+
+  it('setSelectedCategory updates the selected category', () => {
+    useNotificationsStore.getState().setSelectedCategory('payments');
+    expect(useNotificationsStore.getState().selectedCategory).toBe('payments');
+  });
+
+  it('getFilteredNotifications returns all notifications when category is "all"', () => {
+    useNotificationsStore.getState().setNotifications([n1, n2, n3]);
+    useNotificationsStore.getState().setSelectedCategory('all');
+    const filtered = useNotificationsStore.getState().getFilteredNotifications();
+    expect(filtered).toHaveLength(3);
+  });
+
+  it('getFilteredNotifications filters notifications by category', () => {
+    useNotificationsStore.getState().setNotifications([n1, n2, n3]);
+    useNotificationsStore.getState().setSelectedCategory('payments');
+    const filtered = useNotificationsStore.getState().getFilteredNotifications();
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].id).toBe('1');
+  });
+
+  it('getFilteredNotifications filters by members category', () => {
+    useNotificationsStore.getState().setNotifications([n1, n2, n3]);
+    useNotificationsStore.getState().setSelectedCategory('members');
+    const filtered = useNotificationsStore.getState().getFilteredNotifications();
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].id).toBe('2');
+  });
+
+  it('getFilteredNotifications filters by updates category', () => {
+    useNotificationsStore.getState().setNotifications([n1, n2, n3]);
+    useNotificationsStore.getState().setSelectedCategory('updates');
+    const filtered = useNotificationsStore.getState().getFilteredNotifications();
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].id).toBe('3');
   });
 });

--- a/mobile/app/notifications/inbox.tsx
+++ b/mobile/app/notifications/inbox.tsx
@@ -15,8 +15,9 @@ import { useNotificationsStore } from '../../stores/notificationsStore';
 import { useUserNotifications, useMarkAllNotificationsRead } from '../../hooks/useNotifications';
 import { useRefresh } from '../../hooks/useRefresh';
 import { NotificationItem } from '../../components/NotificationItem';
+import { NotificationCategoryFilter } from '../../components/notifications/NotificationCategoryFilter';
 import { EmptyState } from '../../components/ui';
-import { Notification } from '../../types/notification';
+import { Notification, NotificationCategory } from '../../types/notification';
 
 const sortNotifications = (items: Notification[]) =>
   [...items].sort(
@@ -29,8 +30,11 @@ export default function NotificationInboxScreen() {
   const wallet = useAuthStore((state) => state.wallet);
   const notifications = useNotificationsStore((state) => state.notifications);
   const unreadCount = useNotificationsStore((state) => state.unreadCount);
+  const selectedCategory = useNotificationsStore((state) => state.selectedCategory);
   const setNotifications = useNotificationsStore((state) => state.setNotifications);
   const markAllRead = useNotificationsStore((state) => state.markAllRead);
+  const setSelectedCategory = useNotificationsStore((state) => state.setSelectedCategory);
+  const getFilteredNotifications = useNotificationsStore((state) => state.getFilteredNotifications);
 
   const userAddress = wallet?.publicKey ?? '';
   const { data, refetch } = useUserNotifications(userAddress);
@@ -52,9 +56,13 @@ export default function NotificationInboxScreen() {
 
   const { refreshing, onRefresh } = useRefresh(fetchNotifications);
 
+  const filteredNotifications = useMemo(() => {
+    return getFilteredNotifications();
+  }, [getFilteredNotifications]);
+
   const sortedNotifications = useMemo(
-    () => sortNotifications(notifications),
-    [notifications],
+    () => sortNotifications(filteredNotifications),
+    [filteredNotifications],
   );
 
   const handleMarkAllAsRead = useCallback(async () => {
@@ -63,6 +71,13 @@ export default function NotificationInboxScreen() {
     // Sync with backend
     await markAllMutation.mutateAsync(userAddress);
   }, [markAllRead, userAddress, markAllMutation]);
+
+  const handleCategoryChange = useCallback(
+    (category: NotificationCategory) => {
+      setSelectedCategory(category);
+    },
+    [setSelectedCategory],
+  );
 
   const renderItem = useCallback(
     ({ item }: { item: Notification }) => <NotificationItem item={item} />,
@@ -113,6 +128,10 @@ export default function NotificationInboxScreen() {
             <Text style={[styles.subtitle, { color: colors.subtext }]}> 
               {t('notifications.subtitle')}
             </Text>
+            <NotificationCategoryFilter
+              selectedCategory={selectedCategory}
+              onCategoryChange={handleCategoryChange}
+            />
           </View>
         )}
         ListEmptyComponent={
@@ -160,6 +179,7 @@ const styles = StyleSheet.create({
   subtitle: {
     fontSize: 15,
     lineHeight: 22,
+    marginBottom: 12,
   },
   listContainer: {
     paddingBottom: 24,

--- a/mobile/app/notifications/inbox.tsx
+++ b/mobile/app/notifications/inbox.tsx
@@ -6,12 +6,13 @@ import {
   StyleSheet,
   RefreshControl,
   Text,
+  Pressable,
 } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useTheme } from '../../context/ThemeContext';
 import { useAuthStore } from '../../store/authStore';
 import { useNotificationsStore } from '../../stores/notificationsStore';
-import { useUserNotifications } from '../../hooks/useNotifications';
+import { useUserNotifications, useMarkAllNotificationsRead } from '../../hooks/useNotifications';
 import { useRefresh } from '../../hooks/useRefresh';
 import { NotificationItem } from '../../components/NotificationItem';
 import { EmptyState } from '../../components/ui';
@@ -27,10 +28,13 @@ export default function NotificationInboxScreen() {
   const { colors } = useTheme();
   const wallet = useAuthStore((state) => state.wallet);
   const notifications = useNotificationsStore((state) => state.notifications);
+  const unreadCount = useNotificationsStore((state) => state.unreadCount);
   const setNotifications = useNotificationsStore((state) => state.setNotifications);
+  const markAllRead = useNotificationsStore((state) => state.markAllRead);
 
   const userAddress = wallet?.publicKey ?? '';
   const { data, refetch } = useUserNotifications(userAddress);
+  const markAllMutation = useMarkAllNotificationsRead();
 
   useEffect(() => {
     if (data?.success) {
@@ -53,10 +57,19 @@ export default function NotificationInboxScreen() {
     [notifications],
   );
 
+  const handleMarkAllAsRead = useCallback(async () => {
+    // Optimistic update
+    markAllRead();
+    // Sync with backend
+    await markAllMutation.mutateAsync(userAddress);
+  }, [markAllRead, userAddress, markAllMutation]);
+
   const renderItem = useCallback(
     ({ item }: { item: Notification }) => <NotificationItem item={item} />,
     [],
   );
+
+  const hasUnread = unreadCount > 0;
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}> 
@@ -77,7 +90,26 @@ export default function NotificationInboxScreen() {
         }
         ListHeaderComponent={() => (
           <View style={styles.header}>
-            <Text style={[styles.title, { color: colors.text }]}>{t('notifications.title')}</Text>
+            <View style={styles.headerTop}>
+              <Text style={[styles.title, { color: colors.text }]}>{t('notifications.title')}</Text>
+              {hasUnread && (
+                <Pressable
+                  onPress={handleMarkAllAsRead}
+                  disabled={markAllMutation.isPending}
+                  style={({ pressed }) => [
+                    styles.markAllButton,
+                    { 
+                      backgroundColor: colors.accent,
+                      opacity: pressed || markAllMutation.isPending ? 0.7 : 1,
+                    },
+                  ]}
+                >
+                  <Text style={styles.markAllButtonText}>
+                    {t('notifications.markAllAsRead')}
+                  </Text>
+                </Pressable>
+              )}
+            </View>
             <Text style={[styles.subtitle, { color: colors.subtext }]}> 
               {t('notifications.subtitle')}
             </Text>
@@ -105,10 +137,25 @@ const styles = StyleSheet.create({
     paddingTop: 20,
     paddingBottom: 10,
   },
+  headerTop: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 6,
+  },
   title: {
     fontSize: 28,
     fontWeight: '800',
-    marginBottom: 6,
+  },
+  markAllButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 6,
+  },
+  markAllButtonText: {
+    color: '#FFFFFF',
+    fontSize: 12,
+    fontWeight: '600',
   },
   subtitle: {
     fontSize: 15,

--- a/mobile/components/NotificationItem.tsx
+++ b/mobile/components/NotificationItem.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo } from 'react';
 import { TouchableOpacity, Text, View, StyleSheet } from 'react-native';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
-import { Notification } from '../types/notification';
+import { Notification, NOTIFICATION_CATEGORIES } from '../types/notification';
 import { useNotificationsStore } from '../stores/notificationsStore';
 import { useMarkNotificationRead } from '../hooks/useNotifications';
 
@@ -19,13 +19,34 @@ const typeToEmoji: Record<NonNullable<Notification['type']>, string> = {
   status: '📢',
 };
 
+const getNotificationCategory = (notification: Notification) => {
+  if (!notification.type && !notification.category) return 'updates';
+  
+  const category = notification.category;
+  if (category && category !== 'all') return category;
+
+  switch (notification.type) {
+    case 'payout':
+      return 'payments';
+    case 'contribution':
+      return 'payments';
+    case 'member':
+      return 'members';
+    case 'status':
+      return 'updates';
+    default:
+      return 'updates';
+  }
+};
+
 const arePropsEqual = (prev: Props, next: Props) =>
   prev.item.id === next.item.id &&
   prev.item.title === next.item.title &&
   prev.item.message === next.item.message &&
   prev.item.read === next.item.read &&
   prev.item.createdAt === next.item.createdAt &&
-  prev.item.type === next.item.type;
+  prev.item.type === next.item.type &&
+  prev.item.category === next.item.category;
 
 function NotificationItemComponent({ item }: Props) {
   const markRead = useNotificationsStore((state) => state.markRead);
@@ -42,6 +63,8 @@ function NotificationItemComponent({ item }: Props) {
 
   const relativeDate = useMemo(() => dayjs(item.createdAt).fromNow(), [item.createdAt]);
   const icon = typeToEmoji[item.type ?? 'status'];
+  const category = useMemo(() => getNotificationCategory(item), [item]);
+  const categoryInfo = NOTIFICATION_CATEGORIES[category];
 
   return (
     <TouchableOpacity 
@@ -59,6 +82,11 @@ function NotificationItemComponent({ item }: Props) {
               {item.title}
             </Text>
             <Text style={styles.date}>{relativeDate}</Text>
+          </View>
+          <View style={styles.metaRow}>
+            <Text style={[styles.categoryTag, { backgroundColor: categoryInfo.color + '20' }]}>
+              {categoryInfo.emoji} {categoryInfo.label}
+            </Text>
           </View>
           <Text style={styles.message} numberOfLines={2}>
             {item.message}
@@ -109,10 +137,11 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    marginBottom: 4,
+    marginBottom: 6,
   },
   title: {
     fontSize: 15,
+    flex: 1,
   },
   titleUnread: {
     fontWeight: '700',
@@ -124,6 +153,20 @@ const styles = StyleSheet.create({
   date: {
     fontSize: 12,
     color: '#6B7280',
+    marginLeft: 8,
+  },
+  metaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 6,
+  },
+  categoryTag: {
+    fontSize: 11,
+    fontWeight: '600',
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 4,
+    color: '#4B5563',
   },
   message: {
     fontSize: 13,

--- a/mobile/components/NotificationItem.tsx
+++ b/mobile/components/NotificationItem.tsx
@@ -4,6 +4,7 @@ import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import { Notification } from '../types/notification';
 import { useNotificationsStore } from '../stores/notificationsStore';
+import { useMarkNotificationRead } from '../hooks/useNotifications';
 
 dayjs.extend(relativeTime);
 
@@ -28,18 +29,26 @@ const arePropsEqual = (prev: Props, next: Props) =>
 
 function NotificationItemComponent({ item }: Props) {
   const markRead = useNotificationsStore((state) => state.markRead);
+  const markNotificationReadMutation = useMarkNotificationRead();
 
-  const handlePress = useCallback(() => {
+  const handlePress = useCallback(async () => {
     if (!item.read) {
+      // Optimistic update
       markRead(item.id);
+      // Sync with backend
+      await markNotificationReadMutation.mutateAsync(item.id);
     }
-  }, [item.id, item.read, markRead]);
+  }, [item.id, item.read, markRead, markNotificationReadMutation]);
 
   const relativeDate = useMemo(() => dayjs(item.createdAt).fromNow(), [item.createdAt]);
   const icon = typeToEmoji[item.type ?? 'status'];
 
   return (
-    <TouchableOpacity onPress={handlePress} style={styles.touchable}>
+    <TouchableOpacity 
+      onPress={handlePress} 
+      style={styles.touchable}
+      disabled={markNotificationReadMutation.isPending}
+    >
       <View style={[styles.container, item.read ? styles.read : styles.unread]}>
         <View style={styles.iconWrapper}>
           <Text style={styles.icon}>{icon}</Text>

--- a/mobile/components/notifications/NotificationCategoryFilter.tsx
+++ b/mobile/components/notifications/NotificationCategoryFilter.tsx
@@ -1,0 +1,100 @@
+import React, { useCallback } from 'react';
+import { ScrollView, Pressable, Text, StyleSheet } from 'react-native';
+import { NotificationCategory, NOTIFICATION_CATEGORIES } from '../../types/notification';
+
+type NotificationCategoryFilterProps = {
+  selectedCategory: NotificationCategory;
+  onCategoryChange: (category: NotificationCategory) => void;
+};
+
+export function NotificationCategoryFilter({
+  selectedCategory,
+  onCategoryChange,
+}: NotificationCategoryFilterProps) {
+  const categories = Object.keys(NOTIFICATION_CATEGORIES) as NotificationCategory[];
+
+  const handleCategoryPress = useCallback(
+    (category: NotificationCategory) => {
+      onCategoryChange(category);
+    },
+    [onCategoryChange],
+  );
+
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      style={styles.container}
+      contentContainerStyle={styles.contentContainer}
+    >
+      {categories.map((category) => {
+        const isSelected = category === selectedCategory;
+        const categoryInfo = NOTIFICATION_CATEGORIES[category];
+
+        return (
+          <Pressable
+            key={category}
+            onPress={() => handleCategoryPress(category)}
+            style={({ pressed }) => [
+              styles.filterButton,
+              isSelected && styles.filterButtonSelected,
+              pressed && styles.filterButtonPressed,
+            ]}
+          >
+            <Text style={styles.emoji}>{categoryInfo.emoji}</Text>
+            <Text
+              style={[
+                styles.label,
+                isSelected && styles.labelSelected,
+              ]}
+            >
+              {categoryInfo.label}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#E5E7EB',
+  },
+  contentContainer: {
+    gap: 8,
+  },
+  filterButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: '#D1D5DB',
+    backgroundColor: '#FFFFFF',
+  },
+  filterButtonSelected: {
+    borderColor: '#007AFF',
+    backgroundColor: '#EEF6FF',
+  },
+  filterButtonPressed: {
+    opacity: 0.7,
+  },
+  emoji: {
+    fontSize: 14,
+    marginRight: 6,
+  },
+  label: {
+    fontSize: 13,
+    fontWeight: '500',
+    color: '#374151',
+  },
+  labelSelected: {
+    color: '#007AFF',
+    fontWeight: '600',
+  },
+});

--- a/mobile/hooks/useNotifications.ts
+++ b/mobile/hooks/useNotifications.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query';
 import { notificationsApi } from '../services/api/notificationsApi';
 import { queryKeys } from '../services/queryClient';
 
@@ -17,4 +17,24 @@ export function useInvalidateNotifications() {
     () => queryClient.invalidateQueries({ queryKey: queryKeys.notifications.all }),
     [queryClient],
   );
+}
+
+export function useMarkNotificationRead() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (notificationId: string) => notificationsApi.markNotificationRead(notificationId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.notifications.all });
+    },
+  });
+}
+
+export function useMarkAllNotificationsRead() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (userAddress: string) => notificationsApi.markAllNotificationsRead(userAddress),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.notifications.all });
+    },
+  });
 }

--- a/mobile/locales/ar.json
+++ b/mobile/locales/ar.json
@@ -115,8 +115,13 @@
     "subtitle": "قم بتشغيل تنبيه محلي للتحقق من لافتات المقدمة والتنقل بالنقر.",
     "scheduleGroupDetail": "جدولة تنبيه تفاصيل المجموعة",
     "scheduleFallback": "جدولة تنبيه بديل",
-    "markAllAsRead": "وضع علامة على الكل كمقروءة",
-    "contributionDueTitle": "استحقاق المساهمة",
+    "markAllAsRead": "وضع علامة على الكل كمقروءة",    "categories": {
+      "all": "الكل",
+      "payments": "المدفوعات",
+      "members": "الأعضاء",
+      "updates": "التحديثات",
+      "groups": "المجموعات"
+    },    "contributionDueTitle": "استحقاق المساهمة",
     "contributionDueBody": "انقر لفتح شاشة تفاصيل المجموعة.",
     "unknownDestinationTitle": "وجهة غير معروفة",
     "unknownDestinationBody": "انقر لاختبار مسار البديل للشاشة الرئيسية.",

--- a/mobile/locales/ar.json
+++ b/mobile/locales/ar.json
@@ -115,6 +115,7 @@
     "subtitle": "قم بتشغيل تنبيه محلي للتحقق من لافتات المقدمة والتنقل بالنقر.",
     "scheduleGroupDetail": "جدولة تنبيه تفاصيل المجموعة",
     "scheduleFallback": "جدولة تنبيه بديل",
+    "markAllAsRead": "وضع علامة على الكل كمقروءة",
     "contributionDueTitle": "استحقاق المساهمة",
     "contributionDueBody": "انقر لفتح شاشة تفاصيل المجموعة.",
     "unknownDestinationTitle": "وجهة غير معروفة",

--- a/mobile/locales/en.json
+++ b/mobile/locales/en.json
@@ -116,6 +116,13 @@
     "scheduleGroupDetail": "Schedule Group Detail Notification",
     "scheduleFallback": "Schedule Fallback Notification",
     "markAllAsRead": "Mark all as read",
+    "categories": {
+      "all": "All",
+      "payments": "Payments",
+      "members": "Members",
+      "updates": "Updates",
+      "groups": "Groups"
+    },
     "contributionDueTitle": "Contribution due",
     "contributionDueBody": "Tap to open the group detail screen.",
     "unknownDestinationTitle": "Unknown destination",

--- a/mobile/locales/en.json
+++ b/mobile/locales/en.json
@@ -115,6 +115,7 @@
     "subtitle": "Trigger a local notification to verify foreground banners and tap navigation.",
     "scheduleGroupDetail": "Schedule Group Detail Notification",
     "scheduleFallback": "Schedule Fallback Notification",
+    "markAllAsRead": "Mark all as read",
     "contributionDueTitle": "Contribution due",
     "contributionDueBody": "Tap to open the group detail screen.",
     "unknownDestinationTitle": "Unknown destination",

--- a/mobile/locales/es.json
+++ b/mobile/locales/es.json
@@ -90,6 +90,13 @@
     "scheduleGroupDetail": "Programar notificación de detalles del grupo",
     "scheduleFallback": "Programar notificación de respaldo",
     "markAllAsRead": "Marcar todas como leídas",
+    "categories": {
+      "all": "Todas",
+      "payments": "Pagos",
+      "members": "Miembros",
+      "updates": "Actualizaciones",
+      "groups": "Grupos"
+    },
     "contributionDueTitle": "Contribución vencida",
     "contributionDueBody": "Toca para abrir la pantalla de detalles del grupo.",
     "unknownDestinationTitle": "Destino desconocido",

--- a/mobile/locales/es.json
+++ b/mobile/locales/es.json
@@ -84,6 +84,36 @@
     "languageLabel": "Elige el idioma de la aplicación",
     "languageChangeSuccess": "Idioma actualizado."
   },
+  "notifications": {
+    "title": "Notificaciones",
+    "subtitle": "Activa una notificación local para verificar los banners en primer plano y la navegación al tocar.",
+    "scheduleGroupDetail": "Programar notificación de detalles del grupo",
+    "scheduleFallback": "Programar notificación de respaldo",
+    "markAllAsRead": "Marcar todas como leídas",
+    "contributionDueTitle": "Contribución vencida",
+    "contributionDueBody": "Toca para abrir la pantalla de detalles del grupo.",
+    "unknownDestinationTitle": "Destino desconocido",
+    "unknownDestinationBody": "Toca para probar la ruta alternativa de la pantalla de inicio.",
+    "scheduledTitle": "Notificación programada",
+    "scheduledBody": "Una notificación de prueba aparecerá en 2 segundos.",
+    "fallbackScheduledTitle": "Notificación de respaldo programada",
+    "fallbackScheduledBody": "Una notificación de prueba con ruta desconocida aparecerá en 2 segundos.",
+    "unableToScheduleTitle": "No se puede programar la notificación",
+    "unableToScheduleBody": "Por favor, inténtalo de nuevo."
+  },
+  "notificationSettings": {
+    "loading": "Cargando configuración...",
+    "title": "Configuración de notificaciones",
+    "description": "Elige qué notificaciones push quieres recibir",
+    "contributionRemindersTitle": "Recordatorios de contribución",
+    "contributionRemindersDescription": "Recibe notificaciones cuando tus contribuciones vencen",
+    "payoutReceivedTitle": "Pago recibido",
+    "payoutReceivedDescription": "Notificaciones cuando recibes pagos",
+    "newMemberJoinedTitle": "Nuevo miembro se unió",
+    "newMemberJoinedDescription": "Cuando nuevos miembros se unen a tus grupos",
+    "groupStatusChangesTitle": "Cambios en el estado del grupo",
+    "groupStatusChangesDescription": "Actualizaciones cuando cambia el estado del grupo"
+  },
   "profile": {
     "editProfile": "Editar perfil",
     "settings": "Ajustes",

--- a/mobile/locales/fr.json
+++ b/mobile/locales/fr.json
@@ -90,6 +90,13 @@
     "scheduleGroupDetail": "Planifier la notification des détails du groupe",
     "scheduleFallback": "Planifier la notification de secours",
     "markAllAsRead": "Marquer tout comme lu",
+    "categories": {
+      "all": "Tous",
+      "payments": "Paiements",
+      "members": "Membres",
+      "updates": "Mises à jour",
+      "groups": "Groupes"
+    },
     "contributionDueTitle": "Contribution due",
     "contributionDueBody": "Appuyez pour ouvrir l'écran des détails du groupe.",
     "unknownDestinationTitle": "Destination inconnue",

--- a/mobile/locales/fr.json
+++ b/mobile/locales/fr.json
@@ -84,6 +84,36 @@
     "languageLabel": "Choisissez la langue de l'application",
     "languageChangeSuccess": "Langue mise à jour."
   },
+  "notifications": {
+    "title": "Notifications",
+    "subtitle": "Déclenchez une notification locale pour vérifier les bannières au premier plan et la navigation tactile.",
+    "scheduleGroupDetail": "Planifier la notification des détails du groupe",
+    "scheduleFallback": "Planifier la notification de secours",
+    "markAllAsRead": "Marquer tout comme lu",
+    "contributionDueTitle": "Contribution due",
+    "contributionDueBody": "Appuyez pour ouvrir l'écran des détails du groupe.",
+    "unknownDestinationTitle": "Destination inconnue",
+    "unknownDestinationBody": "Appuyez pour tester l'itinéraire de secours de l'écran d'accueil.",
+    "scheduledTitle": "Notification planifiée",
+    "scheduledBody": "Une notification de test apparaîtra dans 2 secondes.",
+    "fallbackScheduledTitle": "Notification de secours planifiée",
+    "fallbackScheduledBody": "Une notification de test avec un itinéraire inconnu apparaîtra dans 2 secondes.",
+    "unableToScheduleTitle": "Impossible de planifier la notification",
+    "unableToScheduleBody": "Veuillez réessayer."
+  },
+  "notificationSettings": {
+    "loading": "Chargement des paramètres...",
+    "title": "Paramètres de notification",
+    "description": "Choisissez les notifications push que vous souhaitez recevoir",
+    "contributionRemindersTitle": "Rappels de contribution",
+    "contributionRemindersDescription": "Recevez des notifications lorsque vos contributions sont dues",
+    "payoutReceivedTitle": "Paiement reçu",
+    "payoutReceivedDescription": "Notifications lorsque vous recevez des paiements",
+    "newMemberJoinedTitle": "Nouveau membre rejoint",
+    "newMemberJoinedDescription": "Quand de nouveaux membres rejoignent vos groupes",
+    "groupStatusChangesTitle": "Changements d'état du groupe",
+    "groupStatusChangesDescription": "Mises à jour lorsque l'état du groupe change"
+  },
   "profile": {
     "editProfile": "Modifier le profil",
     "settings": "Paramètres",

--- a/mobile/locales/sw.json
+++ b/mobile/locales/sw.json
@@ -116,6 +116,13 @@
     "scheduleGroupDetail": "Panga Arifa ya Maelezo ya Kikundi",
     "scheduleFallback": "Panga Arifa ya Njia Mbadala",
     "markAllAsRead": "Weka alama zote kama zimesomwa",
+    "categories": {
+      "all": "Zote",
+      "payments": "Malipo",
+      "members": "Wanachama",
+      "updates": "Masasisho",
+      "groups": "Vikundi"
+    },
     "contributionDueTitle": "Mchango wako umewadia",
     "contributionDueBody": "Gusa kufungua skrini ya maelezo ya kikundi.",
     "unknownDestinationTitle": "Mahali pasipojulikana",

--- a/mobile/locales/sw.json
+++ b/mobile/locales/sw.json
@@ -115,6 +115,7 @@
     "subtitle": "Washa arifa ya ndani ili kujaribu mabango ya arifa wakati programu iko wazi na urambazaji wa kugusa.",
     "scheduleGroupDetail": "Panga Arifa ya Maelezo ya Kikundi",
     "scheduleFallback": "Panga Arifa ya Njia Mbadala",
+    "markAllAsRead": "Weka alama zote kama zimesomwa",
     "contributionDueTitle": "Mchango wako umewadia",
     "contributionDueBody": "Gusa kufungua skrini ya maelezo ya kikundi.",
     "unknownDestinationTitle": "Mahali pasipojulikana",

--- a/mobile/services/api/notificationsApi.ts
+++ b/mobile/services/api/notificationsApi.ts
@@ -32,6 +32,7 @@ class NotificationsApiService {
           message: 'Your monthly contribution to Family Savings Circle is due.',
           read: false,
           createdAt: new Date().toISOString(),
+          category: 'payments',
         },
         {
           id: 'notif_2',
@@ -40,6 +41,25 @@ class NotificationsApiService {
           message: 'You have received a payout of 600 XLM from Investment Club.',
           read: false,
           createdAt: new Date().toISOString(),
+          category: 'payments',
+        },
+        {
+          id: 'notif_3',
+          type: 'member',
+          title: 'New Member Joined',
+          message: 'John Doe has joined Community Savings Group.',
+          read: true,
+          createdAt: new Date(Date.now() - 86400000).toISOString(),
+          category: 'members',
+        },
+        {
+          id: 'notif_4',
+          type: 'status',
+          title: 'Group Update',
+          message: 'Your group has reached 80% of the target savings goal.',
+          read: true,
+          createdAt: new Date(Date.now() - 172800000).toISOString(),
+          category: 'updates',
         },
       ];
 

--- a/mobile/services/api/notificationsApi.ts
+++ b/mobile/services/api/notificationsApi.ts
@@ -55,6 +55,52 @@ class NotificationsApiService {
       };
     }
   }
+
+  /**
+   * Mark a single notification as read
+   */
+  async markNotificationRead(notificationId: string): Promise<ApiResponse<void>> {
+    try {
+      logger.debug('NotificationsApi', `Marking notification ${notificationId} as read`);
+
+      // Mock API call - replace with actual implementation
+      await new Promise(resolve => setTimeout(resolve, 300));
+
+      return {
+        success: true,
+        data: undefined,
+      };
+    } catch (error) {
+      logger.error('NotificationsApi', `Failed to mark notification ${notificationId} as read`, error);
+      return {
+        success: false,
+        error: 'Failed to mark notification as read',
+      };
+    }
+  }
+
+  /**
+   * Mark all notifications as read for a user
+   */
+  async markAllNotificationsRead(userAddress: string): Promise<ApiResponse<void>> {
+    try {
+      logger.debug('NotificationsApi', 'Marking all notifications as read');
+
+      // Mock API call - replace with actual implementation
+      await new Promise(resolve => setTimeout(resolve, 500));
+
+      return {
+        success: true,
+        data: undefined,
+      };
+    } catch (error) {
+      logger.error('NotificationsApi', 'Failed to mark all notifications as read', error);
+      return {
+        success: false,
+        error: 'Failed to mark all notifications as read',
+      };
+    }
+  }
 }
 
 export const notificationsApi = new NotificationsApiService();

--- a/mobile/stores/notificationsStore.ts
+++ b/mobile/stores/notificationsStore.ts
@@ -1,22 +1,47 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { Notification } from '../types/notification';
+import { Notification, NotificationCategory } from '../types/notification';
 
 type NotificationsState = {
   notifications: Notification[];
   unreadCount: number;
+  selectedCategory: NotificationCategory;
 
   setNotifications: (items: Notification[]) => void;
   markRead: (id: string) => void;
   markAllRead: () => void;
+  setSelectedCategory: (category: NotificationCategory) => void;
+  getFilteredNotifications: () => Notification[];
+};
+
+const getNotificationCategory = (notification: Notification): NotificationCategory => {
+  if (!notification.type && !notification.category) return 'updates';
+  
+  const category = notification.category;
+  if (category && category !== 'all') return category;
+
+  // Map type to category if category not explicitly set
+  switch (notification.type) {
+    case 'payout':
+      return 'payments';
+    case 'contribution':
+      return 'payments';
+    case 'member':
+      return 'members';
+    case 'status':
+      return 'updates';
+    default:
+      return 'updates';
+  }
 };
 
 export const useNotificationsStore = create<NotificationsState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       notifications: [],
       unreadCount: 0,
+      selectedCategory: 'all',
 
       setNotifications: (items) =>
         set(() => ({
@@ -37,11 +62,32 @@ export const useNotificationsStore = create<NotificationsState>()(
           notifications: state.notifications.map((n) => ({ ...n, read: true })),
           unreadCount: 0,
         })),
+
+      setSelectedCategory: (category) =>
+        set(() => ({
+          selectedCategory: category,
+        })),
+
+      getFilteredNotifications: () => {
+        const state = get();
+        const { notifications, selectedCategory } = state;
+
+        if (selectedCategory === 'all') {
+          return notifications;
+        }
+
+        return notifications.filter(
+          (notification) => getNotificationCategory(notification) === selectedCategory,
+        );
+      },
     }),
     {
       name: 'esustellar-notifications',
       storage: createJSONStorage(() => AsyncStorage),
-      partialize: (state) => ({ notifications: state.notifications }),
+      partialize: (state) => ({ 
+        notifications: state.notifications,
+        selectedCategory: state.selectedCategory,
+      }),
       onRehydrateStorage: () => (state) => {
         if (state) {
           state.unreadCount = state.notifications.filter((n) => !n.read).length;

--- a/mobile/types/notification.ts
+++ b/mobile/types/notification.ts
@@ -1,5 +1,7 @@
 export type NotificationType = 'contribution' | 'payout' | 'member' | 'status';
 
+export type NotificationCategory = 'all' | 'payments' | 'members' | 'updates' | 'groups';
+
 export type Notification = {
   id: string;
   title: string;
@@ -7,4 +9,13 @@ export type Notification = {
   read: boolean;
   createdAt: string;
   type?: NotificationType;
+  category?: NotificationCategory;
+};
+
+export const NOTIFICATION_CATEGORIES: Record<NotificationCategory, { label: string; emoji: string; color: string }> = {
+  all: { label: 'All', emoji: '📬', color: '#007AFF' },
+  payments: { label: 'Payments', emoji: '💸', color: '#34C759' },
+  members: { label: 'Members', emoji: '👥', color: '#FF9500' },
+  updates: { label: 'Updates', emoji: '📢', color: '#5856D6' },
+  groups: { label: 'Groups', emoji: '👨‍👩‍👧‍👦', color: '#FF3B30' },
 };


### PR DESCRIPTION
Closes #321
feat(notifications): implement read/unread state tracking

- Add API methods for marking notifications as read (single and bulk)
- Implement useMarkNotificationRead and useMarkAllNotificationsRead hooks
- Add 'Mark all as read' button to inbox header
- Update NotificationItem to sync read state with backend
- Add optimistic updates for immediate UI feedback
- Add loading states during sync operations
- Add translation keys for all supported languages (en, es, fr, ar, sw)
- Persist notification state across sessions via AsyncStorage"

Closes #322
feat(notifications): add categories and filtering

- Add NotificationCategory type with 5 categories (payments, members, updates, groups, all)
- Add category icons and colors to NOTIFICATION_CATEGORIES constant
- Implement category filtering in notificationsStore with getFilteredNotifications()
- Add selectedCategory state that persists via AsyncStorage
- Create NotificationCategoryFilter component with horizontal scrollable tabs
- Update NotificationItem to display category tags with emojis and colors
- Update inbox screen to integrate category filter tabs
- Add category field to mock API notifications data
- Expand mock data from 2 to 4 notifications with various categories
- Add comprehensive tests for category filtering functionality
- Add translation keys for categories in all 5 languages (en, es, fr, ar, sw)
- Categories auto-map from notification type if not explicitly set"