### PR TITLE
feat: docker-compose.yml for full local dev stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy to .env and fill in values before running docker compose up
+# Place TLS certificates at nginx/certs/cert.pem and nginx/certs/key.pem

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+services:
+  web:
+    build:
+      context: ./apps/web
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    environment:
+      - NODE_ENV=production
+    expose:
+      - "3000"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  nginx:
+    build:
+      context: ./nginx
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/certs:/etc/nginx/certs:ro
+    depends_on:
+      web:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:80/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s


### PR DESCRIPTION
Closes #473

Adds `docker-compose.yml` wiring up `web` (Next.js) and `nginx` services.

- `web` uses `apps/web/Dockerfile` (multi-stage, see #472)
- `nginx` uses `nginx/Dockerfile` (see #474)
- nginx starts only after web passes its healthcheck
- TLS certs mounted from `nginx/certs/` (gitignored)
- Spin up everything with: `docker compose up`