### PR TITLE
Verify savings contract admin before registering a group

### DIFF
--- a/contracts/registry/Cargo.toml
+++ b/contracts/registry/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 soroban-sdk = { workspace = true }
+esustellar-savings = { path = "../savings" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/registry/src/lib.rs
+++ b/contracts/registry/src/lib.rs
@@ -65,6 +65,17 @@ impl GroupRegistry {
             return Err(Error::GroupAlreadyRegistered);
         }
 
+        // Verify contract_address is a real deployed savings contract that
+        // actually knows about group_id, and that its on-chain admin matches
+        // the admin supplied here, before trusting this registration.
+        let savings_group = esustellar_savings::SavingsContractClient::new(&env, &contract_address)
+            .try_get_group(&group_id)
+            .map_err(|_| Error::InvalidAddress)?
+            .map_err(|_| Error::InvalidAddress)?;
+        if savings_group.admin != admin {
+            return Err(Error::InvalidAddress);
+        }
+
         let group_info = GroupInfo {
             contract_address: contract_address.clone(),
             group_id: group_id.clone(),

--- a/contracts/savings/Cargo.toml
+++ b/contracts/savings/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = { workspace = true }


### PR DESCRIPTION
## Summary

`register_group` accepted any `contract_address` with no on-chain confirmation that it was a real deployed savings contract, let alone one whose admin matched the supplied `admin`. This meant anyone could register fabricated `GroupInfo` entries for arbitrary (even non-contract) addresses.

This adds a cross-contract call into the savings contract at `contract_address` (`get_group`) to confirm the group exists there and that its stored admin matches the `admin` passed to `register_group`, rejecting the call with `Error::InvalidAddress` otherwise.

## Changes

- `contracts/savings/Cargo.toml`: expose the savings crate as an `rlib` (in addition to `cdylib`) so it can be used as a regular Rust dependency from the registry crate.
- `contracts/registry/Cargo.toml`: add a path dependency on the savings crate.
- `contracts/registry/src/lib.rs`: `register_group` now calls `SavingsContractClient::try_get_group` and checks `savings_group.admin == admin` before storing the registration.

Closes #655