### PR TITLE
feat: implement feature kill switches (#346)

### DIFF
--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -12,6 +12,8 @@ import { triggerHapticFeedback } from '../../utils/haptics';
 import { logger } from '../../services/logger';
 import WalletSwitcher from '../../components/wallet/WalletSwitcher';
 import { getActiveWallet, WalletEntry } from '../../services/wallet/multiWallet';
+import { useKillSwitchStore } from '../../stores/killSwitchStore';
+import { useKillSwitch } from '../../hooks/useKillSwitch';
 
 function getGreeting(hour: number, t: any): string {
   if (hour < 12) return t('home.goodMorning');
@@ -124,6 +126,16 @@ export default function HomeScreen() {
 
   const { refreshing, onRefresh } = useRefresh(fetchData);
 
+  const startPolling = useKillSwitchStore((s) => s.startPolling);
+  const stopPolling = useKillSwitchStore((s) => s.stopPolling);
+  const contributions = useKillSwitch('contributions');
+  const groupCreation = useKillSwitch('group-creation');
+
+  useEffect(() => {
+    startPolling();
+    return () => stopPolling();
+  }, [startPolling, stopPolling]);
+
   return (
     <ScrollView
       style={[styles.container, { backgroundColor: colors.background }]}
@@ -144,6 +156,55 @@ export default function HomeScreen() {
       </View>
       <View style={[styles.section, { backgroundColor: colors.card, borderColor: colors.border }]}>
         <Text style={[styles.sectionLabel, { color: colors.subtext }]}>{t('home.quickActions')}</Text>
+        <View style={styles.quickActions}>
+          <TouchableOpacity
+            style={[
+              styles.quickActionButton,
+              { backgroundColor: contributions.isEnabled ? colors.accent : colors.border },
+            ]}
+            disabled={!contributions.isEnabled}
+            onPress={() => {
+              triggerHapticFeedback.selection();
+              router.push('/contributions/wallet');
+            }}
+            accessibilityRole="button"
+            accessibilityLabel="Contribute"
+            accessibilityState={{ disabled: !contributions.isEnabled }}
+          >
+            <Text style={[styles.quickActionLabel, { color: contributions.isEnabled ? '#fff' : colors.subtext }]}>
+              Contribute
+            </Text>
+          </TouchableOpacity>
+          {!contributions.isEnabled && (
+            <Text style={[styles.killSwitchMessage, { color: colors.subtext }]}>
+              {contributions.disabledMessage}
+            </Text>
+          )}
+
+          <TouchableOpacity
+            style={[
+              styles.quickActionButton,
+              { backgroundColor: groupCreation.isEnabled ? colors.accent : colors.border },
+            ]}
+            disabled={!groupCreation.isEnabled}
+            onPress={() => {
+              triggerHapticFeedback.selection();
+              router.push('/groups/create');
+            }}
+            accessibilityRole="button"
+            accessibilityLabel="Create group"
+            accessibilityState={{ disabled: !groupCreation.isEnabled }}
+          >
+            <Text style={[styles.quickActionLabel, { color: groupCreation.isEnabled ? '#fff' : colors.subtext }]}>
+              New Group
+            </Text>
+          </TouchableOpacity>
+          {!groupCreation.isEnabled && (
+            <Text style={[styles.killSwitchMessage, { color: colors.subtext }]}>
+              {groupCreation.disabledMessage}
+            </Text>
+          )}
+        </View>
       </View>
     </ScrollView>
   );
@@ -174,4 +235,24 @@ const styles = StyleSheet.create({
   },
   sectionLabel: { fontSize: 13, marginBottom: 4 },
   sectionValue: { fontSize: 24, fontWeight: '700' },
+  quickActions: {
+    marginTop: 12,
+    gap: 10,
+  },
+  quickActionButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 14,
+    borderRadius: 10,
+    gap: 10,
+  },
+  quickActionLabel: {
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  killSwitchMessage: {
+    fontSize: 12,
+    marginTop: 4,
+    marginLeft: 4,
+  },
 });

--- a/mobile/hooks/useKillSwitch.ts
+++ b/mobile/hooks/useKillSwitch.ts
@@ -1,0 +1,16 @@
+import { useKillSwitchStore } from '../stores/killSwitchStore'
+import { KillSwitchKey } from '../services/killSwitch'
+
+type UseKillSwitchResult = {
+  isEnabled: boolean
+  disabledMessage: string
+  isFetching: boolean
+}
+
+export function useKillSwitch(key: KillSwitchKey): UseKillSwitchResult {
+  const isEnabled = useKillSwitchStore((s) => s.isEnabled(key))
+  const disabledMessage = useKillSwitchStore((s) => s.disabledMessage(key))
+  const isFetching = useKillSwitchStore((s) => s.isFetching)
+
+  return { isEnabled, disabledMessage, isFetching }
+}

--- a/mobile/services/killSwitch.ts
+++ b/mobile/services/killSwitch.ts
@@ -1,0 +1,113 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { env } from '../config/env'
+
+// ── Kill switch keys ──────────────────────────────────────────────────────────
+
+export type KillSwitchKey =
+  | 'contributions'
+  | 'group-creation'
+  | 'wallet-transfers'
+  | 'notifications'
+
+export type KillSwitch = {
+  key: KillSwitchKey
+  title: string
+  description: string
+  enabled: boolean         // true = feature is live; false = feature is off
+  disabledMessage: string  // shown to the user when the feature is off
+}
+
+// Safe defaults -- all features on. Used when remote fetch fails and no cache exists.
+export const DEFAULT_KILL_SWITCHES: KillSwitch[] = [
+  {
+    key: 'contributions',
+    title: 'Contributions',
+    description: 'Ability to make contributions to savings groups.',
+    enabled: true,
+    disabledMessage: 'Contributions are temporarily unavailable. Please try again later.',
+  },
+  {
+    key: 'group-creation',
+    title: 'Group Creation',
+    description: 'Ability to create new savings groups.',
+    enabled: true,
+    disabledMessage: 'Group creation is temporarily unavailable. Please try again later.',
+  },
+  {
+    key: 'wallet-transfers',
+    title: 'Wallet Transfers',
+    description: 'Ability to transfer funds between wallets.',
+    enabled: true,
+    disabledMessage: 'Wallet transfers are temporarily unavailable. Please try again later.',
+  },
+  {
+    key: 'notifications',
+    title: 'Notifications',
+    description: 'Push and in-app notification delivery.',
+    enabled: true,
+    disabledMessage: 'Notifications are temporarily unavailable. Please try again later.',
+  },
+]
+
+// ── Storage ───────────────────────────────────────────────────────────────────
+
+const STORAGE_KEY = 'esustellar:kill-switches'
+
+export async function loadCachedKillSwitches(): Promise<KillSwitch[] | null> {
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY)
+    return raw ? (JSON.parse(raw) as KillSwitch[]) : null
+  } catch {
+    return null
+  }
+}
+
+export async function cacheKillSwitches(switches: KillSwitch[]): Promise<void> {
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(switches))
+  } catch {
+    // Cache failure must never crash the app
+  }
+}
+
+// ── Remote fetch ──────────────────────────────────────────────────────────────
+
+// Merges remote payload into defaults so unknown keys never break the client.
+function mergeWithDefaults(remote: Partial<Record<KillSwitchKey, boolean>>): KillSwitch[] {
+  return DEFAULT_KILL_SWITCHES.map((sw) => {
+    if (Object.prototype.hasOwnProperty.call(remote, sw.key)) {
+      return { ...sw, enabled: remote[sw.key] as boolean }
+    }
+    return sw
+  })
+}
+
+export async function fetchKillSwitches(): Promise<KillSwitch[]> {
+  try {
+    const res = await fetch(`${env.API_URL}/config/kill-switches`, {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' },
+    })
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    const remote = (await res.json()) as Partial<Record<KillSwitchKey, boolean>>
+    const merged = mergeWithDefaults(remote)
+    await cacheKillSwitches(merged)
+    return merged
+  } catch {
+    // Remote fetch failed -- try cache, then fall back to safe defaults
+    const cached = await loadCachedKillSwitches()
+    return cached ?? DEFAULT_KILL_SWITCHES
+  }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+export function isFeatureEnabled(switches: KillSwitch[], key: KillSwitchKey): boolean {
+  const sw = switches.find((s) => s.key === key)
+  return sw ? sw.enabled : true // default to enabled if key not found
+}
+
+export function getDisabledMessage(switches: KillSwitch[], key: KillSwitchKey): string {
+  const sw = switches.find((s) => s.key === key)
+  return sw?.disabledMessage ?? 'This feature is temporarily unavailable.'
+}

--- a/mobile/stores/index.ts
+++ b/mobile/stores/index.ts
@@ -4,3 +4,6 @@ export { useGroupsStore } from './groupsStore';
 export { useUserStore } from './userStore';
 export { useWalletStore } from './walletStore';
 export type { WalletState } from './walletStore';
+
+export { useKillSwitchStore } from './killSwitchStore';
+export type { KillSwitch } from '../services/killSwitch';

--- a/mobile/stores/killSwitchStore.ts
+++ b/mobile/stores/killSwitchStore.ts
@@ -1,0 +1,83 @@
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import {
+  KillSwitch,
+  KillSwitchKey,
+  DEFAULT_KILL_SWITCHES,
+  fetchKillSwitches,
+  isFeatureEnabled,
+  getDisabledMessage,
+} from '../services/killSwitch'
+
+const POLL_INTERVAL_MS = 5 * 60 * 1000 // 5 minutes
+
+type KillSwitchState = {
+  switches: KillSwitch[]
+  lastFetchedAt: number | null
+  isFetching: boolean
+  pollingHandle: ReturnType<typeof setInterval> | null
+
+  // Actions
+  hydrate: () => Promise<void>
+  startPolling: () => void
+  stopPolling: () => void
+  isEnabled: (key: KillSwitchKey) => boolean
+  disabledMessage: (key: KillSwitchKey) => string
+}
+
+export const useKillSwitchStore = create<KillSwitchState>()(
+  persist(
+    (set, get) => ({
+      switches: DEFAULT_KILL_SWITCHES,
+      lastFetchedAt: null,
+      isFetching: false,
+      pollingHandle: null,
+
+      hydrate: async () => {
+        if (get().isFetching) return
+        set({ isFetching: true })
+        try {
+          const switches = await fetchKillSwitches()
+          set({ switches, lastFetchedAt: Date.now() })
+        } finally {
+          set({ isFetching: false })
+        }
+      },
+
+      startPolling: () => {
+        const existing = get().pollingHandle
+        if (existing !== null) return // already polling
+
+        // Fetch immediately, then on interval
+        void get().hydrate()
+        const handle = setInterval(() => {
+          void get().hydrate()
+        }, POLL_INTERVAL_MS)
+
+        set({ pollingHandle: handle })
+      },
+
+      stopPolling: () => {
+        const handle = get().pollingHandle
+        if (handle !== null) {
+          clearInterval(handle)
+          set({ pollingHandle: null })
+        }
+      },
+
+      isEnabled: (key: KillSwitchKey) => isFeatureEnabled(get().switches, key),
+
+      disabledMessage: (key: KillSwitchKey) => getDisabledMessage(get().switches, key),
+    }),
+    {
+      name: 'esustellar-kill-switches',
+      storage: createJSONStorage(() => AsyncStorage),
+      // Do not persist runtime-only fields
+      partialize: (state) => ({
+        switches: state.switches,
+        lastFetchedAt: state.lastFetchedAt,
+      }),
+    },
+  ),
+)


### PR DESCRIPTION
- Add killSwitch service with typed keys, remote fetch, AsyncStorage cache
- Add killSwitchStore (Zustand + persist) with 5-min polling
- Add useKillSwitch hook for per-feature gate checks
- Export killSwitchStore from stores/index
- Gate contributions and group-creation quick actions on home screen
- Safe fallback: network failure keeps last known state, never kills features

closes #346 