### PR TITLE
feat: Nginx reverse proxy config for Next.js app

### DIFF
--- a/nginx/.gitignore
+++ b/nginx/.gitignore
@@ -1,0 +1,3 @@
+certs/*.pem
+certs/*.crt
+certs/*.key

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,7 @@
+FROM nginx:1.27-alpine
+COPY nginx.conf /etc/nginx/nginx.conf
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- http://localhost:80/ || exit 1
+
+EXPOSE 80 443

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,69 @@
+worker_processes auto;
+error_log /var/log/nginx/error.log warn;
+pid /var/run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    sendfile      on;
+    keepalive_timeout 65;
+    server_tokens off;
+
+    # Rate limiting
+    limit_req_zone $binary_remote_addr zone=web:10m rate=20r/s;
+
+    # Redirect HTTP → HTTPS
+    server {
+        listen 80;
+        server_name _;
+        return 301 https://$host$request_uri;
+    }
+
+    server {
+        listen 443 ssl;
+        server_name _;
+        http2 on;
+
+        # SSL
+        ssl_certificate     /etc/nginx/certs/cert.pem;
+        ssl_certificate_key /etc/nginx/certs/key.pem;
+        ssl_protocols       TLSv1.2 TLSv1.3;
+        ssl_ciphers         HIGH:!aNULL:!MD5;
+        ssl_session_cache   shared:SSL:10m;
+        ssl_session_timeout 10m;
+
+        # Security headers
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Content-Type-Options    "nosniff"                             always;
+        add_header X-Frame-Options           "SAMEORIGIN"                          always;
+        add_header X-XSS-Protection          "1; mode=block"                       always;
+        add_header Referrer-Policy           "strict-origin-when-cross-origin"     always;
+        add_header Permissions-Policy        "geolocation=(), microphone=()"       always;
+
+        # Proxy to Next.js container
+        location / {
+            limit_req zone=web burst=40 nodelay;
+
+            proxy_pass         http://web:3000;
+            proxy_http_version 1.1;
+            proxy_set_header   Upgrade           $http_upgrade;
+            proxy_set_header   Connection        "upgrade";
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+            proxy_read_timeout 60s;
+        }
+
+        # Next.js static assets — long-lived cache
+        location /_next/static/ {
+            proxy_pass http://web:3000/_next/static/;
+            expires    365d;
+            add_header Cache-Control "public, immutable";
+        }
+    }
+}


### PR DESCRIPTION
Closes #474

Adds `nginx/nginx.conf` with:
- HTTP→HTTPS redirect
- Proxy to `web:3000` with proper headers
- Security headers (HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy)
- Rate limiting (20r/s, burst 40)
- Long-lived cache for `/_next/static/` assets
- `nginx/Dockerfile` using `nginx:1.27-alpine` with HEALTHCHECK