### PR TITLE
feat(monitoring): Grafana dashboards, deployment, and network policies

### DIFF
--- a/infra/k8s/network-policies.yaml
+++ b/infra/k8s/network-policies.yaml
@@ -1,0 +1,89 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: deny-all-ingress
+  namespace: esustellar
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress: []
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-controller
+  namespace: esustellar
+spec:
+  podSelector:
+    matchLabels:
+      app: esustellar-web
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: controller
+      ports:
+        - port: 3000
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-monitoring
+  namespace: esustellar
+spec:
+  podSelector:
+    matchLabels:
+      app: esustellar-web
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: esustellar-monitoring
+      ports:
+        - port: 9464
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-egress
+  namespace: esustellar
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-only-api-egress
+  namespace: esustellar
+spec:
+  podSelector:
+    matchLabels:
+      app: esustellar-web
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 443
+        - port: 80
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: esustellar-monitoring

--- a/infra/monitoring/grafana/dashboards/dashboard-provisioning.yaml
+++ b/infra/monitoring/grafana/dashboards/dashboard-provisioning.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboards-provisioning
+  namespace: esustellar-monitoring
+data:
+  dashboards.yaml: |
+    apiVersion: 1
+    providers:
+      - name: "default"
+        orgId: 1
+        folder: ""
+        type: file
+        disableDeletion: true
+        editable: false
+        options:
+          path: /var/lib/grafana/dashboards

--- a/infra/monitoring/grafana/dashboards/on-chain-events.json
+++ b/infra/monitoring/grafana/dashboards/on-chain-events.json
@@ -1,0 +1,28 @@
+{
+  "__inputs": [],
+  "__requires": [],
+  "title": "On-Chain Savings Events",
+  "uid": "on-chain-events",
+  "panels": [
+    {
+      "title": "Groups Created",
+      "type": "stat",
+      "targets": [{ "expr": "increase(stellar_group_created_total[24h])", "legendFormat": "24h" }]
+    },
+    {
+      "title": "Contributions Made",
+      "type": "graph",
+      "targets": [{ "expr": "rate(stellar_contribution_total[5m])", "legendFormat": "rate" }]
+    },
+    {
+      "title": "Payouts Sent",
+      "type": "graph",
+      "targets": [{ "expr": "rate(stellar_payout_total[5m])", "legendFormat": "rate" }]
+    },
+    {
+      "title": "Event Log",
+      "type": "logs",
+      "targets": [{ "expr": "{job=\"stellar-indexer\"}", "legendFormat": "" }]
+    }
+  ]
+}

--- a/infra/monitoring/grafana/dashboards/web-app-golden-signals.json
+++ b/infra/monitoring/grafana/dashboards/web-app-golden-signals.json
@@ -1,0 +1,27 @@
+{
+  "__inputs": [],
+  "__requires": [],
+  "title": "Web App — Golden Signals",
+  "uid": "web-app-golden-signals",
+  "panels": [
+    {
+      "title": "Request Rate",
+      "type": "graph",
+      "targets": [{ "expr": "rate(http_requests_total[5m])", "legendFormat": "rate" }]
+    },
+    {
+      "title": "Error Rate",
+      "type": "graph",
+      "targets": [{ "expr": "rate(http_requests_total{status=~\"5..\"}[5m])", "legendFormat": "errors" }]
+    },
+    {
+      "title": "Latency (p50/p95/p99)",
+      "type": "graph",
+      "targets": [
+        { "expr": "histogram_quantile(0.50, rate(http_request_duration_seconds_bucket[5m]))", "legendFormat": "p50" },
+        { "expr": "histogram_quantile(0.95, rate(http_request_duration_seconds_bucket[5m]))", "legendFormat": "p95" },
+        { "expr": "histogram_quantile(0.99, rate(http_request_duration_seconds_bucket[5m]))", "legendFormat": "p99" }
+      ]
+    }
+  ]
+}

--- a/infra/monitoring/grafana/datasources/prometheus.yaml
+++ b/infra/monitoring/grafana/datasources/prometheus.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasources
+  namespace: esustellar-monitoring
+data:
+  datasources.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        access: proxy
+        url: http://prometheus:9090
+        isDefault: true
+        editable: false

--- a/infra/monitoring/grafana/grafana-deployment.yaml
+++ b/infra/monitoring/grafana/grafana-deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: esustellar-monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+        - name: grafana
+          image: grafana/grafana:10.4.2
+          ports:
+            - containerPort: 3000
+              name: grafana-http
+          env:
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-admin
+                  key: password
+            - name: GF_INSTALL_PLUGINS
+              value: ""
+          volumeMounts:
+            - name: grafana-storage
+              mountPath: /var/lib/grafana
+            - name: grafana-datasources
+              mountPath: /etc/grafana/provisioning/datasources
+            - name: grafana-dashboards
+              mountPath: /etc/grafana/provisioning/dashboards
+            - name: grafana-dashboard-files
+              mountPath: /var/lib/grafana/dashboards
+      volumes:
+        - name: grafana-storage
+          persistentVolumeClaim:
+            claimName: grafana-storage
+        - name: grafana-datasources
+          configMap:
+            name: grafana-datasources
+        - name: grafana-dashboards
+          configMap:
+            name: grafana-dashboards-provisioning
+        - name: grafana-dashboard-files
+          configMap:
+            name: grafana-dashboard-files
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  namespace: esustellar-monitoring
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: grafana-http
+  selector:
+    app: grafana
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: grafana-storage
+  namespace: esustellar-monitoring
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/infra/monitoring/grafana/kustomization.yaml
+++ b/infra/monitoring/grafana/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: esustellar-monitoring
+resources:
+  - grafana-deployment.yaml
+  - datasources/prometheus.yaml
+  - dashboards/dashboard-provisioning.yaml
+  - dashboards/on-chain-events.json
+  - dashboards/web-app-golden-signals.json
+configMapGenerator:
+  - name: grafana-dashboard-files
+    files:
+      - dashboards/on-chain-events.json
+      - dashboards/web-app-golden-signals.json


### PR DESCRIPTION
## Summary
Grafana monitoring stack and Kubernetes NetworkPolicies.

## Changes
- **Grafana deployment** with provisioning and PVC
- **Prometheus datasource** auto-provisioned in Grafana
- **Dashboard: web app golden signals** (rate, errors, latency)
- **Dashboard: on-chain savings events** (groups, contributions, payouts)
- **NetworkPolicies** restricting ingress/egress traffic

Closes #510, 
Closes #509, 
Closes #508, 
Closes #506