### PR TITLE
 Feat(savings): Address multiple contract improvements

### DIFF
--- a/contracts/savings/src/lib.rs
+++ b/contracts/savings/src/lib.rs
@@ -344,7 +344,15 @@ impl SavingsContract {
 
         env.events().publish(
             (symbol_short!("created"),),
-            (group_id, contribution_amount, total_members),
+            (
+                group.group_id.clone(),
+                group.admin.clone(),
+                group.contribution_amount,
+                group.total_members,
+                group.frequency.clone(),
+                group.start_timestamp,
+                group.is_public,
+            ),
         );
 
         Ok(group)
@@ -1592,4 +1600,3 @@ impl SavingsContract {
 
 #[cfg(test)]
 mod tests;
-

--- a/contracts/savings/src/lib.rs
+++ b/contracts/savings/src/lib.rs
@@ -3,6 +3,21 @@
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, symbol_short, token, Address, Env, String,
     Vec,
+    pub fn get_group_duration_seconds(env: Env, group_id: String) -> Result<u64, Error> {
+        let group: SavingsGroup = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Group(group_id.clone()))
+            .ok_or(Error::GroupNotFound)?;
+
+        let frequency_seconds = match group.frequency {
+            Frequency::Weekly => 604800,
+            Frequency::BiWeekly => 1209600,
+            Frequency::Monthly => 2592000,
+        };
+
+        Ok(u64::from(group.total_members) * frequency_seconds)
+    }
 };
 
 // #696: Error codes are unique per-contract. Savings contract codes start at 1.

--- a/contracts/savings/src/lib.rs
+++ b/contracts/savings/src/lib.rs
@@ -109,6 +109,9 @@ pub struct SavingsGroup {
     pub start_timestamp: u64,
     pub status: GroupStatus,
     pub is_public: bool,
+    /// The current round number. Initialized to 0, meaning no round has
+    /// started yet. Incremented to 1 when the group becomes Active.
+    /// See `get_round_deadline` for validation against this sentinel.
     pub current_round: u32,
     pub platform_fee_percent: u32,
     pub treasury: Address,

--- a/contracts/savings/src/lib.rs
+++ b/contracts/savings/src/lib.rs
@@ -127,6 +127,9 @@ pub struct SavingsGroup {
 #[derive(Clone)]
 pub struct Member {
     pub address: Address,
+    /// Timestamp of when the member joined. For the admin, this is the
+    /// group-creation timestamp. For other members, it's the timestamp
+    /// of their `join_group` call.
     pub join_timestamp: u64,
     pub join_order: u32,
     pub status: MemberStatus,


### PR DESCRIPTION

**Description**:

This pull request addresses four key areas of improvement in the savings contract:

- Expanded created Event: The created event now includes the admin address, start_timestamp, frequency, and is_public flag. This allows for more efficient indexing and a better user experience in client applications, as it eliminates the need for a separate get_group() call to retrieve this information.
 Closes #760 

- Documented current_round Sentinel: Added a comment to the SavingsGroup struct to clarify that current_round is initialized to 0 as a sentinel value, indicating that no round has started yet. This improves code clarity and maintainability.
 Closes #761 

- Clarified join_timestamp Semantics: Added a comment to the Member struct to document the different meanings of join_timestamp for the group admin (group creation time) versus other members (the time they join). This helps prevent confusion and ensures the field is interpreted correctly.
 Closes #762 

- New get_group_duration_seconds View Function: Introduced a new view function, get_group_duration_seconds, which calculates and returns the total expected duration of a savings group in seconds. This provides a convenient way for prospective 
members to understand the full time commitment of a group before joining.
Closes #763 

These changes enhance the functionality, clarity, and developer experience of the savings contract.