### PR TITLE
feat(mobile): Add fiat on-ramp integration

### DIFF
--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -85,6 +85,7 @@ const HomeHeader = React.memo(() => {
 });
 
 export default function HomeScreen() {
+  const router = useRouter();
   const { t } = useTranslation();
   const { colors } = useTheme();
   const wallet = useAuthStore((s) => s.wallet);
@@ -144,6 +145,14 @@ export default function HomeScreen() {
       </View>
       <View style={[styles.section, { backgroundColor: colors.card, borderColor: colors.border }]}>
         <Text style={[styles.sectionLabel, { color: colors.subtext }]}>{t('home.quickActions')}</Text>
+        <TouchableOpacity
+          style={[styles.actionButton, { backgroundColor: colors.accent }]}
+          onPress={() => router.push('/onramp')}
+          accessibilityLabel="Buy crypto"
+          accessibilityRole="button"
+        >
+          <Text style={styles.actionButtonText}>💳 Buy Crypto</Text>
+        </TouchableOpacity>
       </View>
     </ScrollView>
   );
@@ -174,4 +183,15 @@ const styles = StyleSheet.create({
   },
   sectionLabel: { fontSize: 13, marginBottom: 4 },
   sectionValue: { fontSize: 24, fontWeight: '700' },
+  actionButton: {
+    marginTop: 10,
+    paddingVertical: 12,
+    borderRadius: 12,
+    alignItems: 'center',
+  },
+  actionButtonText: {
+    color: '#FFFFFF',
+    fontSize: 15,
+    fontWeight: '700',
+  },
 });

--- a/mobile/app/onramp/index.tsx
+++ b/mobile/app/onramp/index.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import {
+  Pressable,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+import { useTheme } from '../../context/ThemeContext';
+import { ONRAMP_PROVIDERS, OnRampProvider } from '../../services/onramp/providers';
+
+export default function OnRampScreen() {
+  const router = useRouter();
+  const { colors } = useTheme();
+
+  const handleSelectProvider = (provider: OnRampProvider) => {
+    router.push(`/onramp/purchase?provider=${provider.id}`);
+  };
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
+      <ScrollView contentContainerStyle={styles.content}>
+        <Pressable style={styles.back} onPress={() => router.back()}>
+          <Text style={[styles.backText, { color: colors.accent }]}>← Back</Text>
+        </Pressable>
+
+        <Text style={[styles.title, { color: colors.text }]}>Buy Crypto</Text>
+        <Text style={[styles.subtitle, { color: colors.subtext }]}>
+          Purchase XLM directly into your Stellar wallet using a fiat on-ramp provider.
+          KYC verification is handled securely by the provider.
+        </Text>
+
+        <View style={styles.providers}>
+          {ONRAMP_PROVIDERS.map((provider) => (
+            <Pressable
+              key={provider.id}
+              style={[styles.providerCard, { backgroundColor: colors.card, borderColor: colors.border }]}
+              onPress={() => handleSelectProvider(provider)}
+            >
+              <Text style={styles.providerIcon}>{provider.icon}</Text>
+              <View style={styles.providerInfo}>
+                <Text style={[styles.providerName, { color: colors.text }]}>
+                  {provider.name}
+                </Text>
+                <Text style={[styles.providerDesc, { color: colors.subtext }]}>
+                  {provider.description}
+                </Text>
+                <Text style={[styles.providerFiat, { color: colors.subtext }]}>
+                  {provider.supportedFiat.join(', ')}
+                </Text>
+              </View>
+              <Text style={[styles.arrow, { color: colors.subtext }]}>›</Text>
+            </Pressable>
+          ))}
+        </View>
+
+        <View style={[styles.notice, { backgroundColor: colors.card, borderColor: colors.border }]}>
+          <Text style={[styles.noticeTitle, { color: colors.text }]}>How it works</Text>
+          <Text style={[styles.noticeBody, { color: colors.subtext }]}>
+            1. Select a provider above{'\n'}
+            2. Complete identity verification (first time only){'\n'}
+            3. Enter payment details and amount{'\n'}
+            4. XLM is sent directly to your connected wallet
+          </Text>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  content: { padding: 20, paddingBottom: 40 },
+  back: { marginBottom: 12 },
+  backText: { fontSize: 15, fontWeight: '600' },
+  title: { fontSize: 26, fontWeight: '800', marginBottom: 6 },
+  subtitle: { fontSize: 15, lineHeight: 22, marginBottom: 24 },
+  providers: { gap: 12, marginBottom: 24 },
+  providerCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderWidth: 1,
+    borderRadius: 16,
+    padding: 16,
+  },
+  providerIcon: { fontSize: 32, marginRight: 14 },
+  providerInfo: { flex: 1 },
+  providerName: { fontSize: 16, fontWeight: '700', marginBottom: 2 },
+  providerDesc: { fontSize: 13, lineHeight: 18, marginBottom: 4 },
+  providerFiat: { fontSize: 12 },
+  arrow: { fontSize: 24, fontWeight: '300' },
+  notice: { borderWidth: 1, borderRadius: 16, padding: 16 },
+  noticeTitle: { fontSize: 15, fontWeight: '700', marginBottom: 8 },
+  noticeBody: { fontSize: 14, lineHeight: 22 },
+});

--- a/mobile/app/onramp/purchase.tsx
+++ b/mobile/app/onramp/purchase.tsx
@@ -1,0 +1,172 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  Linking,
+  Pressable,
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { WebView, WebViewNavigation } from 'react-native-webview';
+import { useTheme } from '../../context/ThemeContext';
+import { useAuthStore } from '../../store/authStore';
+import {
+  buildWidgetUrl,
+  ONRAMP_PROVIDERS,
+} from '../../services/onramp/providers';
+
+export default function OnRampPurchaseScreen() {
+  const router = useRouter();
+  const { colors } = useTheme();
+  const { provider: providerId } = useLocalSearchParams<{ provider: string }>();
+  const wallet = useAuthStore((s) => s.wallet);
+  const webViewRef = useRef<WebView>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const provider = useMemo(
+    () => ONRAMP_PROVIDERS.find((p) => p.id === providerId),
+    [providerId],
+  );
+
+  const widgetUrl = useMemo(() => {
+    if (!provider || !wallet?.publicKey) return null;
+    return buildWidgetUrl(provider, { walletAddress: wallet.publicKey });
+  }, [provider, wallet?.publicKey]);
+
+  useEffect(() => {
+    if (!provider) {
+      setError('Unknown provider. Please go back and try again.');
+    } else if (!wallet?.publicKey) {
+      setError('No wallet connected. Please connect a wallet first.');
+    }
+  }, [provider, wallet?.publicKey]);
+
+  const handleNavigationStateChange = (navState: WebViewNavigation) => {
+    // Detect completion URLs (provider-specific success callbacks)
+    const url = navState.url.toLowerCase();
+    if (
+      url.includes('transak.com/order-successful') ||
+      url.includes('success') ||
+      url.includes('complete')
+    ) {
+      // Could trigger a sync or show success UI
+    }
+  };
+
+  const handleShouldStartLoadWithRequest = (request: { url: string }) => {
+    // Open external links (e.g. support, T&C) in system browser
+    const url = request.url;
+    if (
+      url.startsWith('http') &&
+      !url.includes('transak.com') &&
+      !url.includes('moonpay.com') &&
+      !url.includes('buy.moonpay')
+    ) {
+      Linking.openURL(url);
+      return false;
+    }
+    return true;
+  };
+
+  if (error) {
+    return (
+      <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
+        <View style={styles.errorContainer}>
+          <Text style={[styles.errorText, { color: colors.text }]}>{error}</Text>
+          <Pressable style={[styles.backButton, { borderColor: colors.border }]} onPress={() => router.back()}>
+            <Text style={[styles.backButtonText, { color: colors.accent }]}>Go Back</Text>
+          </Pressable>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (!widgetUrl) {
+    return (
+      <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
+        <ActivityIndicator size="large" color={colors.accent} />
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
+      <View style={[styles.header, { borderBottomColor: colors.border }]}>
+        <Pressable onPress={() => router.back()}>
+          <Text style={[styles.headerBack, { color: colors.accent }]}>← Close</Text>
+        </Pressable>
+        <Text style={[styles.headerTitle, { color: colors.text }]}>
+          {provider?.name ?? 'Buy Crypto'}
+        </Text>
+        <View style={styles.headerSpacer} />
+      </View>
+
+      {loading && (
+        <View style={styles.loadingOverlay}>
+          <ActivityIndicator size="large" color={colors.accent} />
+          <Text style={[styles.loadingText, { color: colors.subtext }]}>
+            Loading {provider?.name}...
+          </Text>
+        </View>
+      )}
+
+      <WebView
+        ref={webViewRef}
+        source={{ uri: widgetUrl }}
+        style={styles.webview}
+        onLoadEnd={() => setLoading(false)}
+        onError={() => {
+          setLoading(false);
+          setError('Failed to load the purchase widget. Please check your connection.');
+        }}
+        onNavigationStateChange={handleNavigationStateChange}
+        onShouldStartLoadWithRequest={handleShouldStartLoadWithRequest}
+        javaScriptEnabled
+        domStorageEnabled
+        thirdPartyCookiesEnabled
+        allowsInlineMediaPlayback
+        startInLoadingState={false}
+      />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  headerBack: { fontSize: 15, fontWeight: '600' },
+  headerTitle: { fontSize: 16, fontWeight: '700' },
+  headerSpacer: { width: 60 },
+  webview: { flex: 1 },
+  loadingOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'center',
+    alignItems: 'center',
+    zIndex: 10,
+  },
+  loadingText: { marginTop: 12, fontSize: 14 },
+  errorContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 32,
+  },
+  errorText: { fontSize: 16, textAlign: 'center', marginBottom: 20 },
+  backButton: {
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingVertical: 12,
+    paddingHorizontal: 24,
+  },
+  backButtonText: { fontSize: 15, fontWeight: '600' },
+});

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -40,6 +40,7 @@
     "react-native-screens": "3.31.1",
     "react-native-svg": "15.2.0",
     "react-native-web": "~0.19.10",
+    "react-native-webview": "^13.8.0",
     "zustand": "^4.5.2"
   },
   "overrides": {

--- a/mobile/services/onramp/providers.ts
+++ b/mobile/services/onramp/providers.ts
@@ -1,0 +1,99 @@
+/**
+ * Fiat On-Ramp Provider Configuration (#367)
+ *
+ * Supports WebView-based on-ramp providers that handle KYC/compliance
+ * internally. The user is redirected to the provider's widget to complete
+ * the purchase, then funds arrive in their Stellar wallet.
+ */
+
+export interface OnRampProvider {
+  id: string;
+  name: string;
+  icon: string;
+  description: string;
+  /** Supported fiat currencies */
+  supportedFiat: string[];
+  /** Base URL for the provider widget */
+  widgetBaseUrl: string;
+  /** Whether the provider handles KYC internally */
+  handlesKyc: boolean;
+}
+
+export const ONRAMP_PROVIDERS: OnRampProvider[] = [
+  {
+    id: 'transak',
+    name: 'Transak',
+    icon: '💳',
+    description: 'Buy XLM with card or bank transfer. KYC handled in-widget.',
+    supportedFiat: ['USD', 'EUR', 'GBP', 'NGN', 'KES', 'ZAR'],
+    widgetBaseUrl: 'https://global.transak.com',
+    handlesKyc: true,
+  },
+  {
+    id: 'moonpay',
+    name: 'MoonPay',
+    icon: '🌙',
+    description: 'Purchase XLM using credit/debit cards worldwide.',
+    supportedFiat: ['USD', 'EUR', 'GBP', 'AUD', 'CAD'],
+    widgetBaseUrl: 'https://buy.moonpay.com',
+    handlesKyc: true,
+  },
+];
+
+export interface OnRampWidgetParams {
+  walletAddress: string;
+  cryptoCurrency?: string;
+  fiatCurrency?: string;
+  fiatAmount?: number;
+}
+
+/**
+ * Build the full widget URL for a given provider.
+ * Each provider has its own query param structure.
+ */
+export function buildWidgetUrl(
+  provider: OnRampProvider,
+  params: OnRampWidgetParams,
+): string {
+  const { walletAddress, cryptoCurrency = 'XLM', fiatCurrency, fiatAmount } = params;
+
+  if (provider.id === 'transak') {
+    const query = new URLSearchParams({
+      apiKey: getTransakApiKey(),
+      cryptoCurrencyCode: cryptoCurrency,
+      walletAddress,
+      network: 'stellar',
+      disableWalletAddressForm: 'true',
+      themeColor: '6366F1',
+      ...(fiatCurrency && { defaultFiatCurrency: fiatCurrency }),
+      ...(fiatAmount && { defaultFiatAmount: String(fiatAmount) }),
+    });
+    return `${provider.widgetBaseUrl}?${query.toString()}`;
+  }
+
+  if (provider.id === 'moonpay') {
+    const query = new URLSearchParams({
+      apiKey: getMoonPayApiKey(),
+      currencyCode: cryptoCurrency.toLowerCase(),
+      walletAddress,
+      colorCode: '%236366F1',
+      ...(fiatCurrency && { baseCurrencyCode: fiatCurrency.toLowerCase() }),
+      ...(fiatAmount && { baseCurrencyAmount: String(fiatAmount) }),
+    });
+    return `${provider.widgetBaseUrl}?${query.toString()}`;
+  }
+
+  return provider.widgetBaseUrl;
+}
+
+/**
+ * API keys should come from environment config in production.
+ * These are placeholder keys for the MVP prototype.
+ */
+function getTransakApiKey(): string {
+  return process.env.EXPO_PUBLIC_TRANSAK_API_KEY || 'TRANSAK_STAGING_KEY';
+}
+
+function getMoonPayApiKey(): string {
+  return process.env.EXPO_PUBLIC_MOONPAY_API_KEY || 'MOONPAY_STAGING_KEY';
+}


### PR DESCRIPTION
closes #367 

- Create on-ramp service with Transak and MoonPay provider configs
- Build provider selection screen at /onramp with clear UX
- Build WebView-based purchase flow at /onramp/purchase
- KYC/compliance handled by providers within their widgets
- Add 'Buy Crypto' button to home screen quick actions
- Add react-native-webview dependency
- Widget URLs auto-populate wallet address and network (Stellar)
- External links open in system browser for compliance docs