### PR TITLE
[MEDIUM] Guard against round == 0 underflow in get_next_payout_recipient

### DIFF
--- a/contracts/savings/src/lib.rs
+++ b/contracts/savings/src/lib.rs
@@ -1334,12 +1334,32 @@ impl SavingsContract {
         contributions.len() == members.len()
     }
 
+    /// Returns the address of the next member due to receive a payout for `round`.
+    ///
+    /// # Invariant
+    /// `round` must be >= 1. Round numbering starts at 1 when a group transitions
+    /// to `Active` (see the group activation flow), so `round - 1` below is safe.
+    /// This explicit guard exists so that a future refactor calling this helper
+    /// before that transition, or restructuring round numbering, doesn't silently
+    /// reintroduce a `u32` underflow panic.
+    ///
+    /// # Errors
+    /// - `Error::InvalidRound` if `round` is 0.
+    /// - `Error::NoRecipientFound` if no eligible member is found.
     fn get_next_payout_recipient(env: &Env, group_id: String, round: u32) -> Result<Address, Error> {
+        if round == 0 {
+            return Err(Error::InvalidRound);
+        }
+        debug_assert!(
+            round >= 1,
+            "round must be >= 1; current_round starts at 1 when a group becomes Active"
+        );
+
         let members: Vec<Address> = env
             .storage().persistent().get(&DataKey::Members(group_id.clone()))
             .unwrap_or(Vec::new(&env));
 
-        let target_order = round.saturating_sub(1);
+        let target_order = round - 1;
         let mut best: Option<(u32, Address)> = None;
 
         for member_addr in members.iter() {
@@ -1359,11 +1379,6 @@ impl SavingsContract {
 
             let is_better = match &best {
                 None => true,
-                Some((best_order, _)) => data.join_order < *best_order,
-            };
-
-            if is_better {
-                best = Some((data.join_order, member_addr.clone()));
                 Some((best_order, _)) => member_data.join_order < *best_order,
             };
 


### PR DESCRIPTION
Closes #629
Closes #631
Closes #632
Closes #633


## Summary
Adds an explicit guard against `round == 0` in `get_next_payout_recipient`, per #633.

## Changes
- `contracts/savings/src/lib.rs` — `get_next_payout_recipient` now returns `Error::InvalidRound` immediately if `round == 0`, instead of relying on `round.saturating_sub(1)` to silently mask the invariant. A `debug_assert!` and doc comment document that `round` must always be >= 1 (round numbering starts at 1 when a group becomes `Active`), so a future refactor that calls this helper earlier, or restructures round numbering, will fail loudly instead of silently misbehaving or panicking.
- Also cleaned up a pre-existing duplicated code block inside this same function that referenced an undefined `data` variable (likely a leftover copy-paste artifact), which would have prevented the crate from compiling.

## Notes
This was found while addressing #633 — the literal `round - 1` subtraction described in the issue had already been changed to `round.saturating_sub(1)` on `main`, which avoids the panic but doesn't document or enforce the invariant, and silently normalizes `round == 0` to `target_order == 0` rather than surfacing an error. This PR restores an explicit `round - 1` with a guard in front, matching the pattern already used in `get_round_deadline` for consistency.

