### PR TITLE
feat(infra): deployer keypair rotation script and env-var validator

### DIFF
--- a/docs/runbooks/deployer-keypair-rotation.md
+++ b/docs/runbooks/deployer-keypair-rotation.md
@@ -1,0 +1,90 @@
+# Deployer Keypair Rotation Runbook
+
+This runbook documents the procedure for rotating the EsuStellar deployer Stellar keypair without causing deployment downtime.
+
+---
+
+## When to Rotate
+
+- Suspected key compromise
+- Scheduled security rotation (recommended every 90 days)
+- Team member with key access leaves the project
+
+---
+
+## Pre-rotation Checklist
+
+- [ ] No deployments in progress
+- [ ] You have write access to CI/CD secrets (GitHub Actions → Repository Secrets)
+- [ ] Stellar CLI is installed and authenticated locally
+
+---
+
+## Automated Rotation (recommended)
+
+Run the rotation script:
+
+```bash
+./infra/scripts/rotate-deployer-keypair.sh [network]
+# Default network: testnet
+# For mainnet: ./infra/scripts/rotate-deployer-keypair.sh mainnet
+```
+
+The script will:
+1. Generate a new `deployer-new` keypair
+2. Fund the account (Friendbot on testnet; manual on mainnet)
+3. Print the new public and secret keys — **save the secret key immediately**
+4. Remove the old `deployer` local identity
+5. Rename `deployer-new` → `deployer`
+
+---
+
+## Post-rotation Steps
+
+1. Update the `DEPLOYER_SECRET_KEY` secret in CI/CD (GitHub → Settings → Secrets → Actions).
+2. Trigger a test deployment to confirm the new key works.
+3. Verify the old public key no longer appears in `stellar keys ls`.
+
+---
+
+## Manual Rotation (fallback)
+
+If the script is unavailable:
+
+```bash
+# 1. Generate new keypair
+stellar keys generate deployer-new --network testnet --no-fund
+stellar keys fund deployer-new --network testnet   # testnet only
+
+# 2. Note new public key
+stellar keys address deployer-new
+
+# 3. Note new secret key (update CI/CD secrets immediately)
+stellar keys show deployer-new
+
+# 4. Remove old keypair
+stellar keys rm deployer
+
+# 5. Rename
+NEW_SECRET=$(stellar keys show deployer-new)
+stellar keys add deployer --secret-key "$NEW_SECRET"
+stellar keys rm deployer-new
+```
+
+---
+
+## Rollback
+
+If the new key fails:
+
+1. Restore the old secret key from your secrets manager.
+2. Re-add it locally: `stellar keys add deployer --secret-key <OLD_SECRET>`.
+3. Revert the CI/CD secret.
+
+---
+
+## Related
+
+- `infra/scripts/rotate-deployer-keypair.sh` — automation script
+- `deploy.sh` — uses the `deployer` identity for contract deployments
+- GitHub issue: [#534](https://github.com/BlockHaven-Labs/esustellar/issues/534)

--- a/infra/scripts/deploy/validate-env.sh
+++ b/infra/scripts/deploy/validate-env.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# validate-env.sh — Check required environment variables before deployment.
+# Usage: ./infra/scripts/deploy/validate-env.sh [env-file]
+#
+# Exits 0 if all required vars are present and non-empty, 1 otherwise.
+set -euo pipefail
+
+ENV_FILE="${1:-apps/web/.env.local}"
+
+# Load env file if it exists
+if [ -f "$ENV_FILE" ]; then
+  # shellcheck disable=SC1090
+  set -o allexport
+  source "$ENV_FILE"
+  set +o allexport
+fi
+
+REQUIRED_VARS=(
+  "NEXT_PUBLIC_REGISTRY_CONTRACT_ID"
+  "NEXT_PUBLIC_SAVINGS_CONTRACT_ID"
+  "NEXT_PUBLIC_CONTRACT_ID"
+)
+
+errors=0
+for var in "${REQUIRED_VARS[@]}"; do
+  if [ -z "${!var:-}" ]; then
+    echo "❌ Missing or empty: $var"
+    errors=$((errors + 1))
+  else
+    echo "✅ $var"
+  fi
+done
+
+if [ "$errors" -gt 0 ]; then
+  echo ""
+  echo "❌ $errors required variable(s) not set. Aborting deployment."
+  exit 1
+fi
+
+echo ""
+echo "✅ All required env vars are set."

--- a/infra/scripts/rotate-deployer-keypair.sh
+++ b/infra/scripts/rotate-deployer-keypair.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# rotate-deployer-keypair.sh — Rotate the Stellar deployer keypair without downtime.
+# Usage: ./infra/scripts/rotate-deployer-keypair.sh [network]
+#
+# Steps:
+#   1. Generate a new deployer keypair (deployer-new)
+#   2. Fund the new account on testnet, or prompt for mainnet
+#   3. Print the new public key for CI/CD secret update
+#   4. Remove the old deployer identity
+#   5. Rename deployer-new → deployer
+#
+# The caller must update their CI/CD secrets (DEPLOYER_SECRET_KEY) with the
+# new secret key printed during this script before the next deployment.
+set -euo pipefail
+
+NETWORK="${1:-testnet}"
+OLD_KEY="deployer"
+NEW_KEY="deployer-new"
+
+command -v stellar >/dev/null 2>&1 || { echo "❌ stellar CLI not found"; exit 1; }
+
+echo "🔑 EsuStellar Deployer Keypair Rotation"
+echo "========================================"
+echo "Network: $NETWORK"
+echo ""
+
+# Step 1: Generate new keypair
+echo "Step 1: Generating new keypair '$NEW_KEY'..."
+if stellar keys ls | awk '{print $1}' | grep -xq "$NEW_KEY"; then
+  echo "  ⚠️  '$NEW_KEY' already exists — removing before regenerating."
+  stellar keys rm "$NEW_KEY"
+fi
+stellar keys generate "$NEW_KEY" --network "$NETWORK" --no-fund
+
+NEW_PUBLIC=$(stellar keys address "$NEW_KEY")
+NEW_SECRET=$(stellar keys show "$NEW_KEY" 2>/dev/null || true)
+echo "  ✅ New public key:  $NEW_PUBLIC"
+
+# Step 2: Fund the new account
+echo ""
+echo "Step 2: Funding new account..."
+if [ "$NETWORK" = "testnet" ]; then
+  stellar keys fund "$NEW_KEY" --network "$NETWORK"
+  echo "  ✅ Testnet account funded via Friendbot."
+else
+  echo "  ⚠️  Mainnet detected. Fund this address manually before continuing:"
+  echo "       $NEW_PUBLIC"
+  read -rp "  Press ENTER once the account is funded..."
+fi
+
+# Step 3: Print rotation info
+echo ""
+echo "Step 3: New credentials — update CI/CD secrets NOW before proceeding:"
+echo "  DEPLOYER_PUBLIC_KEY=${NEW_PUBLIC}"
+if [ -n "$NEW_SECRET" ]; then
+  echo "  DEPLOYER_SECRET_KEY=${NEW_SECRET}"
+fi
+echo ""
+read -rp "  Have you saved the new secret key? [y/N] " confirm
+if [[ "${confirm,,}" != "y" ]]; then
+  echo "❌ Rotation aborted. Re-run when ready."
+  exit 1
+fi
+
+# Step 4: Remove old keypair
+echo ""
+echo "Step 4: Removing old keypair '$OLD_KEY'..."
+if stellar keys ls | awk '{print $1}' | grep -xq "$OLD_KEY"; then
+  stellar keys rm "$OLD_KEY"
+  echo "  ✅ Old keypair removed."
+else
+  echo "  ℹ️  '$OLD_KEY' not found locally — skipping."
+fi
+
+# Step 5: Rename new → deployer
+echo ""
+echo "Step 5: Renaming '$NEW_KEY' to '$OLD_KEY'..."
+# stellar CLI stores keys by name; re-generate under the target name using the same secret
+if [ -n "$NEW_SECRET" ]; then
+  stellar keys add "$OLD_KEY" --secret-key "$NEW_SECRET"
+  stellar keys rm "$NEW_KEY"
+  echo "  ✅ Keypair renamed to '$OLD_KEY'."
+else
+  echo "  ⚠️  Could not retrieve secret — please rename manually:"
+  echo "       stellar keys add deployer --secret-key <NEW_SECRET>"
+fi
+
+echo ""
+echo "🎉 Keypair rotation complete."
+echo "   Remember to update DEPLOYER_SECRET_KEY in your CI/CD environment."


### PR DESCRIPTION
## Summary

Resolves both issues assigned to @Blaqkenny.

Closes #534
Closes #525

## Changes

### `infra/scripts/rotate-deployer-keypair.sh` (closes #534)
Automates the Stellar deployer keypair rotation without downtime:
- Generates a new `deployer-new` keypair
- Funds it via Friendbot on testnet, or prompts for manual funding on mainnet
- Prints new public/secret keys for CI/CD update with confirmation gate
- Removes old `deployer` local identity
- Renames `deployer-new` → `deployer`

### `infra/scripts/deploy/validate-env.sh` (closes #525)
Pre-deployment env-var validator:
- Loads an optional env file (default: `apps/web/.env.local`)
- Checks `NEXT_PUBLIC_REGISTRY_CONTRACT_ID`, `NEXT_PUBLIC_SAVINGS_CONTRACT_ID`, `NEXT_PUBLIC_CONTRACT_ID` are set and non-empty
- Exits non-zero and lists every missing var so deployments fail fast

### `docs/runbooks/deployer-keypair-rotation.md`
Runbook documenting when to rotate, automated and manual procedures, post-rotation checklist, and rollback steps.

## Tested
- Scripts are syntactically valid bash (`bash -n` passes)
- Env validator correctly exits 1 when vars are unset and 0 when all present