### PR TITLE
feat: API rate limiting, contract access audit, secrets template, artifact cleanup

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// In-memory store: ip -> { count, resetAt }
+// Note: this resets on cold starts; for multi-instance deployments use Redis/Upstash.
+const ipStore = new Map<string, { count: number; resetAt: number }>();
+
+interface RateLimit {
+  requests: number; // max requests per window
+  windowMs: number; // window in milliseconds
+}
+
+// Per-route limits (stricter on mutation/faucet-adjacent routes)
+const ROUTE_LIMITS: Array<{ pattern: RegExp; limit: RateLimit }> = [
+  { pattern: /^\/api\//, limit: { requests: 60, windowMs: 60_000 } },
+];
+
+const DEFAULT_LIMIT: RateLimit = { requests: 120, windowMs: 60_000 };
+
+function getLimit(pathname: string): RateLimit {
+  for (const { pattern, limit } of ROUTE_LIMITS) {
+    if (pattern.test(pathname)) return limit;
+  }
+  return DEFAULT_LIMIT;
+}
+
+function getClientIp(req: NextRequest): string {
+  return (
+    req.headers.get("x-forwarded-for")?.split(",")[0].trim() ??
+    req.headers.get("x-real-ip") ??
+    "unknown"
+  );
+}
+
+export function middleware(req: NextRequest): NextResponse {
+  const { pathname } = req.nextUrl;
+  const ip = getClientIp(req);
+  const key = `${ip}:${pathname.split("/").slice(0, 3).join("/")}`;
+  const limit = getLimit(pathname);
+  const now = Date.now();
+
+  let entry = ipStore.get(key);
+  if (!entry || now > entry.resetAt) {
+    entry = { count: 0, resetAt: now + limit.windowMs };
+    ipStore.set(key, entry);
+  }
+
+  entry.count += 1;
+
+  const remaining = Math.max(0, limit.requests - entry.count);
+  const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
+
+  if (entry.count > limit.requests) {
+    return new NextResponse("Too Many Requests", {
+      status: 429,
+      headers: {
+        "Retry-After": String(retryAfter),
+        "X-RateLimit-Limit": String(limit.requests),
+        "X-RateLimit-Remaining": "0",
+        "X-RateLimit-Reset": String(Math.ceil(entry.resetAt / 1000)),
+      },
+    });
+  }
+
+  const res = NextResponse.next();
+  res.headers.set("X-RateLimit-Limit", String(limit.requests));
+  res.headers.set("X-RateLimit-Remaining", String(remaining));
+  res.headers.set("X-RateLimit-Reset", String(Math.ceil(entry.resetAt / 1000)));
+  return res;
+}
+
+export const config = {
+  // Apply to all routes except Next.js internals and static assets
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};

--- a/docs/contract-access-control-audit.md
+++ b/docs/contract-access-control-audit.md
@@ -1,0 +1,97 @@
+# Soroban Contract Access Control Audit
+
+**Date:** 2026-06-29  
+**Contracts audited:** `contracts/savings` · `contracts/registry`  
+**Auditor:** JudeDaniel6
+
+---
+
+## Summary
+
+Both contracts enforce access control through Soroban's `Address::require_auth()` mechanism, which cryptographically verifies that the transaction was signed by the expected account. No unintended privileged paths were found.
+
+---
+
+## contracts/savings (`SavingsContract`)
+
+### Admin-gated functions
+
+| Function | Auth check | Notes |
+|---|---|---|
+| `create_group` | `admin.require_auth()` | Caller must sign as `admin`; admin auto-joins the group as first member |
+
+### Member-gated functions (any group member)
+
+| Function | Auth check | Notes |
+|---|---|---|
+| `join_group` | `member.require_auth()` | Only the joining address can call on their own behalf |
+| `contribute` | `member.require_auth()` | Contribution recorded only for the authenticated member |
+
+### Internal / private functions
+
+| Function | Access | Notes |
+|---|---|---|
+| `distribute_payout` | `fn` (private) | Called automatically when all members pay; not externally callable |
+| `add_admin_to_group` | `fn` (private) | Called only from `create_group` |
+| `get_next_payout_recipient` | `fn` (private) | Read-only helper |
+| `all_members_paid` | `fn` (private) | Read-only helper |
+| `calculate_deadline` | `fn` (private) | Read-only helper |
+
+### Read-only (unauthenticated) functions
+
+`get_group`, `get_members`, `get_member`, `get_all_groups`, `get_user_groups`, `get_contributions`, `get_payouts`
+
+### Findings
+
+- ✅ **No pause/upgrade/emergency-drain function exists.** There is no privileged path to halt or drain a group by the admin after it becomes `Active`. This is consistent with the trustless design goal.
+- ✅ **Payout recipient selection is deterministic** (sequential by `join_order`), not admin-controlled, preventing bias.
+- ✅ **Admin cannot skip contributions.** `contribute` requires the caller to be a member and performs the same checks for all members including the admin.
+- ⚠️ **No contract upgrade path.** The contract is immutable once deployed. While this strengthens trustlessness, it means bugs cannot be patched without redeploying and migrating groups. Recommend documenting this trade-off in `contracts/savings/README.md`.
+- ⚠️ **Admin is auto-joined as member 0.** If the admin address is compromised, the attacker gains member rights (contribution, payout eligibility) but cannot access other members' funds or alter group parameters.
+
+---
+
+## contracts/registry (`GroupRegistry`)
+
+### Admin-gated functions
+
+| Function | Auth check | Notes |
+|---|---|---|
+| `register_group` | `admin.require_auth()` | Only the declared admin of a group can register it |
+
+### Member-gated functions
+
+| Function | Auth check | Notes |
+|---|---|---|
+| `add_member` | `member.require_auth()` | Users register themselves into a group's user mapping |
+
+### Read-only (unauthenticated) functions
+
+`get_all_public_groups`, `get_group_info`, `get_user_groups`, `get_group_count`
+
+### Findings
+
+- ✅ **Anyone can register a group** as long as they sign as `admin`. There is no global registry admin that could censor or revoke group registrations.
+- ✅ **`add_member` is idempotent.** Calling it a second time for an already-registered member is a no-op (returns `Ok(())`), preventing duplicate entries.
+- ⚠️ **No de-registration function.** Once registered, a group contract address cannot be removed from the registry. This is intentional for transparency but means stale/abandoned group entries accumulate over time.
+- ⚠️ **Group info is self-reported.** The `name`, `is_public`, and `total_members` fields in `GroupInfo` are provided by the caller at registration time and not verified against the savings contract state. A malicious actor could register a group with misleading metadata. Recommend cross-validating against the savings contract in the frontend.
+
+---
+
+## Overall Risk Assessment
+
+| Risk | Severity | Status |
+|---|---|---|
+| Unauthorised fund access | Critical | ✅ Not present |
+| Admin rug-pull / drain | High | ✅ Not possible by design |
+| Privilege escalation | High | ✅ Not present |
+| Misleading registry metadata | Low | ⚠️ Noted; mitigate in frontend |
+| No upgrade path for bug fixes | Medium | ⚠️ Documented trade-off |
+
+---
+
+## Recommendations
+
+1. Add a note to `contracts/savings/README.md` explaining the immutability trade-off and the recommended redeployment procedure if a critical bug is found.
+2. In the frontend (`apps/web`), cross-validate `GroupInfo.total_members` from the registry against the live savings contract before displaying group details.
+3. Consider emitting a `Paused` event path in a future contract version to allow groups to be temporarily halted by unanimous member vote (not admin unilaterally).

--- a/infra/secrets/templates/.env.example
+++ b/infra/secrets/templates/.env.example
@@ -1,0 +1,105 @@
+# ============================================================
+# EsuStellar — Complete Secrets Reference
+# ============================================================
+# Copy this file to .env (never commit .env) and fill in values.
+# Every variable used across the monorepo is documented here.
+#
+# Sections:
+#   1. Stellar / Soroban
+#   2. Web application (apps/web)
+#   3. Contract deployment
+#   4. Docker / Container registry
+#   5. Monitoring & alerting
+#   6. CI/CD (GitHub Actions)
+# ============================================================
+
+# ------------------------------------------------------------
+# 1. Stellar / Soroban
+# ------------------------------------------------------------
+
+# Stellar network to target: testnet | mainnet | standalone
+STELLAR_NETWORK=testnet
+
+# Horizon HTTP endpoint
+# Testnet:  https://horizon-testnet.stellar.org
+# Mainnet:  https://horizon.stellar.org
+STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
+
+# Soroban RPC endpoint
+# Testnet:  https://soroban-testnet.stellar.org
+# Mainnet:  https://mainnet.stellar.validationcloud.io/v1/<API_KEY>
+STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+
+# Network passphrase
+# Testnet:  Test SDF Network ; September 2015
+# Mainnet:  Public Global Stellar Network ; September 2015
+STELLAR_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+
+# Deployer keypair — used by deploy.sh and CI to upload WASM / invoke contracts
+# NEVER share or commit the secret key.
+STELLAR_DEPLOYER_PUBLIC_KEY=G...
+STELLAR_DEPLOYER_SECRET_KEY=S...
+
+# Deployed contract IDs (populated after first deploy)
+SAVINGS_CONTRACT_ID=
+REGISTRY_CONTRACT_ID=
+
+# ------------------------------------------------------------
+# 2. Web application (apps/web)
+# ------------------------------------------------------------
+
+# Public RPC / Horizon URLs exposed to the browser (NEXT_PUBLIC_ prefix required)
+NEXT_PUBLIC_STELLAR_NETWORK=testnet
+NEXT_PUBLIC_HORIZON_URL=https://horizon-testnet.stellar.org
+NEXT_PUBLIC_SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+NEXT_PUBLIC_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+NEXT_PUBLIC_SAVINGS_CONTRACT_ID=
+NEXT_PUBLIC_REGISTRY_CONTRACT_ID=
+
+# ------------------------------------------------------------
+# 3. Contract deployment
+# ------------------------------------------------------------
+
+# Optional: Stellar Validation Cloud API key for mainnet RPC
+VALIDATION_CLOUD_API_KEY=
+
+# Optional: Friendbot endpoint for testnet account funding
+STELLAR_FRIENDBOT_URL=https://friendbot.stellar.org
+
+# ------------------------------------------------------------
+# 4. Docker / Container registry
+# ------------------------------------------------------------
+
+# GitHub Container Registry (ghcr.io) credentials
+# Used by CI (ghcr-publish.yml) and docker-compose for pulling private images.
+GHCR_USERNAME=
+GHCR_TOKEN=           # GitHub PAT with packages:read / packages:write
+
+# Image tag overrides (defaults to git SHA in CI)
+WEB_IMAGE_TAG=latest
+
+# ------------------------------------------------------------
+# 5. Monitoring & alerting
+# ------------------------------------------------------------
+
+# Prometheus / Grafana basic-auth password (set in docker-compose / k8s secret)
+GRAFANA_ADMIN_PASSWORD=
+
+# Alertmanager — Slack webhook for critical alerts
+ALERTMANAGER_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...
+
+# Balance exporter — the Stellar account to monitor for minimum deployer balance
+BALANCE_EXPORTER_ACCOUNT=G...
+BALANCE_EXPORTER_THRESHOLD_XLM=10
+
+# ------------------------------------------------------------
+# 6. CI/CD (GitHub Actions)
+# ------------------------------------------------------------
+# The variables below are stored as GitHub Actions secrets and are
+# NOT needed in a local .env file. They are listed here for reference
+# so engineers know which secrets must be configured in the repository.
+#
+# STELLAR_DEPLOYER_SECRET_KEY  — deployer secret key used in deploy.sh
+# GHCR_TOKEN                   — packages:write PAT for image publishing
+# CODECOV_TOKEN                — Codecov upload token
+# ALERTMANAGER_SLACK_WEBHOOK_URL — duplicated here for reference

--- a/scripts/cleanup-artifacts.sh
+++ b/scripts/cleanup-artifacts.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# scripts/cleanup-artifacts.sh
+#
+# Removes:
+#   - WASM files older than 30 days from the target/ directory
+#   - Container image tags beyond the 10 most recent for each package in GHCR
+#
+# Usage:
+#   ./scripts/cleanup-artifacts.sh [--dry-run]
+#
+# Requirements (container cleanup):
+#   - gh CLI authenticated (gh auth login)
+#   - GHCR_OWNER env var (defaults to git remote org/user)
+
+set -euo pipefail
+
+DRY_RUN=false
+if [[ "${1:-}" == "--dry-run" ]]; then
+  DRY_RUN=true
+  echo "[dry-run] No files or images will be deleted."
+fi
+
+log()  { echo "[cleanup] $*"; }
+warn() { echo "[cleanup] WARN: $*" >&2; }
+
+# ── WASM cleanup ──────────────────────────────────────────────────────────────
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WASM_MAX_AGE_DAYS=30
+
+log "Scanning for WASM files older than ${WASM_MAX_AGE_DAYS} days under ${REPO_ROOT}/target/ ..."
+
+mapfile -t OLD_WASMS < <(
+  find "${REPO_ROOT}/target" -name "*.wasm" -mtime "+${WASM_MAX_AGE_DAYS}" 2>/dev/null || true
+)
+
+if [[ ${#OLD_WASMS[@]} -eq 0 ]]; then
+  log "No stale WASM files found."
+else
+  for f in "${OLD_WASMS[@]}"; do
+    if $DRY_RUN; then
+      log "[dry-run] Would delete: $f"
+    else
+      rm -f "$f"
+      log "Deleted: $f"
+    fi
+  done
+fi
+
+# ── Container image cleanup ───────────────────────────────────────────────────
+
+KEEP_TAGS=10
+
+# Determine GHCR owner from env or git remote
+if [[ -z "${GHCR_OWNER:-}" ]]; then
+  GHCR_OWNER="$(git -C "${REPO_ROOT}" remote get-url origin 2>/dev/null \
+    | sed -E 's|.*github\.com[:/]([^/]+)/.*|\1|' || true)"
+fi
+
+if [[ -z "${GHCR_OWNER:-}" ]]; then
+  warn "Cannot determine GHCR_OWNER. Set the GHCR_OWNER environment variable."
+  warn "Skipping container image cleanup."
+  exit 0
+fi
+
+if ! command -v gh &>/dev/null; then
+  warn "gh CLI not found. Skipping container image cleanup."
+  exit 0
+fi
+
+log "Fetching container packages for owner '${GHCR_OWNER}' ..."
+
+# List all container packages (may be empty for new orgs)
+PACKAGES=$(gh api \
+  --paginate \
+  "/users/${GHCR_OWNER}/packages?package_type=container" \
+  --jq '.[].name' 2>/dev/null || \
+  gh api \
+  --paginate \
+  "/orgs/${GHCR_OWNER}/packages?package_type=container" \
+  --jq '.[].name' 2>/dev/null || true)
+
+if [[ -z "$PACKAGES" ]]; then
+  log "No container packages found for '${GHCR_OWNER}'."
+  exit 0
+fi
+
+while IFS= read -r pkg; do
+  log "Processing package: ${pkg}"
+
+  # Fetch all versions sorted by created_at descending
+  VERSIONS=$(gh api \
+    --paginate \
+    "/users/${GHCR_OWNER}/packages/container/${pkg}/versions" \
+    --jq 'sort_by(.created_at) | reverse | .[].id' 2>/dev/null || \
+    gh api \
+    --paginate \
+    "/orgs/${GHCR_OWNER}/packages/container/${pkg}/versions" \
+    --jq 'sort_by(.created_at) | reverse | .[].id' 2>/dev/null || true)
+
+  if [[ -z "$VERSIONS" ]]; then
+    log "  No versions found."
+    continue
+  fi
+
+  mapfile -t VERSION_IDS <<< "$VERSIONS"
+  TOTAL=${#VERSION_IDS[@]}
+  log "  Found ${TOTAL} version(s); keeping ${KEEP_TAGS}."
+
+  if [[ $TOTAL -le $KEEP_TAGS ]]; then
+    log "  Nothing to delete."
+    continue
+  fi
+
+  # Delete everything beyond the KEEP_TAGS most recent
+  for id in "${VERSION_IDS[@]:${KEEP_TAGS}}"; do
+    if $DRY_RUN; then
+      log "  [dry-run] Would delete version id=${id}"
+    else
+      gh api --method DELETE \
+        "/users/${GHCR_OWNER}/packages/container/${pkg}/versions/${id}" \
+        2>/dev/null || \
+        gh api --method DELETE \
+        "/orgs/${GHCR_OWNER}/packages/container/${pkg}/versions/${id}" \
+        2>/dev/null || \
+        warn "  Failed to delete version id=${id} (may already be gone)"
+      log "  Deleted version id=${id}"
+    fi
+  done
+done <<< "$PACKAGES"
+
+log "Cleanup complete."


### PR DESCRIPTION
## Summary

Resolves all four issues assigned to @JudeDaniel6.

Closes #531
Closes #532
Closes #540
Closes #541

---

## Changes

### #541 — API rate limiting on apps/web backend routes
- Added `apps/web/middleware.ts` — a Next.js Edge middleware that applies in-process rate limiting to all routes.
- Limits: **60 req/min** on `/api/*`, **120 req/min** on all other pages.
- Returns `429 Too Many Requests` with `Retry-After`, `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` headers.
- Nginx already enforces `limit_req_zone` at the reverse-proxy layer; this adds a second layer of protection directly in the application.

### #540 — Soroban contract access control audit
- Added `docs/contract-access-control-audit.md` documenting the full access control surface of `contracts/savings` and `contracts/registry`.
- Key findings: no unauthorised fund access paths, no admin rug-pull vector, no privilege escalation.
- Noted trade-offs: contract immutability (no upgrade path), self-reported registry metadata.

### #532 — Audit and document all project secrets
- Created `infra/secrets/templates/.env.example` listing every secret variable used across the monorepo (Stellar keys, RPC URLs, GHCR tokens, Grafana, Alertmanager, CI/CD secrets) with descriptions and safe placeholder values.
- File is force-added past the `secrets/` gitignore rule because it is a *template* (no real values).

### #531 — Script: clean up old WASM builds and stale container images
- Added `scripts/cleanup-artifacts.sh` (executable).
- Deletes WASM files older than 30 days from `target/`.
- Deletes GHCR container image versions beyond the 10 most recent per package via the `gh` CLI.
- Supports `--dry-run` flag to preview deletions without executing them.

## Testing
- Middleware: verified TypeScript compiles, matcher pattern correct.
- Cleanup script: verified with `--dry-run` on local checkout (no WASM files to delete, no GHCR packages accessible from fork).
- Audit doc: cross-referenced against `contracts/savings/src/lib.rs` and `contracts/registry/src/lib.rs`.