### PR TITLE
Add VPC module, ECR with lifecycle policies, Infracost CI, and DR runbook

### DIFF
--- a/.github/workflows/infracost.yml
+++ b/.github/workflows/infracost.yml
@@ -1,0 +1,41 @@
+# #555: Infracost CI integration — cost estimation on pull requests.
+#
+# Requires INFRACOST_API_KEY secret to be set in the repository.
+
+name: Infracost Cost Estimate
+
+on:
+  pull_request:
+    paths:
+      - "infra/terraform/**"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  infracost:
+    name: Infracost Cost Estimate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Infracost
+        uses: infracost/actions/setup@v3
+        with:
+          api-key: ${{ secrets.INFRACOST_API_KEY }}
+
+      - name: Generate Infracost Breakdown
+        run: |
+          infracost breakdown --path infra/terraform/ \
+            --format json \
+            --out-file infracost-breakdown.json
+
+      - name: Annotate PR with Cost Estimate
+        uses: infracost/actions/comment@v3
+        with:
+          path: infracost-breakdown.json
+          behavior: update
+          match-by: filename
+          percent-fallback-threshold: 10

--- a/docs/disaster-recovery-runbook.md
+++ b/docs/disaster-recovery-runbook.md
@@ -1,0 +1,247 @@
+# Disaster Recovery Runbook
+
+**Contract**: eSuStellar Soroban Savings/Registry
+**Environment**: `{{ ENVIRONMENT }}`
+**Last Updated**: July 2026
+
+## Table of Contents
+
+- [Overview](#overview)
+- [RTO/RPO Targets](#rtorpo-targets)
+- [Pre-Requisites](#pre-requisites)
+- [Scenario 1: Contract Upgrade (Admin Key Rotation)](#scenario-1-contract-upgrade)
+- [Scenario 2: Data Corruption or Erroneous State](#scenario-2-data-corruption)
+- [Scenario 3: Lost Admin Key](#scenario-3-lost-admin-key)
+- [Scenario 4: Full Network Migration](#scenario-4-network-migration)
+- [Post-Recovery Validation](#post-recovery-validation)
+
+---
+
+## Overview
+
+This runbook covers disaster recovery procedures for the eSuStellar Soroban smart contracts (savings + registry) deployed on Stellar. All recovery actions require admin authorization and should be performed during a maintenance window when possible.
+
+## RTO/RPO Targets
+
+| Metric | Target |
+|--------|--------|
+| Recovery Time Objective (RTO) | 2 hours |
+| Recovery Point Objective (RPO) | 0 (no data loss for contract state) |
+| Maximum Tolerable Downtime | 4 hours |
+
+## Pre-Requisites
+
+- Stellar CLI (`stellar`) installed and configured
+- Admin private key securely accessible
+- Access to the target network (testnet/staging/mainnet)
+- Current contract WASM hashes documented in deployment-info.json
+- Backup of all DataKey schemas and version information
+
+---
+
+## Scenario 1: Contract Upgrade (Admin Key Rotation)
+
+**Trigger**: Key compromise, team member departure, or scheduled rotation.
+
+### Steps
+
+1. **Verify current admin**
+   ```bash
+   stellar contract invoke \
+     --id <CONTRACT_ID> \
+     --source <NEW_ADMIN_SECRET> \
+     --network <NETWORK> \
+     -- get_admin
+   ```
+
+2. **Transfer admin to new key**
+   ```bash
+   stellar contract invoke \
+     --id <CONTRACT_ID> \
+     --source <OLD_ADMIN_SECRET> \
+     --network <NETWORK> \
+     -- set_admin \
+     --new_admin <NEW_ADMIN_ADDRESS>
+   ```
+
+3. **Verify new admin**
+   ```bash
+   stellar contract invoke \
+     --id <CONTRACT_ID> \
+     --source <NEW_ADMIN_SECRET> \
+     --network <NETWORK> \
+     -- get_admin
+   ```
+
+4. **Rotate registry admin** (if both contracts share an admin)
+   ```bash
+   # Repeat steps 1-3 for the registry contract
+   ```
+
+5. **Update CI/CD secrets** with new admin key
+
+6. **Document the rotation** in deployment history
+
+---
+
+## Scenario 2: Data Corruption or Erroneous State
+
+**Trigger**: Incorrect payout distribution, stuck rounds, or corrupted member data.
+
+### Steps
+
+1. **Assess damage scope**
+   ```bash
+   # Check all active groups
+   stellar contract invoke \
+     --id <SAVINGS_CONTRACT_ID> \
+     --source <ADMIN_SECRET> \
+     --network <NETWORK> \
+     -- get_all_groups
+
+   # Check specific group state
+   stellar contract invoke \
+     --id <SAVINGS_CONTRACT_ID> \
+     --source <ADMIN_SECRET> \
+     --network <NETWORK> \
+     -- get_group \
+     --group_id <GROUP_ID>
+   ```
+
+2. **Emergency pause** (if applicable — add a pause mechanism)
+   - For now: Admin can call `force_end_round` to halt stalled rounds
+
+3. **Force end stalled rounds**
+   ```bash
+   stellar contract invoke \
+     --id <SAVINGS_CONTRACT_ID> \
+     --source <ADMIN_SECRET> \
+     --network <NETWORK> \
+     -- force_end_round \
+     --admin <ADMIN_ADDRESS> \
+     --group_id <GROUP_ID>
+   ```
+
+4. **Reset round data** (if needed, requires new version deployment)
+   - Deploy new contract version with corrected state initialization
+   - Use `CONTRACT_VERSION` constant to verify correct deployment
+
+5. **Notify affected users** through official channels
+
+---
+
+## Scenario 3: Lost Admin Key
+
+**Trigger**: Admin private key is lost or compromised with no rotation planned.
+
+### Steps
+
+1. **Verify admin key is truly lost**
+   - Attempt recovery from hardware wallet backups
+   - Check secure vault backups
+
+2. **If governance token is available** (future enhancement):
+   - Use multisig or governance contract to rotate admin
+
+3. **If no recovery possible**:
+   - Deploy a new contract instance
+   - Migrate state using the registry contract
+   - **Data loss risk**: All uncommitted contributions may be unrecoverable
+
+4. **Deploy fresh contracts**
+   ```bash
+   stellar contract deploy \
+     --wasm contracts/savings/target/soroban/savings_contract.wasm \
+     --source <NEW_ADMIN_SECRET> \
+     --network <NETWORK>
+   ```
+
+5. **Re-register all groups** via the registry contract
+
+---
+
+## Scenario 4: Full Network Migration
+
+**Trigger**: Network upgrade, chain fork, or infrastructure migration.
+
+### Steps
+
+1. **Export current state**
+   - Document all DataKey schemas and their values
+   - Record all active group IDs and member lists
+   - Export contribution history (if off-chain storage is used)
+
+2. **Deploy new contracts on target network**
+   ```bash
+   stellar contract deploy \
+     --wasm contracts/savings/target/soroban/savings_contract.wasm \
+     --source <ADMIN_SECRET> \
+     --network <TARGET_NETWORK>
+
+   stellar contract deploy \
+     --wasm contracts/registry/target/soroban/registry_contract.wasm \
+     --source <ADMIN_SECRET> \
+     --network <TARGET_NETWORK>
+   ```
+
+3. **Initialize new contracts**
+   ```bash
+   stellar contract invoke \
+     --id <NEW_SAVINGS_ID> \
+     --source <ADMIN_SECRET> \
+     --network <TARGET_NETWORK> \
+     -- initialize \
+     --admin <ADMIN_ADDRESS>
+
+   stellar contract invoke \
+     --id <NEW_REGISTRY_ID> \
+     --source <ADMIN_SECRET> \
+     --network <TARGET_NETWORK> \
+     -- initialize \
+     --admin <ADMIN_ADDRESS>
+   ```
+
+4. **Migrate groups** (requires scripted registration)
+   - Re-create each group with original parameters
+   - Re-add members using `add_member`
+   - Note: Contribution history cannot be migrated on-chain
+
+5. **Update DNS, frontend, and SDK configurations** to point to new contract IDs
+
+---
+
+## Post-Recovery Validation
+
+After any recovery procedure, verify:
+
+- [ ] Admin key is correctly set
+- [ ] All active groups are accessible via `get_group`
+- [ ] Member counts match pre-recovery values
+- [ ] Payout schedule is intact
+- [ ] Registry contract reflects all registered groups
+- [ ] Frontend can load group data without errors
+- [ ] No error code collisions (savings: 1-99, registry: 100+)
+
+```bash
+# Quick validation script
+echo "=== Savings Contract ==="
+stellar contract invoke --id <SAVINGS_ID> --source <ADMIN> --network <NET> -- get_admin
+stellar contract invoke --id <SAVINGS_ID> --source <ADMIN> --network <NET> -- get_all_groups
+
+echo "=== Registry Contract ==="
+stellar contract invoke --id <REGISTRY_ID> --source <ADMIN> --network <NET> -- get_all_registered_groups
+```
+
+---
+
+## Escalation Contacts
+
+| Role | Contact | Escalation |
+|------|---------|------------|
+| Primary Admin | _@esustellar.com | Immediate |
+| Security Lead | _@esustellar.com | Within 1 hour |
+| Infrastructure | _@esustellar.com | Within 4 hours |
+
+---
+
+*This runbook should be reviewed and updated after every deployment or major incident.*

--- a/infra/terraform/modules/ecr/main.tf
+++ b/infra/terraform/modules/ecr/main.tf
@@ -1,0 +1,99 @@
+# #552: ECR module — container registry with lifecycle policies,
+# vulnerability scanning, and cross-account pull permissions.
+
+locals {
+  name_prefix = "${var.project_name}-${var.environment}"
+  repos       = ["savings", "registry"]
+}
+
+resource "aws_ecr_repository" "this" {
+  for_each             = toset(local.repos)
+  name                 = "${local.name_prefix}-${each.key}"
+  image_tag_mutability = var.image_tag_mutability
+  force_delete         = false
+
+  image_scanning_configuration {
+    scan_on_push = var.scan_on_push
+  }
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+
+  tags = {
+    Project     = var.project_name
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+# Lifecycle policy: retain only latest N images, expire untagged after 7 days
+resource "aws_ecr_lifecycle_policy" "this" {
+  for_each   = aws_ecr_repository.this
+  repository = each.value.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Expire untagged images after 7 days"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 7
+        }
+        action = {
+          type = "expire"
+        }
+      },
+      {
+        rulePriority = 2
+        description  = "Keep only latest ${var.max_image_count} images"
+        selection = {
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = var.max_image_count
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}
+
+# --- Cross-account pull policy for shared registries ---
+# Allows specified accounts to pull images (for staging -> mainnet promotion)
+
+data "aws_iam_policy_document" "cross_account_pull" {
+  count = length(var.allowed_account_ids) > 0 ? 1 : 0
+
+  statement {
+    sid    = "CrossAccountPull"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = [for id in var.allowed_account_ids : "arn:aws:iam::${id}:root"]
+    }
+    actions = [
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage",
+      "ecr:GetAuthorizationToken",
+    ]
+  }
+}
+
+variable "allowed_account_ids" {
+  description = "AWS account IDs allowed to pull images cross-account"
+  type        = list(string)
+  default     = []
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_ecr_repository_policy" "cross_account" {
+  for_each   = length(var.allowed_account_ids) > 0 ? aws_ecr_repository.this : {}
+  repository = each.value.name
+  policy     = data.aws_iam_policy_document.cross_account[0].json
+}

--- a/infra/terraform/modules/ecr/outputs.tf
+++ b/infra/terraform/modules/ecr/outputs.tf
@@ -1,0 +1,14 @@
+output "repository_arns" {
+  description = "Map of repository name to ARN"
+  value       = { for k, v in aws_ecr_repository.this : k => v.arn }
+}
+
+output "repository_urls" {
+  description = "Map of repository name to registry URL"
+  value       = { for k, v in aws_ecr_repository.this : k => v.repository_url }
+}
+
+output "registry_id" {
+  description = "AWS account ID (registry ID)"
+  value       = data.aws_caller_identity.current.account_id
+}

--- a/infra/terraform/modules/ecr/variables.tf
+++ b/infra/terraform/modules/ecr/variables.tf
@@ -1,0 +1,28 @@
+variable "project_name" {
+  description = "Project name prefix for ECR resources"
+  type        = string
+  default     = "esustellar"
+}
+
+variable "environment" {
+  description = "Deployment environment"
+  type        = string
+}
+
+variable "image_tag_mutability" {
+  description = "Whether image tags are mutable or immutable"
+  type        = string
+  default     = "IMMUTABLE"
+}
+
+variable "max_image_count" {
+  description = "Maximum number of images to retain per repository"
+  type        = number
+  default     = 30
+}
+
+variable "scan_on_push" {
+  description = "Enable vulnerability scanning on image push"
+  type        = bool
+  default     = true
+}

--- a/infra/terraform/modules/vpc/main.tf
+++ b/infra/terraform/modules/vpc/main.tf
@@ -1,0 +1,181 @@
+# #551: VPC module — production-grade networking with public/private subnets,
+# NAT gateways, and VPC flow logs.
+
+locals {
+  name_prefix = "${var.project_name}-${var.environment}"
+}
+
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name        = "${local.name_prefix}-vpc"
+    Project     = var.project_name
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+# --- Internet Gateway ---
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = {
+    Name = "${local.name_prefix}-igw"
+  }
+}
+
+# --- Public Subnets ---
+
+resource "aws_subnet" "public" {
+  count                   = length(var.public_subnet_cidrs)
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = var.public_subnet_cidrs[count.index]
+  availability_zone       = var.availability_zones[count.index]
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "${local.name_prefix}-public-${var.availability_zones[count.index]}"
+    Tier = "public"
+  }
+}
+
+# --- Private Subnets ---
+
+resource "aws_subnet" "private" {
+  count             = length(var.private_subnet_cidrs)
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = var.private_subnet_cidrs[count.index]
+  availability_zone = var.availability_zones[count.index]
+
+  tags = {
+    Name = "${local.name_prefix}-private-${var.availability_zones[count.index]}"
+    Tier = "private"
+  }
+}
+
+# --- NAT Gateway (one per AZ for HA) ---
+
+resource "aws_eip" "nat" {
+  count  = var.enable_nat_gateway ? length(var.availability_zones) : 0
+  domain = "vpc"
+
+  tags = {
+    Name = "${local.name_prefix}-nat-eip-${count.index}"
+  }
+}
+
+resource "aws_nat_gateway" "this" {
+  count         = var.enable_nat_gateway ? length(var.availability_zones) : 0
+  allocation_id = aws_eip.nat[count.index].id
+  subnet_id     = aws_subnet.public[count.index].id
+
+  tags = {
+    Name = "${local.name_prefix}-nat-${count.index}"
+  }
+
+  depends_on = [aws_internet_gateway.this]
+}
+
+# --- Route Tables ---
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-public-rt"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  count          = length(var.public_subnet_cidrs)
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table" "private" {
+  count  = var.enable_nat_gateway ? length(var.availability_zones) : 1
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = var.enable_nat_gateway ? aws_nat_gateway.this[count.index].id : null
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-private-rt-${count.index}"
+  }
+}
+
+resource "aws_route_table_association" "private" {
+  count          = length(var.private_subnet_cidrs)
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private[count.index].id
+}
+
+# --- VPC Flow Logs ---
+
+resource "aws_flow_log" "this" {
+  count                = var.enable_flow_logs ? 1 : 0
+  vpc_id               = aws_vpc.this.id
+  traffic_type         = "ALL"
+  iam_role_arn         = aws_iam_role.flow_log[0].arn
+  log_destination      = aws_cloudwatch_log_group.flow_log[0].arn
+  log_destination_type = "cloud-watch-logs"
+
+  tags = {
+    Name = "${local.name_prefix}-flow-log"
+  }
+}
+
+resource "aws_cloudwatch_log_group" "flow_log" {
+  count             = var.enable_flow_logs ? 1 : 0
+  name              = "/aws/vpc/flow-log/${local.name_prefix}"
+  retention_in_days = 30
+}
+
+data "aws_iam_policy_document" "flow_log_assume" {
+  count = var.enable_flow_logs ? 1 : 0
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["vpc-flow-logs.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "flow_log" {
+  count              = var.enable_flow_logs ? 1 : 0
+  name               = "${local.name_prefix}-flow-log-role"
+  assume_role_policy = data.aws_iam_policy_document.flow_log_assume[0].json
+}
+
+data "aws_iam_policy_document" "flow_log_permissions" {
+  count = var.enable_flow_logs ? 1 : 0
+  statement {
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogGroups",
+      "logs:DescribeLogStreams",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "flow_log" {
+  count  = var.enable_flow_logs ? 1 : 0
+  name   = "${local.name_prefix}-flow-log-policy"
+  role   = aws_iam_role.flow_log[0].id
+  policy = data.aws_iam_policy_document.flow_log_permissions[0].json
+}

--- a/infra/terraform/modules/vpc/outputs.tf
+++ b/infra/terraform/modules/vpc/outputs.tf
@@ -1,0 +1,29 @@
+output "vpc_id" {
+  description = "ID of the VPC"
+  value       = aws_vpc.this.id
+}
+
+output "vpc_cidr" {
+  description = "CIDR block of the VPC"
+  value       = aws_vpc.this.cidr_block
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the public subnets"
+  value       = aws_subnet.public[*].id
+}
+
+output "private_subnet_ids" {
+  description = "IDs of the private subnets"
+  value       = aws_subnet.private[*].id
+}
+
+output "nat_gateway_ips" {
+  description = "Public IPs of the NAT gateways"
+  value       = aws_eip.nat[*].public_ip
+}
+
+output "internet_gateway_id" {
+  description = "ID of the internet gateway"
+  value       = aws_internet_gateway.this.id
+}

--- a/infra/terraform/modules/vpc/variables.tf
+++ b/infra/terraform/modules/vpc/variables.tf
@@ -1,0 +1,46 @@
+variable "project_name" {
+  description = "Project name prefix for VPC resources"
+  type        = string
+  default     = "esustellar"
+}
+
+variable "environment" {
+  description = "Deployment environment"
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "availability_zones" {
+  description = "List of availability zones"
+  type        = list(string)
+  default     = ["us-east-1a", "us-east-1b", "us-east-1c"]
+}
+
+variable "public_subnet_cidrs" {
+  description = "CIDR blocks for public subnets"
+  type        = list(string)
+  default     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+}
+
+variable "private_subnet_cidrs" {
+  description = "CIDR blocks for private subnets"
+  type        = list(string)
+  default     = ["10.0.11.0/24", "10.0.12.0/24", "10.0.13.0/24"]
+}
+
+variable "enable_nat_gateway" {
+  description = "Enable NAT gateway for private subnets"
+  type        = bool
+  default     = true
+}
+
+variable "enable_flow_logs" {
+  description = "Enable VPC flow logs to CloudWatch"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
## Summary

Addresses issues #551, #552, #555, and #556 with infrastructure modules and operational documentation.

### Changes

- **#551**: Add VPC module — production-grade networking with public/private subnets across 3 AZs, NAT gateways for HA, internet gateway, route tables, and VPC flow logs to CloudWatch
- **#552**: Add ECR module — container registry for savings + registry contracts with immutable tags, lifecycle policies (30 image cap, 7-day untagged expiry), vulnerability scanning on push, and cross-account pull permissions
- **#555**: Add Infracost CI workflow — automated cost estimation on PRs touching `infra/terraform/`, posts annotated breakdown directly on the pull request
- **#556**: Add disaster recovery runbook — comprehensive guide covering 4 scenarios: admin key rotation, data corruption, lost admin key, and full network migration, with step-by-step procedures and post-recovery validation checklist

Closes #551
Closes #552
Closes #555
Closes #556