### PR TITLE
feat(infra): testnet Terraform environment (#899), web app HPA (#900)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,60 @@
+version: 2
+updates:
+  # Rust / Cargo dependencies
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "BlockHaven-Labs/core"
+    labels:
+      - "dependencies"
+      - "rust"
+    groups:
+      soroban-sdk:
+        patterns:
+          - "soroban-sdk"
+          - "soroban-*"
+
+  # NPM / Node dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "BlockHaven-Labs/core"
+    labels:
+      - "dependencies"
+      - "javascript"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"
+
+  # Docker
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "docker"
+
+  # Mobile (React Native / Expo)
+  - package-ecosystem: "npm"
+    directory: "/mobile"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "mobile"

--- a/.github/workflows/contracts-ci.yml
+++ b/.github/workflows/contracts-ci.yml
@@ -1,0 +1,84 @@
+name: Contracts CI
+
+on:
+  pull_request:
+    paths:
+      - "contracts/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  check:
+    name: Check & Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Cargo check
+        run: cargo check --workspace --all-targets
+
+      - name: Clippy (warnings as errors)
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run cargo test
+        run: cargo test --workspace
+
+  fmt:
+    name: Format Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+  soroban-build:
+    name: Soroban Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Stellar CLI
+        run: |
+          curl -s https://soroban.stellar.org | bash
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Build contracts
+        run: |
+          for contract in contracts/*/; do
+            if [ -f "$contract/Cargo.toml" ]; then
+              echo "Building $contract..."
+              cd "$contract"
+              stellar contract build
+              cd ../..
+            fi
+          done

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -1,0 +1,118 @@
+name: Web CI
+
+on:
+  pull_request:
+    paths:
+      - "apps/web/**"
+      - "packages/**"
+      - "package.json"
+      - "package-lock.json"
+  push:
+    branches: [main]
+
+env:
+  NODE_VERSION: "20"
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build shared packages
+        run: npm run build:shared
+
+      - name: Run ESLint
+        run: npm run lint --workspace=apps/web
+
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build shared packages
+        run: npm run build:shared
+
+      - name: TypeScript type check
+        run: npx tsc --noEmit --workspace=apps/web
+
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build shared packages
+        run: npm run build:shared
+
+      - name: Run tests
+        run: npm run test --workspace=apps/web
+
+  build:
+    name: Production Build
+    runs-on: ubuntu-latest
+    needs: [lint, typecheck, test]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build shared packages
+        run: npm run build:shared
+
+      - name: Production build
+        run: npm run build --workspace=apps/web
+        env:
+          NEXT_TELEMETRY_DISABLED: 1
+
+  # Placeholder for Playwright E2E (enabled once test suite exists)
+  # e2e:
+  #   name: E2E Tests
+  #   runs-on: ubuntu-latest
+  #   needs: [build]
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: actions/setup-node@v4
+  #       with:
+  #         node-version: ${{ env.NODE_VERSION }}
+  #         cache: "npm"
+  #     - run: npm ci
+  #     - run: npm run build:shared
+  #     - run: npx playwright install --with-deps
+  #     - run: npm run test:e2e --workspace=apps/web

--- a/infra/secrets/README.md
+++ b/infra/secrets/README.md
@@ -1,0 +1,104 @@
+# Secrets Management Strategy
+
+This document describes how EsuStellar manages secrets across development,
+staging, and production environments.
+
+## Approach: Kubernetes Secrets + Sealed Secrets
+
+We use a layered approach:
+
+1. **Local development**: `.env` files (gitignored) for developer convenience
+2. **CI/CD**: GitHub Actions encrypted secrets
+3. **Staging/Production**: Kubernetes Secrets encrypted with Bitnami Sealed Secrets
+
+## Secrets Inventory
+
+### Blockchain / RPC
+
+| Secret | Environment | Description |
+|--------|-------------|-------------|
+| `STELLAR_RPC_URL` | All | Horizon / RPC endpoint URL |
+| `STELLAR_NETWORK_PASSPHRASE` | All | `Test Suggested Ledger` or `Public Global Stellar Network` |
+| `DEPLOYER_SECRET_KEY` | CI only | Stellar account used for contract deployment |
+
+### Application
+
+| Secret | Environment | Description |
+|--------|-------------|-------------|
+| `NEXTAUTH_SECRET` | Staging/Prod | Session encryption key |
+| `DATABASE_URL` | Staging/Prod | Postgres connection string (if applicable) |
+
+### Monitoring
+
+| Secret | Environment | Description |
+|--------|-------------|-------------|
+| `GRAFANA_ADMIN_PASSWORD` | Staging/Prod | Grafana admin password |
+| `SLACK_WEBHOOK_URL` | Staging/Prod | Alert routing webhook |
+
+## Local Development
+
+Create a `.env` file in the project root (never commit this):
+
+```bash
+STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+STELLAR_NETWORK_PASSPHRASE=Test Suggested Ledger ; October 2022
+# Do NOT put deployer keys in .env — use `stellar keys` CLI instead
+```
+
+## CI/CD (GitHub Actions)
+
+Secrets are stored in GitHub repository settings under Settings > Secrets.
+
+Required secrets for the CI workflows:
+
+- `CODECOV_TOKEN` — for test coverage uploads
+
+Required secrets for deployment:
+
+- `STELLAR_RPC_URL`
+- `DEPLOYER_SECRET_KEY`
+- `KUBE_CONFIG` — base64-encoded kubeconfig for the target cluster
+
+## Kubernetes (Sealed Secrets)
+
+For staging and production, we encrypt Kubernetes Secrets using
+[Bitnami Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets):
+
+```bash
+# Encrypt a secret
+kubectl create secret generic app-secrets \
+  --from-literal=STELLAR_RPC_URL=https://soroban-testnet.stellar.org \
+  --dry-run=client -o yaml | \
+  kubeseal --format yaml > infra/secrets/sealed-app-secrets.yaml
+```
+
+The `SealedSecret` CRD is safe to commit to the repo. Only the controller
+in the cluster can decrypt it.
+
+## Rotation Policy
+
+| Secret | Rotation Cadence |
+|--------|-----------------|
+| `DEPLOYER_SECRET_KEY` | Every 90 days |
+| `NEXTAUTH_SECRET` | Every 90 days |
+| `GRAFANA_ADMIN_PASSWORD` | Every 180 days |
+| `SLACK_WEBHOOK_URL` | On personnel change |
+
+## What Must NEVER Be Committed
+
+- `.env` files
+- Raw Kubernetes secret YAML (unencrypted)
+- Private keys or seed phrases
+- API tokens in plaintext
+
+If a secret is accidentally committed, rotate it immediately and
+check `git log` for any leaked references.
+
+## Verification
+
+After applying this strategy, verify:
+
+1. `git status` shows no `.env` files tracked
+2. `.gitignore` includes `.env*`
+3. CI workflows reference GitHub Secrets, not hardcoded values
+4. Sealed Secrets CRDs are valid: `kubeseal --validate -f infra/secrets/`

--- a/infra/testnet/main.tf
+++ b/infra/testnet/main.tf
@@ -1,0 +1,155 @@
+# Testnet environment — inherits the shared Terraform module
+# and applies testnet-specific overrides.
+
+module "shared" {
+  source = "../terraform"
+
+  project_name         = var.project_name
+  environment          = "testnet"
+  aws_region           = var.aws_region
+  enable_logging       = true
+  allowed_ingress_cidrs = var.allowed_ingress_cidrs
+}
+
+# ── Stellar Testnet RPC access ──────────────────────────────────────────────
+
+resource "aws_ssm_parameter" "stellar_rpc_url" {
+  name        = "/${var.project_name}/testnet/stellar-rpc-url"
+  description = "Stellar testnet RPC endpoint"
+  type        = "String"
+  value       = var.stellar_rpc_url
+
+  tags = module.shared.common_tags
+}
+
+resource "aws_ssm_parameter" "stellar_network_passphrase" {
+  name        = "/${var.project_name}/testnet/stellar-network-passphrase"
+  description = "Stellar testnet network passphrase"
+  type        = "String"
+  value       = "Test Suggested Ledger ; October 2022"
+
+  tags = module.shared.common_tags
+}
+
+# ── ECS Fargate for web app ────────────────────────────────────────────────
+
+resource "aws_ecs_cluster" "web" {
+  name = "${var.project_name}-testnet-web"
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+
+  tags = module.shared.common_tags
+}
+
+resource "aws_ecs_task_definition" "web" {
+  family                   = "${var.project_name}-testnet-web"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = 256
+  memory                   = 512
+
+  container_definitions = jsonencode([
+    {
+      name      = "web"
+      image     = var.web_image
+      essential = true
+
+      portMappings = [
+        {
+          containerPort = 3000
+          hostPort      = 3000
+          protocol      = "tcp"
+        }
+      ]
+
+      environment = [
+        { name = "NEXT_PUBLIC_STELLAR_NETWORK", value = "testnet" },
+        { name = "NEXT_TELEMETRY_DISABLED",     value = "1" },
+      ]
+
+      secrets = [
+        {
+          name      = "STELLAR_RPC_URL"
+          valueFrom = aws_ssm_parameter.stellar_rpc_url.arn
+        },
+        {
+          name      = "STELLAR_NETWORK_PASSPHRASE"
+          valueFrom = aws_ssm_parameter.stellar_network_passphrase.arn
+        },
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = "/ecs/${var.project_name}-testnet-web"
+          "awslogs-region"        = var.aws_region
+          "awslogs-stream-prefix" = "ecs"
+        }
+      }
+    }
+  ])
+
+  tags = module.shared.common_tags
+}
+
+resource "aws_ecs_service" "web" {
+  name            = "${var.project_name}-testnet-web"
+  cluster         = aws_ecs_cluster.web.id
+  task_definition = aws_ecs_task_definition.web.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets         = module.shared.private_subnet_ids
+    security_groups = [aws_security_group.web.id]
+  }
+
+  tags = module.shared.common_tags
+}
+
+resource "aws_security_group" "web" {
+  name_prefix = "${var.project_name}-testnet-web-"
+  vpc_id      = module.shared.vpc_id
+
+  ingress {
+    from_port   = 3000
+    to_port     = 3000
+    protocol    = "tcp"
+    cidr_blocks = var.allowed_ingress_cidrs
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(module.shared.common_tags, { Name = "${var.project_name}-testnet-web-sg" })
+}
+
+# ── CloudWatch Logs ────────────────────────────────────────────────────────
+
+resource "aws_cloudwatch_log_group" "web" {
+  name              = "/ecs/${var.project_name}-testnet-web"
+  retention_in_days = 14
+
+  tags = module.shared.common_tags
+}
+
+# ── Outputs ────────────────────────────────────────────────────────────────
+
+output "ecs_cluster_arn" {
+  value = aws_ecs_cluster.web.arn
+}
+
+output "ecs_service_name" {
+  value = aws_ecs_service.web.name
+}
+
+output "stellar_rpc_url_ssm" {
+  value = aws_ssm_parameter.stellar_rpc_url.name
+}

--- a/infra/testnet/outputs.tf
+++ b/infra/testnet/outputs.tf
@@ -1,0 +1,7 @@
+output "environment" {
+  value = "testnet"
+}
+
+output "ecs_cluster_arn" {
+  value = module.shared.ecs_cluster_arn
+}

--- a/infra/testnet/variables.tf
+++ b/infra/testnet/variables.tf
@@ -1,0 +1,29 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "project_name" {
+  description = "Project name prefix"
+  type        = string
+  default     = "esustellar"
+}
+
+variable "allowed_ingress_cidrs" {
+  description = "CIDR blocks allowed to access the web app"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "stellar_rpc_url" {
+  description = "Stellar testnet RPC endpoint URL"
+  type        = string
+  default     = "https://soroban-testnet.stellar.org"
+}
+
+variable "web_image" {
+  description = "Docker image for the web app"
+  type        = string
+  default     = "esustellar/web:latest"
+}

--- a/k8s/web/deployment.yaml
+++ b/k8s/web/deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: esustellar-web
+  labels:
+    app: esustellar-web
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: esustellar-web
+  template:
+    metadata:
+      labels:
+        app: esustellar-web
+    spec:
+      containers:
+        - name: web
+          image: esustellar/web:latest
+          ports:
+            - containerPort: 3000
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          env:
+            - name: NEXT_TELEMETRY_DISABLED
+              value: "1"
+            - name: STELLAR_NETWORK
+              value: "testnet"
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 30

--- a/k8s/web/hpa.yaml
+++ b/k8s/web/hpa.yaml
@@ -1,0 +1,51 @@
+# Issue #900 — Horizontal Pod Autoscaler for the web app.
+#
+# Scaling rationale:
+# - CPU target 70%: the web app is I/O bound (Stellar RPC calls),
+#   so CPU usage is a reasonable proxy for request load.
+# - Memory target 80%: Next.js SSR can spike memory under heavy
+#   concurrent requests; 80% provides headroom before OOM kills.
+# - Min 2 replicas: ensures availability during rolling deploys.
+# - Max 8 replicas: prevents runaway costs while handling traffic
+#   spikes (e.g., contribution deadline windows).
+# - Scale-up is faster (60s stabilization) than scale-down (300s)
+#   to respond quickly to bursts.
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: esustellar-web-hpa
+  labels:
+    app: esustellar-web
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: esustellar-web
+  minReplicas: 2
+  maxReplicas: 8
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+        - type: Pods
+          value: 2
+          periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Percent
+          value: 25
+          periodSeconds: 120
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80

--- a/k8s/web/service.yaml
+++ b/k8s/web/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: esustellar-web
+  labels:
+    app: esustellar-web
+spec:
+  selector:
+    app: esustellar-web
+  ports:
+    - port: 80
+      targetPort: 3000
+      protocol: TCP
+  type: ClusterIP


### PR DESCRIPTION
## Summary

Adds testnet infrastructure-as-code and Kubernetes autoscaling for the web app.

## Changes

### #899 — Infrastructure-as-code for testnet environment
- `infra/testnet/main.tf` — Full ECS Fargate setup with shared module inheritance
- SSM parameters for Stellar RPC URL and network passphrase
- ECS task definition with secrets injection from SSM
- CloudWatch log group with 14-day retention
- Security group for web traffic

### #900 — Kubernetes horizontal pod autoscaler
- `k8s/web/hpa.yaml` — HPA targeting 70% CPU and 80% memory
- Min 2 / max 8 replicas with controlled scale-up (60s) and scale-down (300s)
- `k8s/web/deployment.yaml` — Deployment with resource requests/limits and health probes
- `k8s/web/service.yaml` — ClusterIP service for internal access

Rationale for HPA targets:
- CPU 70%: web app is I/O-bound (Stellar RPC calls), CPU is a reasonable load proxy
- Memory 80%: Next.js SSR can spike under concurrent requests
- Scale-up faster than scale-down to handle contribution deadline bursts

Closes #899, closes #900