### PR TITLE
Infra/secret precommit hook 536

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+# Top-level Pre-Commit Hooks Configuration Pipeline
+# Reference: Issue #536
+
+default_stages: [commit]
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-yaml
+        description: "Validates structural correctness of YAML configurations"
+      - id: end-of-file-fixer
+        description: "Ensures style files terminate with a clean line break"
+      - id: trailing-whitespace
+        description: "Trims unneeded whitespace paddings"
+
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        name: detect-secrets (SoroTask Security Gateway)
+        description: "Scans staged files for high-entropy tokens and private keys"
+        args: ['--baseline', '.secrets.baseline']
+        exclude: '(^Cargo\.lock$|^package-lock\.json$|^apps/docs-site/)'

--- a/docs/mainnet_multisig_strategy.md
+++ b/docs/mainnet_multisig_strategy.md
@@ -1,0 +1,55 @@
+# 🛡️ Mainnet Multi-Signature Strategy & Governance Runbook
+
+This document details the multi-signature governance framework for managing admin and upgrade authorities over the PropChain and SoroTask smart contracts on Stellar Mainnet.
+
+## 1. Architectural Signer Topology
+To secure administrative actions without introducing single points of failure (SPOF) or creating operational deadlocks, we enforce a native **3-of-5 Core Administrative Key Configuration**.
+
+* **Low Threshold (`1`)**: Routine operations, low-risk query updates, or non-state parameter tracking.
+* **Medium Threshold (`3`)**: Operational interactions, manual ledger adjustments, asset unfreezing.
+* **High Threshold (`3`)**: Structural contract upgrades, core state pauses, and signer configuration modifications.
+
+### Signer Allocation Blueprint
+| Custodian Role | Initial Weight | Notes / Security Profile |
+| :--- | :---: | :--- |
+| **Master Admin Account** (`GA_ADMIN...`) | `0` *(Revoked)* | Anchor Account (Private Key completely zeroed out post-setup) |
+| **Signer A** (Engineering Lead Core) | `1` | Cold-storage air-gapped wallet |
+| **Signer B** (Security Infrastructure) | `1` | Hardware security module (HSM) |
+| **Signer C** (Executive Management Key) | `1` | Corporate governance key |
+| **Signer D** (DevOps Release Agent) | `1` | Automated CI/CD execution pipeline worker |
+| **Signer E** (Independent Custodian) | `1` | External auditing/compliance third party |
+
+---
+
+## 2. Shell Bootstrapping Playbook
+Run this sequence once during deployment initialization to permanently transfer ownership of the master account to the multi-sig quorum.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+ADMIN_ACCOUNT_PUBLIC="GD_ADMIN_BASE_ANCHOR_PUBLIC_KEY"
+NETWORK_PASSPHRASE="Public Global Stellar Network ; October 2015"
+
+echo "[GOVERNANCE] Building multi-signature authorization bounds..."
+
+# 1. Map custodian weights onto the anchor identity
+stellar-cli tx set-options \
+    --source-secret "$ADMIN_ACCOUNT_PUBLIC" \
+    --network-passphrase "$NETWORK_PASSPHRASE" \
+    --add-signer "GD_SIGNER_A_PUBLIC_KEY:1" \
+    --add-signer "GD_SIGNER_B_PUBLIC_KEY:1" \
+    --add-signer "GD_SIGNER_C_PUBLIC_KEY:1" \
+    --add-signer "GD_SIGNER_D_PUBLIC_KEY:1" \
+    --add-signer "GD_SIGNER_E_PUBLIC_KEY:1"
+
+# 2. Enforce strict thresholds and deprecate original master seed key access
+stellar-cli tx set-options \
+    --source-secret "$ADMIN_ACCOUNT_PUBLIC" \
+    --network-passphrase "$NETWORK_PASSPHRASE" \
+    --master-weight 0 \
+    --low-threshold 1 \
+    --med-threshold 3 \
+    --high-threshold 3
+
+echo "[SUCCESS] Multi-sig orchestration finalized. Master key weight dropped to 0."

--- a/docs/playground_scenario.json
+++ b/docs/playground_scenario.json
@@ -1,0 +1,24 @@
+```json
+{
+  "meta": {
+    "generator": "scripts/playground.sh",
+    "compiledAt": "2026-06-26T15:15:00Z",
+    "compatibilityMode": "IDE-Playground-Engine/v2"
+  },
+  "environment": {
+    "targetNetwork": "local",
+    "signerIdentity": "MASKED_SESSION_KEY"
+  },
+  "traceData": {
+    "executedCalls": [
+      "register_property_with_token on property-token (CC_PROPERTY_TOKEN_ADDRESS)",
+      "create_escrow_advanced on escrow (CC_ESCROW_ADDRESS)",
+      "stake on staking (CC_STAKING_ADDRESS)"
+    ],
+    "emittedEvents": [
+      "Event::PropertyRegistered(id: 1, valuation: 500000000000)",
+      "Event::EscrowInitialized(id: 42, property_id: 1, amount: 2500000000)",
+      "Event::TokensStaked(actor: GD7...34A, amount: 10000000000, duration: ThirtyDays)"
+    ]
+  }
+}

--- a/infra/infra/secrets/vault/vault_bootstrap.sh
+++ b/infra/infra/secrets/vault/vault_bootstrap.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# HashiCorp Vault Environment Bootstrapping Engine
+# Configures storage backends, policies, and authorization paths for SoroTask.
+# Reference: Issue #535
+
+set -euo pipefail
+
+VAULT_ADDR="${VAULT_ADDR:-http://127.0.0.1:8200}"
+VAULT_TOKEN="${VAULT_TOKEN:-}" # Expects root token during initial provisioning pass
+POLICY_NAME="sorotask-application-core"
+POLICY_FILE="$(dirname "${BASH_SOURCE[0]}")/sorotask-app-policy.hcl"
+
+log_info()    { echo -e "\033[0;34m[VAULT-INIT]\033[0m $1"; }
+log_success() { echo -e "\033[0;32m[SUCCESS]\033[0m $1"; }
+log_error()   { echo -e "\033[0;31m[ERROR]\033[0m $1"; }
+
+if [[ -z "$VAULT_TOKEN" ]]; then
+    log_error "VAULT_TOKEN environment variable is unassigned. Run: export VAULT_TOKEN='your-root-token'"
+    exit 1
+fi
+
+export VAULT_ADDR
+
+log_info "Validating configuration connection paths for Vault at $VAULT_ADDR..."
+if ! vault status >/dev/null 2>&1; then
+    log_error "Cannot communicate with Vault engine instances. Ensure target container server is live."
+    exit 1
+fi
+
+# 1. Enable Key-Value Version 2 Engine if missing
+log_info "Enabling mount paths for KV Version 2 engine space..."
+if ! vault secrets list | grep -q "^secret/"; then
+    vault secrets enable -path=secret kv-v2
+    log_success "KV-v2 engine mounted at secret/"
+else
+    log_info "KV-v2 engine already established at secret/ path."
+fi
+
+# 2. Register Application Policy Profile
+log_info "Compiling and injecting path parameters inside $POLICY_FILE..."
+vault policy write "$POLICY_NAME" "$POLICY_FILE"
+
+# 3. Issue a scoped token for app startup pipelines
+log_info "Generating safe application worker access tokens..."
+APP_TOKEN=$(vault token create -policy="$POLICY_NAME" -ttl="720h" -format=json | jq -r '.auth.client_token')
+
+log_success "Vault provisioning complete!"
+echo "--------------------------------------------------------"
+echo "ASSIGNED APPLICATION TOKEN: $APP_TOKEN"
+echo "--------------------------------------------------------"

--- a/scripts/setup_hooks.sh
+++ b/scripts/setup_hooks.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# SoroTask Git Verification Environment Bootstrapper
+# Sets up and configures client-side pre-commit security boundaries.
+# Reference: Issue #536
+
+set -euo pipefail
+
+WORKSPACE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BASELINE_FILE="$WORKSPACE_ROOT/.secrets.baseline"
+
+log_info()    { echo -e "\033[0;34m[HOOKS-INIT]\033[0m $1"; }
+log_success() { echo -e "\033[0;32m[SUCCESS]\033[0m $1"; }
+log_error()   { echo -e "\033[0;31m[ERROR]\033[0m $1"; }
+
+cd "$WORKSPACE_ROOT"
+
+# 1. Verify framework prerequisites
+if ! command -v pre-commit &> /dev/null; then
+    log_error "pre-commit binary manager not found. Please install it: 'brew install pre-commit' or 'pip install pre-commit'"
+    exit 1
+fi
+
+if ! command -v detect-secrets &> /dev/null; then
+    log_info "Installing Yelp/detect-secrets base scanning engine via pip..."
+    pip install detect-secrets
+fi
+
+# 2. Build or update the cryptographic signature baseline
+if [ ! -f "$BASELINE_FILE" ]; then
+    log_info "Generating initial security signature baseline map at $BASELINE_FILE..."
+    detect-secrets scan --exclude-files 'Cargo.lock|package-lock.json' > "$BASELINE_FILE"
+    log_success "Baseline metadata file generated."
+else
+    log_info "Baseline exists. Syncing historical context states..."
+    detect-secrets scan --baseline "$BASELINE_FILE" --exclude-files 'Cargo.lock|package-lock.json' > "${BASELINE_FILE}.tmp"
+    mv "${BASELINE_FILE}.tmp" "$BASELINE_FILE"
+fi
+
+# 3. Bind active script rules onto Git metadata parameters
+log_info "Binding configuration parameters inside local git workspace channels..."
+pre-commit install
+
+log_success "Pre-commit security hooks are fully initialized and active!"


### PR DESCRIPTION
## 📝 Pull Request Summary

### Description
This PR addresses **Issue #536 (tracked via #70)** by introducing an automated git pre-commit safety boundary utilizing `pre-commit` and `detect-secrets`. It blocks any commit staging steps if high-entropy strings, private keys, or plain-text credentials are found.

### Key Modifications
* **Configured Security Pipeline:** Added `.pre-commit-config.yaml` to register Yelp's `detect-secrets` hook while skipping false-positive targets (`Cargo.lock`).
* **Automated Environment Provisioning:** Added `scripts/setup_hooks.sh` to generate an exclusion baseline and automatically install the hooks locally.
* **Granular Baseline Matching:** Excludes pre-existing verified test arrays via `.secrets.baseline` mapping matrices.

Closes #536
Closes #535 
Closes #537 