### PR TITLE
fix(savings): add group_id to payout and round_end events; add event schema doc

### DIFF
--- a/contracts/savings/src/lib.rs
+++ b/contracts/savings/src/lib.rs
@@ -994,9 +994,10 @@ impl SavingsContract {
         recipient_data.status = MemberStatus::ReceivedPayout;
         env.storage().persistent().set(&DataKey::MemberData(group_id.clone(), recipient.clone()), &recipient_data);
 
+        // #752: include group_id so the activity feed can attribute this payout
         env.events().publish(
             (symbol_short!("payout"),),
-            (recipient, payout_amount, current_round),
+            (group_id.clone(), recipient, payout_amount, current_round),
         );
 
         Self::end_round(env, group_id, group)?;
@@ -1041,8 +1042,12 @@ impl SavingsContract {
 
         env.storage().persistent().set(&DataKey::Group(group_id), &group);
 
-        env.events()
-            .publish((symbol_short!("round_end"),), group.current_round - 1);
+        // #753: add group_id and wrap round number in a tuple for consistent shape
+        let ended_round = if group.current_round > 0 { group.current_round - 1 } else { 0 };
+        env.events().publish(
+            (symbol_short!("round_end"),),
+            (group_id.clone(), ended_round),
+        );
 
         Ok(())
     }
@@ -1278,3 +1283,4 @@ impl SavingsContract {
 
 #[cfg(test)]
 mod tests;
+

--- a/docs/event-schema.md
+++ b/docs/event-schema.md
@@ -1,0 +1,70 @@
+# Event Schema — SavingsContract
+
+All events follow the shape `(topics_tuple, data_tuple)`.
+Every event includes `group_id` as the first data element so off-chain
+consumers (activity feeds, indexers) can attribute any event to its group.
+
+## Events
+
+### `created`
+Emitted when a new savings group is registered.
+
+```
+topics: (symbol_short!("created"),)
+data:   (group_id: String, contribution_amount: i128, total_members: u32)
+```
+
+### `joined`
+Emitted when a member (including the admin on group creation) joins a group.
+
+```
+topics: (symbol_short!("joined"),)
+data:   (group_id: String, member: Address, join_order: u32)
+```
+
+### `contrib`
+Emitted when a member successfully contributes for the current round.
+
+```
+topics: (symbol_short!("contrib"),)
+data:   (group_id: String, member: Address, amount: i128, round: u32)
+```
+
+### `payout`
+Emitted when a round's pool is disbursed to the round's recipient.
+
+```
+topics: (symbol_short!("payout"),)
+data:   (group_id: String, recipient: Address, amount: i128, round: u32)
+```
+
+### `round_end`
+Emitted at the close of every round.
+
+```
+topics: (symbol_short!("round_end"),)
+data:   (group_id: String, ended_round: u32)
+```
+
+### `default`
+Emitted when a member is marked as defaulted.
+
+```
+topics: (symbol_short!("default"),)
+data:   (group_id: String, member: Address, round: u32)
+```
+
+### `cancelled`
+Emitted when a group is cancelled before it becomes active.
+
+```
+topics: (symbol_short!("cancelled"),)
+data:   (caller: Address, group_id: String)
+```
+
+## Notes
+
+- All `symbol_short!` values must be ≤ 9 bytes (Soroban limit).
+- `group_id` is always present so consumers can filter by group without
+  cross-referencing additional state.
+- `round` values are 1-indexed (round 1 is the first active round).


### PR DESCRIPTION
## Summary

- **#752** – `payout` event now includes `group_id` as first data element.
- **#753** – `round_end` event now includes `group_id` and uses a consistent tuple data shape; the bare round number is replaced with `(group_id, ended_round)`.
- **#754** – Documents that `created` was the only event with `group_id`; the remaining events are fixed in this PR (alongside Tinna23's PR fixing `joined`/`contrib`).
- **#755** – With all events now carrying `group_id`, the activity feed can reliably attribute every event to its originating group without additional state lookups.

## Files changed

| File | Change |
|---|---|
| `contracts/savings/src/lib.rs` | `payout` event + `group_id`; `round_end` event + `group_id` + tuple shape |
| `docs/event-schema.md` | New — canonical event topic/data schema for all SavingsContract events |

Closes #752
Closes #753
Closes #754
Closes #755