### PR TITLE
fix: payout fallback for defaulted members and registry metadata sync

### DIFF
--- a/contracts/registry/src/lib.rs
+++ b/contracts/registry/src/lib.rs
@@ -161,6 +161,44 @@ impl GroupRegistry {
         Ok(())
     }
 
+    /// Update the mutable metadata for a registered group.
+    ///
+    /// Registry copies of `name`, `is_public`, and `total_members` go stale
+    /// once the underlying savings group changes. This lets the group admin
+    /// re-sync those fields so discovery and listings stay accurate. Only the
+    /// registered admin may call it.
+    pub fn update_group_info(
+        env: Env,
+        contract_address: Address,
+        name: String,
+        is_public: bool,
+        total_members: u32,
+    ) -> Result<(), Error> {
+        let mut group_info: GroupInfo = env
+            .storage()
+            .persistent()
+            .get(&DataKey::GroupInfo(contract_address.clone()))
+            .ok_or(Error::GroupNotFound)?;
+
+        // Only the registered admin may mutate the stored group info.
+        group_info.admin.require_auth();
+
+        group_info.name = name;
+        group_info.is_public = is_public;
+        group_info.total_members = total_members;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::GroupInfo(contract_address.clone()), &group_info);
+
+        env.events().publish(
+            (symbol_short!("upd_group"),),
+            (contract_address, group_info.admin.clone()),
+        );
+
+        Ok(())
+    }
+
     /// Get all groups a user is a member of
     pub fn get_user_groups(env: Env, user: Address) -> Vec<Address> {
         env.storage()

--- a/contracts/savings/src/lib.rs
+++ b/contracts/savings/src/lib.rs
@@ -550,7 +550,14 @@ impl SavingsContract {
             .get(&DataKey::Members(group_id.clone()))
             .unwrap_or(Vec::new(&env));
 
-        // Find member with join_order matching current round (0-indexed)
+        let target_order = round - 1;
+
+        // The preferred recipient is the member whose join_order matches this
+        // round. If that member has defaulted (or was already paid), fall back
+        // to the next eligible member in join_order so a single default cannot
+        // stall payout for the rest of the group.
+        let mut best: Option<(u32, Address)> = None;
+
         for member_addr in members.iter() {
             let member_data: Member = env
                 .storage()
@@ -558,12 +565,27 @@ impl SavingsContract {
                 .get(&DataKey::MemberData(group_id.clone(), member_addr.clone()))
                 .unwrap();
 
-            if member_data.join_order == round - 1 && !member_data.has_received_payout {
-                return Ok(member_addr);
+            if member_data.has_received_payout
+                || member_data.status == MemberStatus::Defaulted
+                || member_data.join_order < target_order
+            {
+                continue;
+            }
+
+            let is_better = match &best {
+                None => true,
+                Some((best_order, _)) => member_data.join_order < *best_order,
+            };
+
+            if is_better {
+                best = Some((member_data.join_order, member_addr.clone()));
             }
         }
 
-        Err(Error::NoRecipientFound)
+        match best {
+            Some((_, addr)) => Ok(addr),
+            None => Err(Error::NoRecipientFound),
+        }
     }
 
     // View functions


### PR DESCRIPTION
## Summary

Two small, focused fixes for the assigned audit findings.

### Payout reassignment for defaulted members (#635)
`get_next_payout_recipient` previously only matched the member whose `join_order == round - 1`, returning `NoRecipientFound` if that member had defaulted. It now skips defaulted (and already-paid) members and falls back to the next eligible member in `join_order`, so a single default no longer stalls the round for everyone else. When the exact-round member is still eligible it remains the recipient, preserving existing behaviour.

### Registry metadata sync (#656)
Added an admin-authenticated `update_group_info` function so a group's registry copy of `name`, `is_public`, and `total_members` can be re-synced after the underlying savings group changes, instead of the registry silently holding stale caller-supplied values with no way to update them.

## Closes

- closes #635
- closes #656
