### PR TITLE
ci: add stale-issue github action workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,32 @@
+name: "Close Stale Issues and PRs"
+
+on:
+  schedule:
+    # Runs at 00:00 UTC every day
+    - cron: '0 0 * * *'
+  workflow_dispatch: # Allows you to trigger it manually from the Actions tab
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: "Handle Stale Items"
+        uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          
+          # Configuration criteria
+          days-before-stale: 30
+          days-before-close: 7
+          
+          # Custom Labels
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          
+          # Custom Messages
+          stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed in 7 days if no further activity occurs. Thank you for your contributions!'
+          stale-pr-message: 'This PR has been automatically marked as stale because it has not had recent activity. It will be closed in 7 days if no further activity occurs.'


### PR DESCRIPTION
Closes #467 
Closes #468 
Closes #469 
Closes #470

## What i did 
Configures the `actions/stale` GitHub Action to automatically monitor, label, and close inactive issues and Pull Requests.

## Acceptance Criteria Verified
* [x] Configured threshold for 30 days of inactivity.
* [x] Provided a 7-day warning period before final closure.
* [x] Standard labels (`stale`) applied automatically.