### PR TITLE
feat: add A/B testing framework to mobile (#342)

### DIFF
--- a/mobile/__tests__/abTesting.test.ts
+++ b/mobile/__tests__/abTesting.test.ts
@@ -1,0 +1,111 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import {
+  assignVariant,
+  trackEvent,
+  getEvents,
+  clearEvents,
+  getExperiment,
+  EXPERIMENTS,
+} from '../services/abTesting'
+
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+)
+
+beforeEach(async () => {
+  await clearEvents()
+  ;(AsyncStorage.getItem as jest.Mock).mockClear()
+  ;(AsyncStorage.setItem as jest.Mock).mockClear()
+})
+
+describe('assignVariant', () => {
+  it('returns a valid variant id', () => {
+    const experiment = EXPERIMENTS[0]
+    const result = assignVariant('user-123', experiment.id, experiment.variants)
+    const validIds = experiment.variants.map((v) => v.id)
+    expect(validIds).toContain(result)
+  })
+
+  it('is deterministic -- same inputs always produce the same variant', () => {
+    const experiment = EXPERIMENTS[0]
+    const first = assignVariant('user-abc', experiment.id, experiment.variants)
+    const second = assignVariant('user-abc', experiment.id, experiment.variants)
+    expect(first).toBe(second)
+  })
+
+  it('produces different assignments for different users', () => {
+    const experiment = EXPERIMENTS[0]
+    const results = new Set<string>()
+    for (let i = 0; i < 50; i++) {
+      results.add(assignVariant('user-' + i, experiment.id, experiment.variants))
+    }
+    // With 50 users and 2 equal-weight variants, both should appear
+    expect(results.size).toBeGreaterThan(1)
+  })
+
+  it('respects variant weights -- control gets ~50% of traffic', () => {
+    const experiment = EXPERIMENTS[0]
+    let controlCount = 0
+    const total = 200
+    for (let i = 0; i < total; i++) {
+      const v = assignVariant('u' + i, experiment.id, experiment.variants)
+      if (v === 'control') controlCount++
+    }
+    const ratio = controlCount / total
+    expect(ratio).toBeGreaterThan(0.35)
+    expect(ratio).toBeLessThan(0.65)
+  })
+})
+
+describe('getExperiment', () => {
+  it('returns the experiment by id', () => {
+    const exp = getExperiment('onboarding-flow')
+    expect(exp).toBeDefined()
+    expect(exp?.id).toBe('onboarding-flow')
+  })
+
+  it('returns undefined for unknown ids', () => {
+    expect(getExperiment('does-not-exist')).toBeUndefined()
+  })
+})
+
+describe('trackEvent / getEvents', () => {
+  it('persists a tracked event', async () => {
+    await trackEvent({ experimentId: 'onboarding-flow', variantId: 'control', metric: 'view', value: 1 })
+    const events = await getEvents()
+    expect(events).toHaveLength(1)
+    expect(events[0].metric).toBe('view')
+    expect(events[0].variantId).toBe('control')
+    expect(events[0].timestamp).toBeGreaterThan(0)
+  })
+
+  it('accumulates multiple events', async () => {
+    await trackEvent({ experimentId: 'onboarding-flow', variantId: 'control', metric: 'view', value: 1 })
+    await trackEvent({ experimentId: 'contribution-cta', variantId: 'pay-now', metric: 'tap', value: 1 })
+    const events = await getEvents()
+    expect(events).toHaveLength(2)
+  })
+
+  it('value defaults work -- callers can omit value', async () => {
+    await trackEvent({ experimentId: 'onboarding-flow', variantId: 'simplified', metric: 'complete', value: 1 })
+    const events = await getEvents()
+    expect(events[0].value).toBe(1)
+  })
+})
+
+describe('clearEvents', () => {
+  it('removes all tracked events', async () => {
+    await trackEvent({ experimentId: 'onboarding-flow', variantId: 'control', metric: 'view', value: 1 })
+    await clearEvents()
+    const events = await getEvents()
+    expect(events).toHaveLength(0)
+  })
+})
+
+describe('disabled experiments', () => {
+  it('all experiments in EXPERIMENTS have an enabled flag', () => {
+    for (const exp of EXPERIMENTS) {
+      expect(typeof exp.enabled).toBe('boolean')
+    }
+  })
+})

--- a/mobile/hooks/useExperiment.ts
+++ b/mobile/hooks/useExperiment.ts
@@ -1,0 +1,28 @@
+import { useCallback } from 'react'
+import { useABTestingStore } from '../stores/abTestingStore'
+import { trackEvent } from '../services/abTesting'
+
+type UseExperimentResult = {
+  variant: string | null
+  isVariant: (variantId: string) => boolean
+  track: (metric: string, value?: number) => Promise<void>
+}
+
+export function useExperiment(experimentId: string): UseExperimentResult {
+  const getVariant = useABTestingStore((s) => s.getVariant)
+  const variant = getVariant(experimentId)
+
+  const isVariant = useCallback(
+    (variantId: string) => variant === variantId,
+    [variant],
+  )
+
+  const track = useCallback(
+    async (metric: string, value: number = 1) => {
+      await trackEvent({ experimentId, variantId: variant, metric, value })
+    },
+    [experimentId, variant],
+  )
+
+  return { variant, isVariant, track }
+}

--- a/mobile/services/abTesting.ts
+++ b/mobile/services/abTesting.ts
@@ -1,0 +1,99 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+
+export type Variant = {
+  id: string
+  weight: number // fraction of traffic; all weights in an experiment must sum to 1
+}
+
+export type Experiment = {
+  id: string
+  name: string
+  description: string
+  variants: Variant[]
+  enabled: boolean
+}
+
+export type ExperimentEvent = {
+  experimentId: string
+  variantId: string
+  metric: string
+  value: number
+  timestamp: number
+}
+
+export const EXPERIMENTS: Experiment[] = [
+  {
+    id: 'onboarding-flow',
+    name: 'Onboarding Flow',
+    description: 'Simplified single-screen onboarding vs the original multi-step flow.',
+    variants: [
+      { id: 'control', weight: 0.5 },
+      { id: 'simplified', weight: 0.5 },
+    ],
+    enabled: true,
+  },
+  {
+    id: 'contribution-cta',
+    name: 'Contribution CTA Label',
+    description: 'Tests alternative labels on the contribute button.',
+    variants: [
+      { id: 'control', weight: 0.5 },
+      { id: 'pay-now', weight: 0.5 },
+    ],
+    enabled: true,
+  },
+]
+
+const EVENTS_STORAGE_KEY = 'esustellar:ab:events'
+
+// Deterministic djb2 hash -- synchronous, no external deps
+function hashString(str: string): number {
+  let hash = 5381
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) + hash) ^ str.charCodeAt(i)
+  }
+  return Math.abs(hash)
+}
+
+// Assigns a variant deterministically: same userId + experimentId always returns the same variant
+export function assignVariant(userId: string, experimentId: string, variants: Variant[]): string {
+  const bucket = hashString(userId + ':' + experimentId) % 100
+  let cumulative = 0
+  for (const variant of variants) {
+    cumulative += variant.weight * 100
+    if (bucket < cumulative) return variant.id
+  }
+  return variants[variants.length - 1].id
+}
+
+export function getExperiment(id: string): Experiment | undefined {
+  return EXPERIMENTS.find((e) => e.id === id)
+}
+
+export async function trackEvent(event: Omit<ExperimentEvent, 'timestamp'>): Promise<void> {
+  try {
+    const raw = await AsyncStorage.getItem(EVENTS_STORAGE_KEY)
+    const events: ExperimentEvent[] = raw ? JSON.parse(raw) : []
+    events.push({ ...event, timestamp: Date.now() })
+    await AsyncStorage.setItem(EVENTS_STORAGE_KEY, JSON.stringify(events))
+  } catch {
+    // Tracking must never crash the app
+  }
+}
+
+export async function getEvents(): Promise<ExperimentEvent[]> {
+  try {
+    const raw = await AsyncStorage.getItem(EVENTS_STORAGE_KEY)
+    return raw ? JSON.parse(raw) : []
+  } catch {
+    return []
+  }
+}
+
+export async function clearEvents(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(EVENTS_STORAGE_KEY)
+  } catch {
+    // ignore
+  }
+}

--- a/mobile/stores/abTestingStore.ts
+++ b/mobile/stores/abTestingStore.ts
@@ -1,0 +1,58 @@
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { assignVariant, EXPERIMENTS } from '../services/abTesting'
+
+type AssignedVariants = Record<string, string> // experimentId -> variantId
+
+type ABTestingState = {
+  userId: string
+  assignedVariants: AssignedVariants
+  setUserId: (id: string) => void
+  getVariant: (experimentId: string) => string | null
+  resolveAllVariants: () => void
+  resetVariants: () => void
+}
+
+export const useABTestingStore = create<ABTestingState>()(
+  persist(
+    (set, get) => ({
+      userId: '',
+      assignedVariants: {},
+
+      setUserId: (id: string) => {
+        set({ userId: id })
+        get().resolveAllVariants()
+      },
+
+      getVariant: (experimentId: string): string | null => {
+        const experiment = EXPERIMENTS.find((e) => e.id === experimentId)
+        const { userId, assignedVariants } = get()
+        if (assignedVariants[experimentId]) return assignedVariants[experimentId]
+        // Assign on first access and cache it
+        const variant = assignVariant(userId, experimentId, experiment.variants)
+        set((state) => ({
+          assignedVariants: { ...state.assignedVariants, [experimentId]: variant },
+        }))
+        return variant
+      },
+
+      resolveAllVariants: () => {
+        const { userId } = get()
+        const resolved: AssignedVariants = {}
+        for (const experiment of EXPERIMENTS) {
+          if (experiment.enabled) {
+            resolved[experiment.id] = assignVariant(userId, experiment.id, experiment.variants)
+          }
+        }
+        set({ assignedVariants: resolved })
+      },
+
+      resetVariants: () => set({ assignedVariants: {}, userId: '' }),
+    }),
+    {
+      name: 'esustellar-ab-testing',
+      storage: createJSONStorage(() => AsyncStorage),
+    },
+  ),
+)

--- a/mobile/stores/index.ts
+++ b/mobile/stores/index.ts
@@ -1,4 +1,5 @@
 export { useGroupStore } from './useGroupStore';
+export { useABTestingStore } from './abTestingStore';
 export type { Group } from './useGroupStore';
 export { useGroupsStore } from './groupsStore';
 export { useUserStore } from './userStore';


### PR DESCRIPTION
- Add services/abTesting.ts: experiment definitions, deterministic djb2 variant assignment, AsyncStorage event tracking
- Add stores/abTestingStore.ts: Zustand persist store with getVariant, resolveAllVariants
- Add hooks/useExperiment.ts: variant, isVariant(), track() hook
- Add __tests__/abTesting.test.ts: 11 tests covering assignment, determinism, weight distribution, tracking, clearEvents
- Export useABTestingStore from stores/index.ts

closes #342 