### PR TITLE
fix: emit event when member is marked Defaulted (#630)

### DIFF
--- a/contracts/savings/src/lib.rs
+++ b/contracts/savings/src/lib.rs
@@ -344,6 +344,10 @@ impl SavingsContract {
             env.storage()
                 .persistent()
                 .set(&DataKey::MemberData(group_id.clone(), member.clone()), &member_data);
+            env.events().publish(
+                (symbol_short!("default"),),
+                (member, group_id, current_round),
+            );
             return Err(Error::PaymentWindowClosed);
         }
 


### PR DESCRIPTION
- Add env.events().publish call in the contribute() grace-period check, matching the pattern used by created/joined/contrib/payout/ round_end events
- Lets off-chain indexers and the frontend detect a default in real time instead of having to poll member status directly


closes #630 