### PR TITLE
feat: Dockerfile for reproducible Soroban contract builds

### DIFF
--- a/contracts/Dockerfile
+++ b/contracts/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1
+# Reproducible Soroban / Stellar contract build environment.
+# Pins exact Rust toolchain + Stellar CLI versions so WASM output
+# is identical across machines and CI runs.
+
+FROM rust:1.85.0-bookworm AS builder
+
+# Exact Stellar CLI version compatible with soroban-sdk 23
+ARG STELLAR_CLI_VERSION=22.6.0
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates curl binaryen \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install pinned wasm32 target
+RUN rustup target add wasm32v1-none
+
+# Install pinned Stellar CLI
+RUN cargo install --locked stellar-cli --version ${STELLAR_CLI_VERSION} \
+      --features opt
+
+WORKDIR /workspace
+
+# Copy workspace manifests first for layer caching
+COPY Cargo.toml Cargo.lock ./
+COPY contracts/ contracts/
+
+# Build all contracts → WASM artifacts land in target/wasm32v1-none/release/
+RUN stellar contract build
+
+HEALTHCHECK NONE
+
+# ── Output stage ─────────────────────────────────────────────────────────────
+FROM scratch AS artifacts
+COPY --from=builder /workspace/target/wasm32v1-none/release/*.wasm /

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,26 @@
+# Soroban Contract Build Image
+
+Reproducible WASM builds via Docker.
+
+## Build
+
+```bash
+# Build WASM artifacts into a scratch image
+docker build -t esustellar-contracts -f contracts/Dockerfile .
+
+# Extract WASM files to local ./wasm/ directory
+docker create --name tmp-contracts esustellar-contracts && \
+  mkdir -p wasm && \
+  docker cp tmp-contracts:/ wasm/ && \
+  docker rm tmp-contracts
+```
+
+## Pinned versions
+
+| Tool        | Version  |
+|-------------|----------|
+| Rust        | 1.85.0   |
+| Stellar CLI | 22.6.0   |
+| soroban-sdk | 23.x     |
+
+To update, change `ARG STELLAR_CLI_VERSION` and the `FROM rust:` base image tag.


### PR DESCRIPTION
Closes #475

Adds `contracts/Dockerfile` that pins exact versions:
- **Rust** `1.85.0`
- **Stellar CLI** `22.6.0`
- **soroban-sdk** `23.x` (workspace)

Multi-stage build: `builder` compiles all contracts to WASM; `artifacts` (scratch) exposes only the `.wasm` files. Any developer or CI job gets byte-for-byte identical output. See `contracts/README.md` for usage.