### PR TITLE
feat: accessibility audit (WCAG 2.1 AA) for core flows

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -1,0 +1,83 @@
+name: Accessibility Audit (WCAG 2.1 AA)
+
+on:
+  push:
+    branches:
+      - main
+      - "feat/**"
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  a11y-audit:
+    name: axe-core WCAG 2.1 AA audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    defaults:
+      run:
+        working-directory: apps/web
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: apps/web/package-lock.json
+
+      # Install root workspace deps (shared packages)
+      - name: Install root dependencies
+        working-directory: .
+        run: npm ci --ignore-scripts
+
+      # Install apps/web deps (includes @axe-core/playwright and @playwright/test)
+      - name: Install web app dependencies
+        run: npm ci --ignore-scripts
+
+      # Install Playwright browser binaries (Chromium only)
+      - name: Install Playwright browsers
+        run: npx playwright@1.49.1 install --with-deps chromium
+
+      # Build the Next.js app so the dev server starts cleanly
+      - name: Build Next.js app
+        run: npm run build
+        env:
+          # Disable telemetry in CI
+          NEXT_TELEMETRY_DISABLED: "1"
+
+      # Run axe-playwright accessibility tests.
+      # The Playwright webServer config in e2e/playwright.config.ts will
+      # start `npm run dev` automatically on port 3001.
+      - name: Run accessibility audit
+        run: npm run test:a11y
+        env:
+          CI: "true"
+          NEXT_TELEMETRY_DISABLED: "1"
+          A11Y_PORT: "3001"
+
+      # Always upload the JSON report so findings are preserved even on failure
+      - name: Upload a11y report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: a11y-report
+          path: a11y-report.json
+          if-no-files-found: warn
+
+      # Upload Playwright test traces / screenshots on failure
+      - name: Upload Playwright test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-results
+          path: apps/web/test-results/
+          if-no-files-found: ignore

--- a/apps/web/e2e/accessibility/create-group.a11y.ts
+++ b/apps/web/e2e/accessibility/create-group.a11y.ts
@@ -1,0 +1,82 @@
+/**
+ * Accessibility audit — Create group flow
+ *
+ * WCAG 2.1 AA checks (via axe-core) for:
+ *   - /create page initial state
+ *   - Form fields (labels, inputs, selects, switches)
+ *   - Validation error states
+ *
+ * Findings are written to a11y-report.json and violations fail the test.
+ */
+
+import { test } from "@playwright/test";
+import { auditPage, expectNoViolations } from "./helpers";
+
+test.describe("Create group flow — WCAG 2.1 AA", () => {
+  test("create page has no accessibility violations", async ({ page }) => {
+    await page.goto("/create");
+    await page.waitForSelector("main, form, [data-testid='create-group-form']", {
+      state: "visible",
+    });
+
+    const results = await auditPage(page, "create-group-page");
+    expectNoViolations(results, "Create group page");
+  });
+
+  test("create group form fields have proper labels", async ({ page }) => {
+    await page.goto("/create");
+    await page.waitForSelector("form, [role='form']", {
+      state: "visible",
+      timeout: 15_000,
+    });
+
+    // Scope audit to just the form area
+    const results = await auditPage(page, "create-group-form-fields", {
+      include: ["form", "[role='form']", "main"],
+    });
+    expectNoViolations(results, "Create group form fields");
+  });
+
+  test("create group form shows accessible validation errors", async ({
+    page,
+  }) => {
+    await page.goto("/create");
+    // Wait for page to load
+    await page.waitForSelector("main", { state: "visible" });
+
+    // Attempt to submit an empty form to trigger validation messages
+    const submitButton = page.locator(
+      "button[type='submit'], button:has-text('Create'), button:has-text('Submit')"
+    );
+    const hasSubmitButton = (await submitButton.count()) > 0;
+    if (hasSubmitButton) {
+      await submitButton.first().click();
+      // Wait a moment for validation messages to render
+      await page.waitForTimeout(500);
+    }
+
+    const results = await auditPage(
+      page,
+      "create-group-form-validation-errors"
+    );
+    expectNoViolations(results, "Create group form validation errors");
+  });
+
+  test("create group select and switch inputs are accessible", async ({
+    page,
+  }) => {
+    await page.goto("/create");
+    await page.waitForSelector("main", { state: "visible" });
+
+    // Check for Radix UI Select and Switch accessibility
+    const results = await auditPage(
+      page,
+      "create-group-select-switch-inputs",
+      {
+        // Radix UI uses proper ARIA roles; exclude third-party embeds if any
+        exclude: ["iframe"],
+      }
+    );
+    expectNoViolations(results, "Create group select/switch inputs");
+  });
+});

--- a/apps/web/e2e/accessibility/groups.a11y.ts
+++ b/apps/web/e2e/accessibility/groups.a11y.ts
@@ -1,0 +1,95 @@
+/**
+ * Accessibility audit — Groups list and group detail flow
+ *
+ * WCAG 2.1 AA checks (via axe-core) for:
+ *   - /groups listing page
+ *   - Group card components
+ *   - Filter / search controls
+ *   - Group detail page (/groups/[id])
+ *
+ * Findings are written to a11y-report.json and violations fail the test.
+ */
+
+import { test } from "@playwright/test";
+import { auditPage, expectNoViolations } from "./helpers";
+
+test.describe("Groups list and detail flow — WCAG 2.1 AA", () => {
+  test("groups listing page has no accessibility violations", async ({
+    page,
+  }) => {
+    await page.goto("/groups");
+    await page.waitForSelector("main", { state: "visible" });
+
+    const results = await auditPage(page, "groups-listing-page");
+    expectNoViolations(results, "Groups listing page");
+  });
+
+  test("groups filter controls are accessible", async ({ page }) => {
+    await page.goto("/groups");
+    await page.waitForSelector("main", { state: "visible" });
+
+    // Scope to the filter/search area
+    const results = await auditPage(page, "groups-filter-controls", {
+      include: [
+        "[data-testid='groups-filter']",
+        "[aria-label*='filter']",
+        "[aria-label*='search']",
+        "form",
+        "input",
+        "select",
+        "[role='combobox']",
+      ],
+    });
+    expectNoViolations(results, "Groups filter controls");
+  });
+
+  test("group cards have accessible names and roles", async ({ page }) => {
+    await page.goto("/groups");
+    await page.waitForSelector("main", { state: "visible" });
+
+    const results = await auditPage(page, "groups-cards", {
+      include: [
+        "[data-testid='group-card']",
+        "[role='article']",
+        "[role='listitem']",
+        ".group-card",
+        "article",
+        "li",
+      ],
+    });
+    expectNoViolations(results, "Group cards");
+  });
+
+  test("dashboard page has no accessibility violations", async ({ page }) => {
+    await page.goto("/dashboard");
+    // Dashboard may redirect if wallet not connected — audit whatever loads
+    await page.waitForSelector("main, body", { state: "visible" });
+
+    const results = await auditPage(page, "dashboard-page");
+    expectNoViolations(results, "Dashboard page");
+  });
+
+  test("group detail page structure is accessible", async ({ page }) => {
+    // Navigate to the groups list first to check for any group links
+    await page.goto("/groups");
+    await page.waitForSelector("main", { state: "visible" });
+
+    // If group cards with links exist, navigate to the first detail page
+    const groupLink = page.locator("a[href^='/groups/']").first();
+    const hasGroupLink = (await groupLink.count()) > 0;
+
+    if (hasGroupLink) {
+      await groupLink.click();
+      await page.waitForSelector("main", { state: "visible" });
+    } else {
+      // No groups loaded (testnet may be empty); audit the listing page instead
+      // and log that detail test was skipped due to no data
+      console.warn(
+        "[a11y] No group detail links found — auditing groups listing page as fallback"
+      );
+    }
+
+    const results = await auditPage(page, "group-detail-page");
+    expectNoViolations(results, "Group detail page");
+  });
+});

--- a/apps/web/e2e/accessibility/helpers.ts
+++ b/apps/web/e2e/accessibility/helpers.ts
@@ -1,0 +1,114 @@
+/**
+ * Shared helpers for axe-core/playwright accessibility audits.
+ *
+ * All helpers enforce WCAG 2.1 AA compliance and write structured findings to
+ * the a11y-report.json artifact uploaded by CI.
+ */
+
+import { Page, expect } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+import * as fs from "fs";
+import * as path from "path";
+
+/** WCAG 2.1 AA tags that every audit must check. */
+export const WCAG_AA_TAGS = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"];
+
+export interface A11yFinding {
+  flow: string;
+  url: string;
+  timestamp: string;
+  violations: import("axe-core").Result[];
+  passes: number;
+  incomplete: number;
+}
+
+const reportPath = path.resolve(__dirname, "../../a11y-report.json");
+
+/** Append findings from a single page audit to the shared report file. */
+export function appendFinding(finding: A11yFinding): void {
+  let existing: A11yFinding[] = [];
+  if (fs.existsSync(reportPath)) {
+    try {
+      existing = JSON.parse(fs.readFileSync(reportPath, "utf-8"));
+    } catch {
+      existing = [];
+    }
+  }
+  existing.push(finding);
+  fs.writeFileSync(reportPath, JSON.stringify(existing, null, 2), "utf-8");
+}
+
+/**
+ * Run an axe WCAG 2.1 AA audit on the current page.
+ *
+ * @param page     Playwright page object
+ * @param flowName Human-readable name for this flow (used in the report)
+ * @param options  Optional AxeBuilder configuration (e.g. exclude selectors)
+ */
+export async function auditPage(
+  page: Page,
+  flowName: string,
+  options?: {
+    exclude?: string[];
+    include?: string[];
+    disableRules?: string[];
+  }
+): Promise<import("axe-core").AxeResults> {
+  let builder = new AxeBuilder({ page }).withTags(WCAG_AA_TAGS);
+
+  if (options?.exclude) {
+    for (const selector of options.exclude) {
+      builder = builder.exclude(selector);
+    }
+  }
+  if (options?.include) {
+    for (const selector of options.include) {
+      builder = builder.include(selector);
+    }
+  }
+  if (options?.disableRules) {
+    builder = builder.disableRules(options.disableRules);
+  }
+
+  const results = await builder.analyze();
+
+  appendFinding({
+    flow: flowName,
+    url: page.url(),
+    timestamp: new Date().toISOString(),
+    violations: results.violations,
+    passes: results.passes.length,
+    incomplete: results.incomplete.length,
+  });
+
+  return results;
+}
+
+/**
+ * Assert that no WCAG 2.1 AA violations are present.
+ * Provides a readable failure message that lists every violation found.
+ */
+export function expectNoViolations(
+  results: import("axe-core").AxeResults,
+  flowName: string
+): void {
+  if (results.violations.length === 0) return;
+
+  const summary = results.violations
+    .map(
+      (v, i) =>
+        `[${i + 1}] ${v.id} (${v.impact ?? "unknown"} impact): ${v.description}\n` +
+        `    Help: ${v.helpUrl}\n` +
+        `    Nodes affected: ${v.nodes.length}\n` +
+        v.nodes
+          .slice(0, 3)
+          .map((n) => `      - ${n.html}`)
+          .join("\n")
+    )
+    .join("\n\n");
+
+  expect(
+    results.violations,
+    `WCAG 2.1 AA violations found in "${flowName}":\n\n${summary}`
+  ).toHaveLength(0);
+}

--- a/apps/web/e2e/accessibility/home-wallet.a11y.ts
+++ b/apps/web/e2e/accessibility/home-wallet.a11y.ts
@@ -1,0 +1,58 @@
+/**
+ * Accessibility audit — Home page & wallet connection flow
+ *
+ * WCAG 2.1 AA checks (via axe-core) for:
+ *   - Landing page (hero, stats, features, how-it-works, CTA)
+ *   - Wallet connect button states (connected / disconnected)
+ *
+ * Findings are written to a11y-report.json and violations fail the test.
+ */
+
+import { test } from "@playwright/test";
+import { auditPage, expectNoViolations } from "./helpers";
+
+test.describe("Home page / wallet connection flow — WCAG 2.1 AA", () => {
+  test("home page has no accessibility violations", async ({ page }) => {
+    await page.goto("/");
+    // Wait for the hero section to be visible before auditing
+    await page.waitForSelector("main", { state: "visible" });
+
+    const results = await auditPage(page, "home-page");
+    expectNoViolations(results, "Home page");
+  });
+
+  test("wallet connect button area has no accessibility violations", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.waitForSelector("main", { state: "visible" });
+
+    // Scope audit to the header where the wallet button lives
+    const results = await auditPage(page, "wallet-connect-button", {
+      include: ["header", "nav"],
+    });
+    expectNoViolations(results, "Wallet connect button");
+  });
+
+  test("home page is keyboard navigable — skip link present", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    // Tab once — the first focusable element should be a skip-navigation link
+    // or the first interactive element. We run an axe audit after tab focus
+    // so the focus state is included in the audit.
+    await page.keyboard.press("Tab");
+    const results = await auditPage(page, "home-page-keyboard-nav");
+    expectNoViolations(results, "Home page keyboard navigation");
+  });
+
+  test("hero section has no color-contrast violations", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForSelector("section", { state: "visible" });
+
+    const results = await auditPage(page, "home-hero-section", {
+      include: ["main section:first-of-type"],
+    });
+    expectNoViolations(results, "Hero section color contrast");
+  });
+});

--- a/apps/web/e2e/playwright.config.ts
+++ b/apps/web/e2e/playwright.config.ts
@@ -1,0 +1,47 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright configuration for accessibility (WCAG 2.1 AA) audits.
+ * Uses axe-core via @axe-core/playwright to run automated checks against
+ * the three core flows: wallet connect, create group, and groups browse/detail.
+ *
+ * webServer starts Next.js on port 3001 so CI can run the tests without a
+ * separately managed server process.
+ */
+const PORT = process.env.A11Y_PORT ? parseInt(process.env.A11Y_PORT, 10) : 3001;
+const BASE_URL = `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: "./accessibility",
+  testMatch: "**/*.a11y.ts",
+  timeout: 60_000,
+  retries: process.env.CI ? 1 : 0,
+  reporter: [
+    ["list"],
+    [
+      "json",
+      {
+        outputFile: "../../a11y-report.json",
+      },
+    ],
+  ],
+  use: {
+    baseURL: BASE_URL,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: `npm run dev -- --port ${PORT}`,
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    stdout: "pipe",
+    stderr: "pipe",
+  },
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test:a11y": "playwright test --config e2e/playwright.config.ts"
   },
   "dependencies": {
     "@esustellar/shared": "*",
@@ -64,6 +65,8 @@
     "zod": "3.25.76"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.10.1",
+    "@playwright/test": "^1.49.1",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",


### PR DESCRIPTION
Closes #884

## Summary
Integrates axe-core via @axe-core/playwright to audit WCAG 2.1 AA compliance across the three core flows:
- Wallet connection (home page)
- Create group flow
- Groups browse & group detail

## Changes
- New `apps/web/e2e/accessibility/` test suite using axe-playwright
- New `.github/workflows/accessibility.yml` CI workflow
- Uploads `a11y-report.json` artifact with violation details
- Adds `test:a11y` script to apps/web/package.json

## Testing
Run locally: `cd apps/web && npm run test:a11y`