### PR TITLE
fix: add dedicated InvalidRound error for get_round_deadline (#650)

### DIFF
--- a/contracts/savings/src/lib.rs
+++ b/contracts/savings/src/lib.rs
@@ -34,6 +34,7 @@ pub enum Error {
     DataExpired = 16,
     AlreadyInitialized = 15,
     ContributionTooHigh = 16,
+    InvalidRound = 18,
 }
 
 // Configuration constants
@@ -1101,7 +1102,7 @@ impl SavingsContract {
 
         // Validate round number
         if round == 0 || round > group.total_members {
-            return Err(Error::GroupNotFound); // Using existing error, could add new error type
+            return Err(Error::InvalidRound);
         }
 
         // Try to get deadline from storage


### PR DESCRIPTION
- Add Error::InvalidRound = 18 variant
- Return it instead of reusing Error::GroupNotFound when the round number is 0 or exceeds total_members
- Prevents client-side error handling keyed off GroupNotFound from firing for an unrelated validation failure

closes #650 