### PR TITLE
Issue #543: Configure Terraform remote state with locking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,12 @@ frd.md
 logs/
 *.log
 
+# Terraform
+infra/terraform/**/.terraform/
+infra/terraform/**/terraform.tfstate*
+infra/terraform/**/*.tfvars
+*.terraform.lock.hcl
+
 # personal note for maintainer
 # DO NOT EDIT!!!
 personalContributorNote.md

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -6,6 +6,20 @@
 Developer Push → GitHub Actions → Build → Deploy
 ```
 
+## Prerequisite: Terraform Remote State
+
+Before deploying infrastructure with Terraform, bootstrap the remote state backend:
+
+```bash
+cd infra/terraform/state-bootstrap
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars with your AWS region and bucket name
+terraform init
+terraform apply
+```
+
+This creates an S3 bucket (with versioning and encryption) and a DynamoDB table for state locking. All downstream Terraform configs use this remote backend automatically.
+
 ## Step-by-Step
 
 ### 1. Build Contracts

--- a/infra/CHANGELOG.md
+++ b/infra/CHANGELOG.md
@@ -17,3 +17,9 @@ This changelog follows the infra versioning strategy defined in `docs/infra-vers
 - Grafana dashboards for on-chain events and golden signals
 - Alertmanager rule for web app uptime monitoring
 - Documentation for compliance, mobile infra, and Stellar protocol upgrades
+
+## [0.2.0] - 2026-07-23
+
+### Added
+- Terraform bootstrap module (`infra/terraform/state-bootstrap/`) for S3 + DynamoDB remote state
+- Reusable backend config template (`infra/terraform/backend-config.tf`)

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,0 +1,27 @@
+# Terraform
+
+This directory contains Terraform configurations for managing EsuStellar infrastructure.
+
+## Layout
+
+```
+terraform/
+├── README.md                # This file
+├── backend-config.tf        # Reusable remote backend config template
+└── state-bootstrap/         # Bootstrap module: S3 bucket + DynamoDB for remote state
+```
+
+## Quick Start
+
+### 1. Bootstrap remote state infrastructure
+
+See [state-bootstrap/README.md](state-bootstrap/README.md).
+
+### 2. Use the remote backend
+
+After bootstrapping, copy `backend-config.tf` into each Terraform module and update the `key` to match the environment (e.g. `testnet/terraform.tfstate`).
+
+## Prerequisites
+
+- [Terraform](https://developer.hashicorp.com/terraform/downloads) >= 1.5
+- AWS credentials configured (env vars, `~/.aws/credentials`, or IAM role)

--- a/infra/terraform/backend-config.tf
+++ b/infra/terraform/backend-config.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "esustellar-terraform-state"
+    key            = "<ENV>/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "terraform-locks"
+    encrypt        = true
+  }
+}

--- a/infra/terraform/state-bootstrap/README.md
+++ b/infra/terraform/state-bootstrap/README.md
@@ -1,0 +1,32 @@
+# Terraform State Bootstrap
+
+This module creates the **S3 bucket** and **DynamoDB table** used as a remote backend for all other Terraform configurations in this repository.
+
+## Usage
+
+```bash
+# 1. Copy and edit the example vars
+cp terraform.tfvars.example terraform.tfvars
+
+# 2. Apply with local state (run once per AWS account)
+terraform init
+terraform plan
+terraform apply
+```
+
+After bootstrapping, copy the output values into the `backend "s3"` block of downstream Terraform configs (see `../backend-config.tf`).
+
+## Resources
+
+| Resource | Purpose |
+|---|---|
+| S3 bucket | Stores `.tfstate` files |
+| S3 versioning | Retains history of every state revision |
+| S3 SSE | AES-256 encryption at rest |
+| S3 public access block | Prevents accidental public access |
+| DynamoDB table (PAY_PER_REQUEST) | State locking to prevent concurrent operations |
+
+## Notes
+
+- `prevent_destroy = true` is set on the bucket to prevent accidental deletion of state files.
+- This module itself uses **local state**. All downstream configs should use the remote backend created here.

--- a/infra/terraform/state-bootstrap/main.tf
+++ b/infra/terraform/state-bootstrap/main.tf
@@ -1,0 +1,52 @@
+provider "aws" {
+  region = var.aws_region
+}
+
+resource "aws_s3_bucket" "terraform_state" {
+  bucket = var.state_bucket_name
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = var.tags
+}
+
+resource "aws_s3_bucket_versioning" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_dynamodb_table" "terraform_locks" {
+  name         = var.lock_table_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags = var.tags
+}

--- a/infra/terraform/state-bootstrap/outputs.tf
+++ b/infra/terraform/state-bootstrap/outputs.tf
@@ -1,0 +1,19 @@
+output "state_bucket_arn" {
+  description = "ARN of the S3 state bucket"
+  value       = aws_s3_bucket.terraform_state.arn
+}
+
+output "state_bucket_id" {
+  description = "ID (name) of the S3 state bucket"
+  value       = aws_s3_bucket.terraform_state.id
+}
+
+output "lock_table_arn" {
+  description = "ARN of the DynamoDB lock table"
+  value       = aws_dynamodb_table.terraform_locks.arn
+}
+
+output "lock_table_name" {
+  description = "Name of the DynamoDB lock table"
+  value       = aws_dynamodb_table.terraform_locks.name
+}

--- a/infra/terraform/state-bootstrap/terraform.tfvars.example
+++ b/infra/terraform/state-bootstrap/terraform.tfvars.example
@@ -1,0 +1,8 @@
+aws_region         = "us-east-1"
+state_bucket_name  = "esustellar-terraform-state"
+lock_table_name    = "terraform-locks"
+tags = {
+  Environment = "production"
+  Project     = "esustellar"
+  ManagedBy   = "terraform"
+}

--- a/infra/terraform/state-bootstrap/variables.tf
+++ b/infra/terraform/state-bootstrap/variables.tf
@@ -1,0 +1,21 @@
+variable "aws_region" {
+  description = "AWS region for the state resources"
+  type        = string
+}
+
+variable "state_bucket_name" {
+  description = "Name of the S3 bucket for Terraform state"
+  type        = string
+}
+
+variable "lock_table_name" {
+  description = "Name of the DynamoDB table for state locking"
+  type        = string
+  default     = "terraform-locks"
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Summary

Sets up an S3 bucket (with versioning and encryption) and a DynamoDB table for state locking to enable safe, collaborative Terraform workflows.

## Changes

### New files

| File | Description |
|---|---|
| `infra/terraform/state-bootstrap/main.tf` | AWS provider, S3 bucket (versioning, SSE, public access block, `prevent_destroy`), DynamoDB table (PAY_PER_REQUEST, `LockID` hash key) |
| `infra/terraform/state-bootstrap/variables.tf` | Input variables: `aws_region`, `state_bucket_name`, `lock_table_name`, `tags` |
| `infra/terraform/state-bootstrap/outputs.tf` | Outputs: bucket & table ARNs and names |
| `infra/terraform/state-bootstrap/terraform.tfvars.example` | Example variable values |
| `infra/terraform/state-bootstrap/README.md` | Bootstrap instructions |
| `infra/terraform/backend-config.tf` | Reusable `backend \"s3\"` block template for downstream configs |
| `infra/terraform/README.md` | Directory overview |

### Modified files

- `.gitignore` — Added Terraform exclusions (.terraform/, state files, .tfvars, lock files)
- `infra/CHANGELOG.md` — Added v0.2.0 entry
- `docs/deployment.md` — Added remote state bootstrap prerequisite

## How to use

1. `cd infra/terraform/state-bootstrap`
2. `cp terraform.tfvars.example terraform.tfvars` and edit with your AWS region and bucket name
3. `terraform init && terraform apply`
4. Copy `infra/terraform/backend-config.tf` into new Terraform modules, updating the `key` per environment

## Acceptance criteria

- [x] Implementation complete
- [ ] Tests / validation passing (requires AWS credentials + `terraform apply`)
- [x] Documentation updated
- [ ] Reviewed and merged

# Closes #543