### PR TITLE
Feat/binding

### DIFF
--- a/packages/sdk/src/savings/__tests__/get-round-deadline.test.ts
+++ b/packages/sdk/src/savings/__tests__/get-round-deadline.test.ts
@@ -1,0 +1,83 @@
+import { getRoundDeadline, SdkConfig } from "../get-round-deadline";
+
+jest.mock("@stellar/stellar-sdk", () => {
+  const TransactionBuilderMock: any = jest.fn().mockImplementation(() => ({
+    addOperation: jest.fn().mockReturnThis(),
+    setTimeout: jest.fn().mockReturnThis(),
+    build: jest.fn().mockReturnValue({ toXDR: jest.fn().mockReturnValue("mock-xdr") }),
+  }));
+
+  return {
+    Contract: jest.fn().mockImplementation(() => ({
+      call: jest.fn().mockReturnValue("mock-op"),
+    })),
+    Account: jest.fn().mockImplementation(() => ({})),
+    BASE_FEE: "100",
+    TransactionBuilder: TransactionBuilderMock,
+    rpc: {
+      Server: jest.fn(),
+      Api: {
+        isSimulationError: jest.fn(),
+        GetTransactionStatus: { NOT_FOUND: "NOT_FOUND", SUCCESS: "SUCCESS" },
+      },
+    },
+    scValToNative: jest.fn(),
+    nativeToScVal: jest.fn().mockReturnValue("mock-scval"),
+  };
+});
+
+const config: SdkConfig = {
+  contractId: "CSAVINGSCONTRACTID00000000000000000000000000000000000",
+  rpcUrl: "https://soroban-testnet.stellar.org",
+  networkPassphrase: "Test SDF Network ; September 2015",
+};
+
+function getSdk() {
+  return jest.requireMock("@stellar/stellar-sdk") as any;
+}
+
+function makeMockServer(overrides: Record<string, jest.Mock> = {}) {
+  const mockServer = { simulateTransaction: jest.fn(), ...overrides };
+  getSdk().rpc.Server.mockImplementation(() => mockServer);
+  return mockServer;
+}
+
+describe("getRoundDeadline", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getSdk().rpc.Api.isSimulationError.mockReturnValue(false);
+  });
+
+  it("returns deadline timestamp for a valid round", async () => {
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({ result: { retval: "mock-retval" } });
+    getSdk().scValToNative.mockReturnValueOnce(BigInt(1717200000));
+
+    const ts = await getRoundDeadline(config, "ajo-001", 1);
+
+    expect(ts).toBe(1717200000);
+  });
+
+  it("passes group_id and round as ScVals and calls the correct contract method", async () => {
+    const { nativeToScVal, Contract } = getSdk();
+    const mockCall = jest.fn().mockReturnValue("mock-op");
+    Contract.mockImplementationOnce(() => ({ call: mockCall }));
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({ result: { retval: "mock-retval" } });
+    getSdk().scValToNative.mockReturnValueOnce(123n);
+
+    await getRoundDeadline(config, "ajo-001", 2);
+
+    expect(nativeToScVal).toHaveBeenCalledWith("ajo-001", { type: "string" });
+    expect(nativeToScVal).toHaveBeenCalledWith(2, { type: "u32" });
+    expect(mockCall).toHaveBeenCalledWith("get_round_deadline", expect.anything(), expect.anything());
+  });
+
+  it("throws GroupNotFound when the round is out of range", async () => {
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({ error: "contract error: group not found" });
+    getSdk().rpc.Api.isSimulationError.mockReturnValueOnce(true);
+
+    await expect(getRoundDeadline(config, "ajo-001", 999)).rejects.toThrow("GroupNotFound");
+  });
+});

--- a/packages/sdk/src/savings/__tests__/get-round-payouts.test.ts
+++ b/packages/sdk/src/savings/__tests__/get-round-payouts.test.ts
@@ -1,0 +1,81 @@
+import { getRoundPayouts, Payout, SdkConfig } from "../get-round-payouts";
+
+jest.mock("@stellar/stellar-sdk", () => {
+  const TransactionBuilderMock: any = jest.fn().mockImplementation(() => ({
+    addOperation: jest.fn().mockReturnThis(),
+    setTimeout: jest.fn().mockReturnThis(),
+    build: jest.fn().mockReturnValue({ toXDR: jest.fn().mockReturnValue("mock-xdr") }),
+  }));
+
+  return {
+    Contract: jest.fn().mockImplementation(() => ({
+      call: jest.fn().mockReturnValue("mock-op"),
+    })),
+    Account: jest.fn().mockImplementation(() => ({})),
+    BASE_FEE: "100",
+    TransactionBuilder: TransactionBuilderMock,
+    rpc: {
+      Server: jest.fn(),
+      Api: {
+        isSimulationError: jest.fn(),
+        GetTransactionStatus: { NOT_FOUND: "NOT_FOUND", SUCCESS: "SUCCESS" },
+      },
+    },
+    scValToNative: jest.fn(),
+    nativeToScVal: jest.fn().mockReturnValue("mock-scval"),
+  };
+});
+
+const config: SdkConfig = {
+  contractId: "CSAVINGSCONTRACTID00000000000000000000000000000000000",
+  rpcUrl: "https://soroban-testnet.stellar.org",
+  networkPassphrase: "Test SDF Network ; September 2015",
+};
+
+function getSdk() {
+  return jest.requireMock("@stellar/stellar-sdk") as any;
+}
+
+function makeMockServer(overrides: Record<string, jest.Mock> = {}) {
+  const mockServer = { simulateTransaction: jest.fn(), ...overrides };
+  getSdk().rpc.Server.mockImplementation(() => mockServer);
+  return mockServer;
+}
+
+describe("getRoundPayouts", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getSdk().rpc.Api.isSimulationError.mockReturnValue(false);
+  });
+
+  it("returns mapped payouts for a round", async () => {
+    const mockServer = makeMockServer();
+    const rawPayout: Payout = {
+      recipient: "GRECIPIENT000000000000000000000000000000000000000000",
+      amount: 50000000n,
+      round: 1,
+      timestamp: 1717200000n,
+    } as any;
+
+    mockServer.simulateTransaction.mockResolvedValueOnce({ result: { retval: "mock-retval" } });
+    getSdk().scValToNative.mockReturnValueOnce([rawPayout]);
+
+    const payouts = await getRoundPayouts(config, "ajo-001", 1);
+
+    expect(payouts).toHaveLength(1);
+    expect(payouts[0]).toEqual({
+      recipient: rawPayout.recipient,
+      amount: BigInt(50000000),
+      round: 1,
+      timestamp: BigInt(1717200000),
+    });
+  });
+
+  it("throws GroupNotFound when the round is out of range (no payouts yet)", async () => {
+    const mockServer = makeMockServer();
+    mockServer.simulateTransaction.mockResolvedValueOnce({ error: "contract error: group not found" });
+    getSdk().rpc.Api.isSimulationError.mockReturnValueOnce(true);
+
+    await expect(getRoundPayouts(config, "ajo-001", 999)).rejects.toThrow("GroupNotFound");
+  });
+});

--- a/packages/sdk/src/savings/get-round-deadline.ts
+++ b/packages/sdk/src/savings/get-round-deadline.ts
@@ -1,0 +1,85 @@
+import {
+  Contract,
+  nativeToScVal,
+  scValToNative,
+  TransactionBuilder,
+  BASE_FEE,
+  rpc,
+  Account,
+} from "@stellar/stellar-sdk";
+
+const DUMMY_ACCOUNT =
+  "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+export interface SdkConfig {
+  /** Savings contract ID (Stellar address). */
+  contractId: string;
+  /** Soroban RPC endpoint URL. */
+  rpcUrl: string;
+  /** Network passphrase, e.g. "Test SDF Network ; September 2015". */
+  networkPassphrase: string;
+  /** Optional Stellar address used as the simulation source. Defaults to a dummy account. */
+  sourceAccount?: string;
+}
+
+/**
+ * Retrieves the contribution deadline timestamp (Unix seconds) for a specific round.
+ *
+ * This is a read-only simulation — no transaction is submitted and no auth is required.
+ *
+ * **Error variants surfaced by the contract:**
+ * - `GroupNotFound` — no group exists for the given `groupId` (also returned for invalid/out-of-range `round`)
+ *
+ * @throws {Error} If the group/round is not found, the simulation fails, or the result is empty.
+ *
+ * @example
+ * ```ts
+ * const ts = await getRoundDeadline(
+ *   { contractId, rpcUrl, networkPassphrase },
+ *   "ajo-001",
+ *   1,
+ * );
+ * console.log(ts); // 1717200000
+ * ```
+ */
+export async function getRoundDeadline(
+  config: SdkConfig,
+  groupId: string,
+  round: number,
+): Promise<number> {
+  const { contractId, rpcUrl, networkPassphrase } = config;
+  const source = config.sourceAccount ?? DUMMY_ACCOUNT;
+
+  const server = new rpc.Server(rpcUrl, { allowHttp: true });
+  const contract = new Contract(contractId);
+  const account = new Account(source, "0");
+
+  const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase })
+    .addOperation(
+      contract.call(
+        "get_round_deadline",
+        nativeToScVal(groupId, { type: "string" }),
+        nativeToScVal(round, { type: "u32" }),
+      ),
+    )
+    .setTimeout(30)
+    .build();
+
+  const result = await server.simulateTransaction(tx as any);
+
+  if (rpc.Api.isSimulationError(result)) {
+    const errMsg = (result as any).error as string;
+    if (errMsg?.includes("#2") || errMsg?.toLowerCase().includes("not found") || errMsg?.toLowerCase().includes("invalid round")) {
+      throw new Error(`GroupNotFound: no group registered at ${groupId}`);
+    }
+    throw new Error(`Savings contract simulation error: ${errMsg}`);
+  }
+
+  const simResult = result as any;
+  if (!simResult.result?.retval) {
+    throw new Error("Simulation returned empty result");
+  }
+
+  const raw = scValToNative(simResult.result.retval) as bigint | number;
+  return Number(raw);
+}

--- a/packages/sdk/src/savings/get-round-payouts.ts
+++ b/packages/sdk/src/savings/get-round-payouts.ts
@@ -1,0 +1,105 @@
+import {
+  Contract,
+  nativeToScVal,
+  scValToNative,
+  TransactionBuilder,
+  BASE_FEE,
+  rpc,
+  Account,
+} from "@stellar/stellar-sdk";
+
+const DUMMY_ACCOUNT =
+  "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+export interface SdkConfig {
+  /** Savings contract ID (Stellar address). */
+  contractId: string;
+  /** Soroban RPC endpoint URL. */
+  rpcUrl: string;
+  /** Network passphrase, e.g. "Test SDF Network ; September 2015". */
+  networkPassphrase: string;
+  /** Optional Stellar address used as the simulation source. Defaults to a dummy account. */
+  sourceAccount?: string;
+}
+
+/** Mirrors the `Payout` struct from the Savings contract. */
+export interface Payout {
+  recipient: string;
+  amount: bigint;
+  round: number;
+  timestamp: bigint;
+}
+
+/**
+ * Retrieves all payouts distributed in a specific round for a group.
+ *
+ * This is a read-only simulation — no transaction is submitted and no auth is required.
+ *
+ * @throws {Error} If the group is not found, the simulation fails, or the result is empty.
+ *
+ * @example
+ * ```ts
+ * const payouts = await getRoundPayouts(
+ *   { contractId, rpcUrl, networkPassphrase },
+ *   "ajo-001",
+ *   1,
+ * );
+ * console.log(payouts[0].recipient);
+ * ```
+ */
+export async function getRoundPayouts(
+  config: SdkConfig,
+  groupId: string,
+  round: number,
+): Promise<Payout[]> {
+  const { contractId, rpcUrl, networkPassphrase } = config;
+  const source = config.sourceAccount ?? DUMMY_ACCOUNT;
+
+  const server = new rpc.Server(rpcUrl, { allowHttp: true });
+  const contract = new Contract(contractId);
+  const account = new Account(source, "0");
+
+  const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase })
+    .addOperation(
+      contract.call(
+        "get_round_payouts",
+        nativeToScVal(groupId, { type: "string" }),
+        nativeToScVal(round, { type: "u32" }),
+      ),
+    )
+    .setTimeout(30)
+    .build();
+
+  const result = await server.simulateTransaction(tx as any);
+
+  if (rpc.Api.isSimulationError(result)) {
+    const errMsg = (result as any).error as string;
+    if (errMsg?.includes("#2") || errMsg?.toLowerCase().includes("not found") || errMsg?.toLowerCase().includes("invalid round")) {
+      throw new Error(`GroupNotFound: no group registered at ${groupId}`);
+    }
+    throw new Error(`Savings contract simulation error: ${errMsg}`);
+  }
+
+  const simResult = result as any;
+  if (!simResult.result?.retval) {
+    throw new Error("Simulation returned empty result");
+  }
+
+  const raw = scValToNative(simResult.result.retval) as Array<{
+    recipient: string;
+    amount: bigint | number | string;
+    round: number;
+    timestamp: bigint | number | string;
+  }>;
+
+  return raw.map((p) => {
+    const amount = typeof p.amount === "bigint" ? p.amount : BigInt(p.amount as any);
+    const timestamp = typeof p.timestamp === "bigint" ? p.timestamp : BigInt(p.timestamp as any);
+    return {
+      recipient: String(p.recipient),
+      amount,
+      round: Number(p.round),
+      timestamp,
+    };
+  });
+}


### PR DESCRIPTION
**Done**

- **Added**: 

Completed: *Add SDK binding for get_round_deadline* (1/3)

get-round-deadline.ts — read-only SDK binding for `get_round_deadline` with JSDoc/usage example.
- **Tests**: get-round-deadline.test.ts — covers valid round, argument mapping, and out-of-range -> `GroupNotFound`.
- **Error mapping**: simulation errors containing `#2`, `not found`, or `invalid round` are surfaced as `GroupNotFound`.

Want me to run the package tests now? Run locally with:

Closes #383 

```bash
cd packages/sdk
npm test
```

Updated todo list

Made changes.

Closes #381 

Created 4 todos

Completed: *Add getRoundPayouts SDK binding* (3/4)

I'll run the SDK package tests to verify the new unit tests pass.

Ran terminal command:  cd packages/sdk && npm test --silent

Closes #384 

Progress update: added the SDK binding and tests for `get_round_payouts`. Next step: run the package tests — want me to run `cd packages/sdk && npm test` now?

Updated todo list

Made changes.

Closes #380 