### PR TITLE
feat: add Kubernetes infrastructure manifests

### DIFF
--- a/k8s/config/mainnet-configmap.yaml
+++ b/k8s/config/mainnet-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: esustellar-config
+  namespace: esustellar-mainnet
+  labels:
+    app: esustellar-web
+    environment: mainnet
+data:
+  NEXT_PUBLIC_SAVINGS_CONTRACT_ID: ""
+  NEXT_PUBLIC_REGISTRY_CONTRACT_ID: ""
+  NEXT_PUBLIC_CONTRACT_ID: ""

--- a/k8s/config/mainnet-secret.yaml
+++ b/k8s/config/mainnet-secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: esustellar-secrets
+  namespace: esustellar-mainnet
+  labels:
+    app: esustellar-web
+    environment: mainnet
+type: Opaque
+# Values must be base64-encoded. Replace with actual secrets before applying.
+# Example: echo -n 'production' | base64
+stringData:
+  NODE_ENV: "production"

--- a/k8s/config/staging-configmap.yaml
+++ b/k8s/config/staging-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: esustellar-config
+  namespace: esustellar-staging
+  labels:
+    app: esustellar-web
+    environment: staging
+data:
+  NEXT_PUBLIC_SAVINGS_CONTRACT_ID: ""
+  NEXT_PUBLIC_REGISTRY_CONTRACT_ID: ""
+  NEXT_PUBLIC_CONTRACT_ID: ""

--- a/k8s/config/staging-secret.yaml
+++ b/k8s/config/staging-secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: esustellar-secrets
+  namespace: esustellar-staging
+  labels:
+    app: esustellar-web
+    environment: staging
+type: Opaque
+# Values must be base64-encoded. Replace with actual secrets before applying.
+# Example: echo -n 'staging' | base64
+stringData:
+  NODE_ENV: "staging"

--- a/k8s/config/testnet-configmap.yaml
+++ b/k8s/config/testnet-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: esustellar-config
+  namespace: esustellar-testnet
+  labels:
+    app: esustellar-web
+    environment: testnet
+data:
+  NEXT_PUBLIC_SAVINGS_CONTRACT_ID: ""
+  NEXT_PUBLIC_REGISTRY_CONTRACT_ID: ""
+  NEXT_PUBLIC_CONTRACT_ID: ""

--- a/k8s/config/testnet-secret.yaml
+++ b/k8s/config/testnet-secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: esustellar-secrets
+  namespace: esustellar-testnet
+  labels:
+    app: esustellar-web
+    environment: testnet
+type: Opaque
+# Values must be base64-encoded. Replace with actual secrets before applying.
+# Example: echo -n 'test' | base64
+stringData:
+  NODE_ENV: "test"

--- a/k8s/deployments/mainnet.yaml
+++ b/k8s/deployments/mainnet.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: esustellar-web
+  namespace: esustellar-mainnet
+  labels:
+    app: esustellar-web
+    environment: mainnet
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: esustellar-web
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        app: esustellar-web
+    spec:
+      containers:
+        - name: web
+          image: esustellar/web:latest
+          ports:
+            - containerPort: 3000
+          envFrom:
+            - configMapRef:
+                name: esustellar-config
+            - secretRef:
+                name: esustellar-secrets
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 10

--- a/k8s/deployments/staging.yaml
+++ b/k8s/deployments/staging.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: esustellar-web
+  namespace: esustellar-staging
+  labels:
+    app: esustellar-web
+    environment: staging
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: esustellar-web
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        app: esustellar-web
+    spec:
+      containers:
+        - name: web
+          image: esustellar/web:staging
+          ports:
+            - containerPort: 3000
+          envFrom:
+            - configMapRef:
+                name: esustellar-config
+            - secretRef:
+                name: esustellar-secrets
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 10

--- a/k8s/deployments/testnet.yaml
+++ b/k8s/deployments/testnet.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: esustellar-web
+  namespace: esustellar-testnet
+  labels:
+    app: esustellar-web
+    environment: testnet
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: esustellar-web
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        app: esustellar-web
+    spec:
+      containers:
+        - name: web
+          image: esustellar/web:testnet
+          ports:
+            - containerPort: 3000
+          envFrom:
+            - configMapRef:
+                name: esustellar-config
+            - secretRef:
+                name: esustellar-secrets
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 10

--- a/k8s/namespaces/mainnet.yaml
+++ b/k8s/namespaces/mainnet.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: esustellar-mainnet
+  labels:
+    app.kubernetes.io/name: esustellar
+    environment: mainnet

--- a/k8s/namespaces/staging.yaml
+++ b/k8s/namespaces/staging.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: esustellar-staging
+  labels:
+    app.kubernetes.io/name: esustellar
+    environment: staging

--- a/k8s/namespaces/testnet.yaml
+++ b/k8s/namespaces/testnet.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: esustellar-testnet
+  labels:
+    app.kubernetes.io/name: esustellar
+    environment: testnet


### PR DESCRIPTION
## Summary

This PR implements the Kubernetes infrastructure for the EsuStellar web app across all three environments (testnet, staging, mainnet).

## Changes

### Namespaces (closes #504)
- `k8s/namespaces/testnet.yaml` — `esustellar-testnet` namespace
- `k8s/namespaces/staging.yaml` — `esustellar-staging` namespace
- `k8s/namespaces/mainnet.yaml` — `esustellar-mainnet` namespace

### Deployments (closes #503)
- `k8s/deployments/testnet.yaml` — RollingUpdate with `maxUnavailable: 0`, `maxSurge: 1`
- `k8s/deployments/staging.yaml` — RollingUpdate with `maxUnavailable: 0`, `maxSurge: 1`
- `k8s/deployments/mainnet.yaml` — RollingUpdate with `maxUnavailable: 0`, `maxSurge: 1`

### ConfigMaps & Secrets (closes #505)
- `k8s/config/*-configmap.yaml` — `NEXT_PUBLIC_SAVINGS_CONTRACT_ID`, `NEXT_PUBLIC_REGISTRY_CONTRACT_ID`, `NEXT_PUBLIC_CONTRACT_ID` injected at runtime
- `k8s/config/*-secret.yaml` — `NODE_ENV` managed as a Kubernetes Secret per environment

## Testing
Manifests are valid YAML and reference the correct namespaces. Fill in the placeholder values in ConfigMaps and Secrets before applying to a cluster.