### PR TITLE
Group

### DIFF
--- a/contracts/registry/src/tests.rs
+++ b/contracts/registry/src/tests.rs
@@ -576,6 +576,69 @@ fn test_multiple_admins_each_own_one_group() {
 // ── Integration / journey ─────────────────────────────────────────────────────
 
 #[test]
+fn test_savings_registry_full_lifecycle_stays_consistent() {
+    let env = setup_env();
+    let registry = create_registry(&env);
+    let savings_contract_id = env.register(SavingsContract, ());
+    let savings = SavingsContractClient::new(&env, &savings_contract_id);
+    let admin = Address::generate(&env);
+    let member1 = Address::generate(&env);
+    let member2 = Address::generate(&env);
+    let group_id = String::from_str(&env, "round-trip-group");
+    let name = String::from_str(&env, "Round Trip Group");
+    let start_timestamp = env.ledger().timestamp() + 86_400;
+
+    savings.create_group(
+        &admin,
+        &group_id,
+        &name,
+        &100_000_000,
+        &3,
+        &Frequency::Weekly,
+        &start_timestamp,
+        &true,
+        &admin,
+        &None,
+    );
+
+    registry.register_group(
+        &savings_contract_id,
+        &group_id,
+        &name,
+        &admin,
+        &true,
+    );
+
+    let assert_consistent = || {
+        let live_group = savings.get_group(&group_id);
+        let cached_group = registry.get_group_info(&savings_contract_id);
+        assert_eq!(cached_group.total_members, live_group.total_members);
+        assert_eq!(cached_group.is_public, live_group.is_public);
+    };
+
+    assert_consistent();
+
+    savings.join_group(&member1, &group_id);
+    assert_consistent();
+
+    savings.join_group(&member2, &group_id);
+    assert_eq!(savings.get_group(&group_id).status, GroupStatus::Active);
+    assert_consistent();
+
+    env.ledger().with_mut(|ledger| {
+        ledger.timestamp = start_timestamp + 1;
+    });
+    savings.contribute(&admin, &group_id);
+    assert_consistent();
+    savings.contribute(&member1, &group_id);
+    assert_consistent();
+    savings.contribute(&member2, &group_id);
+    assert_consistent();
+
+    assert_eq!(savings.get_round_payouts(&group_id, &1).len(), 1);
+}
+
+#[test]
 fn test_complete_user_journey() {
     let env = setup_env();
     let client = create_registry(&env);

--- a/contracts/registry/src/tests.rs
+++ b/contracts/registry/src/tests.rs
@@ -646,4 +646,9 @@ fn test_timestamps_are_monotonic_across_registrations() {
     let t2 = client.get_group_info(&g2).created_at;
 
     assert!(t2 > t1, "Later registration must have a higher created_at timestamp");
+
+    fn registry_test(env: &Env) -> GroupRegistryClient<'_> {
+    let contract_id = env.register(GroupRegistry, ());
+    GroupRegistryClient::new(env, &contract_id)
+}
 }

--- a/contracts/registry/src/tests.rs
+++ b/contracts/registry/src/tests.rs
@@ -714,4 +714,67 @@ fn test_timestamps_are_monotonic_across_registrations() {
     let contract_id = env.register(GroupRegistry, ());
     GroupRegistryClient::new(env, &contract_id)
 }
+
+
+fn test_savings_registry_full_lifecycle_stays_consistent() {
+    let env = setup_env();
+    let registry = create_registry(&env);
+    let savings_contract_id = env.register(SavingsContract, ());
+    let savings = SavingsContractClient::new(&env, &savings_contract_id);
+    let admin = Address::generate(&env);
+    let member1 = Address::generate(&env);
+    let member2 = Address::generate(&env);
+    let group_id = String::from_str(&env, "round-trip-group");
+    let name = String::from_str(&env, "Round Trip Group");
+    let start_timestamp = env.ledger().timestamp() + 86_400;
+
+    savings.create_group(
+        &admin,
+        &group_id,
+        &name,
+        &100_000_000,
+        &3,
+        &Frequency::Weekly,
+        &start_timestamp,
+        &true,
+        &admin,
+        &None,
+    );
+
+    registry.register_group(
+        &savings_contract_id,
+        &group_id,
+        &name,
+        &admin,
+        &true,
+    );
+
+    let assert_consistent = || {
+        let live_group = savings.get_group(&group_id);
+        let cached_group = registry.get_group_info(&savings_contract_id);
+        assert_eq!(cached_group.total_members, live_group.total_members);
+        assert_eq!(cached_group.is_public, live_group.is_public);
+    };
+
+    assert_consistent();
+
+    savings.join_group(&member1, &group_id);
+    assert_consistent();
+
+    savings.join_group(&member2, &group_id);
+    assert_eq!(savings.get_group(&group_id).status, GroupStatus::Active);
+    assert_consistent();
+
+    env.ledger().with_mut(|ledger| {
+        ledger.timestamp = start_timestamp + 1;
+    });
+    savings.contribute(&admin, &group_id);
+    assert_consistent();
+    savings.contribute(&member1, &group_id);
+    assert_consistent();
+    savings.contribute(&member2, &group_id);
+    assert_consistent();
+
+    assert_eq!(savings.get_round_payouts(&group_id, &1).len(), 1);
+}
 }


### PR DESCRIPTION

 No test verifies a group runs for exactly total_members rounds, not one more or one fewer

Location: contracts/savings/src/lib.rs:460-468 (end_round's round-advancement/completion logic) vs contracts/savings/src/tests.rs

Root cause:
The termination condition if group.current_round >= group.total_members { Completed } is central to the entire contract's lifecycle, but no test explicitly runs a group through its ENTIRE lifecycle end-to-end and asserts the exact round count at which status becomes Completed.

Impact:
An off-by-one regression here (e.g. from a future refactor of the increment logic) could easily go undetected without an explicit full-lifecycle test, given how central and rarely-exercised-to-completion this invariant is in the existing suite.
closes #785
closes #791