### PR TITLE
feat: add late_payment_penalty, social_vouching, migration_coordinator, oracle_feed contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,6 +871,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "late-payment-penalty"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -910,6 +917,13 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "migration-coordinator"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
 
 [[package]]
 name = "num-bigint"
@@ -961,6 +975,13 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "oracle-feed"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
 
 [[package]]
 name = "p256"
@@ -1165,6 +1186,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "referral-rewards"
+version = "0.1.0"
+dependencies = [
+ "proptest",
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -1394,6 +1423,13 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "social-vouching"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
 
 [[package]]
 name = "soroban-builtin-sdk-macros"

--- a/contracts/late_payment_penalty/Cargo.toml
+++ b/contracts/late_payment_penalty/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "late-payment-penalty"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true

--- a/contracts/late_payment_penalty/Makefile
+++ b/contracts/late_payment_penalty/Makefile
@@ -1,0 +1,16 @@
+default: build
+
+all: test
+
+test: build
+	cargo test
+
+build:
+	stellar contract build
+	@ls -l target/wasm32v1-none/release/*.wasm
+
+fmt:
+	cargo fmt --all
+
+clean:
+	cargo clean

--- a/contracts/late_payment_penalty/src/lib.rs
+++ b/contracts/late_payment_penalty/src/lib.rs
@@ -1,0 +1,170 @@
+#![no_std]
+
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, String};
+
+pub const CONTRACT_VERSION: &str = "0.1.0";
+const GROUP_TTL_EXTEND: u32 = 6_312_000;
+
+#[cfg(test)]
+mod tests;
+
+// #696: Error codes start at 600 to avoid overlap.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    NotAdmin = 600,
+    PenaltyPolicyNotSet = 601,
+    InvalidGracePeriod = 602,
+    InvalidPenaltyPercent = 603,
+    ContributionNotLate = 604,
+    AlreadyInitialized = 605,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PenaltyPolicy {
+    pub grace_period: u64,       // seconds after deadline before penalty applies
+    pub penalty_percent: u32,    // basis points (e.g., 500 = 5%)
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Policy(String),              // group_id -> PenaltyPolicy
+    PenaltyPool(String),         // group_id -> i128
+    Initialized,
+    Admin,
+}
+
+/// LatePaymentPenalty contract handles grace periods and penalty logic
+/// for members who contribute late but before a round is force-resolved.
+///
+/// Penalty funds route back into the group's own pool (not FeeTreasury)
+/// to benefit remaining members.
+#[contract]
+pub struct LatePaymentPenalty;
+
+#[contractimpl]
+impl LatePaymentPenalty {
+    pub fn initialize(env: Env, admin: Address) -> Result<(), Error> {
+        if env.storage().persistent().has(&DataKey::Initialized) {
+            return Err(Error::AlreadyInitialized);
+        }
+        env.storage().persistent().set(&DataKey::Initialized, &true);
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+        Ok(())
+    }
+
+    /// Set the penalty policy for a group.
+    /// - grace_period: seconds after the round deadline before penalty kicks in
+    /// - penalty_percent: basis points (e.g., 500 = 5% of contribution amount)
+    pub fn set_penalty_policy(
+        env: Env,
+        admin: Address,
+        group_id: String,
+        grace_period: u64,
+        penalty_percent: u32,
+    ) -> Result<PenaltyPolicy, Error> {
+        admin.require_auth();
+
+        let stored_admin: Address = env
+            .storage().persistent().get(&DataKey::Admin)
+            .ok_or(Error::NotAdmin)?;
+        if admin != stored_admin {
+            return Err(Error::NotAdmin);
+        }
+
+        // Validate: penalty_percent should be 0-5000 (0-50%)
+        if penalty_percent > 5000 {
+            return Err(Error::InvalidPenaltyPercent);
+        }
+
+        // Validate: grace_period should be reasonable (0-30 days)
+        if grace_period > 30 * 86400 {
+            return Err(Error::InvalidGracePeriod);
+        }
+
+        let policy = PenaltyPolicy {
+            grace_period,
+            penalty_percent,
+        };
+
+        let key = DataKey::Policy(group_id.clone());
+        env.storage().persistent().set(&key, &policy);
+        env.storage().persistent().extend_ttl(&key, GROUP_TTL_EXTEND, GROUP_TTL_EXTEND);
+
+        env.events().publish(
+            (symbol_short!("policy"), group_id),
+            (grace_period, penalty_percent),
+        );
+
+        Ok(policy)
+    }
+
+    /// Apply penalty for a late contribution.
+    /// Called by the savings contract during contribute when a member is late.
+    /// Returns the net amount after penalty deduction.
+    ///
+    /// # Arguments
+    /// - group_id: the group the contribution is for
+    /// - member: the member making the late contribution
+    /// - amount: the original contribution amount in stroops
+    /// - deadline_timestamp: the round deadline in seconds
+    pub fn apply_penalty(
+        env: Env,
+        group_id: String,
+        member: Address,
+        amount: i128,
+        deadline_timestamp: u64,
+    ) -> Result<i128, Error> {
+        let policy_key = DataKey::Policy(group_id.clone());
+        let policy: PenaltyPolicy = env
+            .storage().persistent().get(&policy_key)
+            .ok_or(Error::PenaltyPolicyNotSet)?;
+
+        let now = env.ledger().timestamp();
+
+        // Check if contribution is within grace period (no penalty)
+        if now <= deadline_timestamp + policy.grace_period {
+            // Not late past grace — no penalty
+            return Ok(amount);
+        }
+
+        // Calculate penalty
+        let penalty_amount = (amount as u128)
+            .checked_mul(policy.penalty_percent as u128)
+            .and_then(|v| v.checked_div(10_000))
+            .and_then(|v| Some(v as i128))
+            .ok_or(Error::ContributionNotLate)?;
+
+        let net_amount = amount
+            .checked_sub(penalty_amount)
+            .ok_or(Error::ContributionNotLate)?;
+
+        // Route penalty to group's penalty pool
+        let pool_key = DataKey::PenaltyPool(group_id.clone());
+        let current_pool: i128 = env.storage().persistent().get(&pool_key).unwrap_or(0);
+        let new_pool = current_pool.checked_add(penalty_amount).unwrap_or(current_pool);
+        env.storage().persistent().set(&pool_key, &new_pool);
+
+        env.events().publish(
+            (symbol_short!("penalty"), group_id),
+            (member, amount, penalty_amount, net_amount),
+        );
+
+        Ok(net_amount)
+    }
+
+    /// Get the penalty pool balance for a group
+    pub fn penalty_pool_balance(env: Env, group_id: String) -> i128 {
+        let pool_key = DataKey::PenaltyPool(group_id);
+        env.storage().persistent().get(&pool_key).unwrap_or(0)
+    }
+
+    /// Get the penalty policy for a group
+    pub fn get_policy(env: Env, group_id: String) -> Result<PenaltyPolicy, Error> {
+        let policy_key = DataKey::Policy(group_id);
+        env.storage().persistent().get(&policy_key).ok_or(Error::PenaltyPolicyNotSet)
+    }
+}

--- a/contracts/late_payment_penalty/src/tests.rs
+++ b/contracts/late_payment_penalty/src/tests.rs
@@ -1,0 +1,126 @@
+use crate::{LatePaymentPenalty, LatePaymentPenaltyClient};
+use soroban_sdk::{testutils::Address as _, testutils::Ledger, Address, Env, String};
+
+fn setup() -> (Env, Address, LatePaymentPenaltyClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| {
+        li.timestamp = 100_000;
+    });
+    let contract_id = env.register(LatePaymentPenalty, ());
+    let client = LatePaymentPenaltyClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    (env, admin, client)
+}
+
+#[test]
+fn test_set_penalty_policy() {
+    let (env, admin, client) = setup();
+    let group_id = String::from_str(&env, "group-1");
+
+    // 3-day grace, 5% penalty
+    let policy = client.set_penalty_policy(&admin, &group_id, &259_200, &500);
+    assert_eq!(policy.grace_period, 259_200);
+    assert_eq!(policy.penalty_percent, 500);
+}
+
+#[test]
+fn test_set_policy_admin_only() {
+    let (env, _, client) = setup();
+    let non_admin = Address::generate(&env);
+    let group_id = String::from_str(&env, "group-1");
+
+    let result = client.try_set_penalty_policy(&non_admin, &group_id, &259_200, &500);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_apply_penalty_on_time() {
+    let (env, admin, client) = setup();
+    let group_id = String::from_str(&env, "group-1");
+    let member = Address::generate(&env);
+
+    client.set_penalty_policy(&admin, &group_id, &259_200, &500);
+
+    let deadline = 200_000u64;
+    let amount = 100_000_000i128;
+
+    env.ledger().with_mut(|li| { li.timestamp = 150_000; });
+    let net = client.apply_penalty(&group_id, &member, &amount, &deadline);
+    assert_eq!(net, amount);
+}
+
+#[test]
+fn test_apply_penalty_within_grace() {
+    let (env, admin, client) = setup();
+    let group_id = String::from_str(&env, "group-1");
+    let member = Address::generate(&env);
+
+    client.set_penalty_policy(&admin, &group_id, &259_200, &500);
+
+    let deadline = 200_000u64;
+    let amount = 100_000_000i128;
+
+    env.ledger().with_mut(|li| { li.timestamp = 250_000; });
+    let net = client.apply_penalty(&group_id, &member, &amount, &deadline);
+    assert_eq!(net, amount);
+}
+
+#[test]
+fn test_apply_penalty_past_grace() {
+    let (env, admin, client) = setup();
+    let group_id = String::from_str(&env, "group-1");
+    let member = Address::generate(&env);
+
+    client.set_penalty_policy(&admin, &group_id, &259_200, &500);
+
+    let deadline = 200_000u64;
+    let amount = 100_000_000i128;
+
+    env.ledger().with_mut(|li| { li.timestamp = 500_000; });
+    let net = client.apply_penalty(&group_id, &member, &amount, &deadline);
+
+    let expected_penalty = 5_000_000i128;
+    assert_eq!(net, amount - expected_penalty);
+}
+
+#[test]
+fn test_penalty_pool_balance() {
+    let (env, admin, client) = setup();
+    let group_id = String::from_str(&env, "group-1");
+    let member = Address::generate(&env);
+
+    client.set_penalty_policy(&admin, &group_id, &259_200, &500);
+
+    let deadline = 200_000u64;
+    let amount = 100_000_000i128;
+
+    assert_eq!(client.penalty_pool_balance(&group_id), 0);
+
+    env.ledger().with_mut(|li| { li.timestamp = 500_000; });
+    client.apply_penalty(&group_id, &member, &amount, &deadline);
+
+    assert_eq!(client.penalty_pool_balance(&group_id), 5_000_000);
+}
+
+#[test]
+fn test_get_policy() {
+    let (env, admin, client) = setup();
+    let group_id = String::from_str(&env, "group-1");
+
+    client.set_penalty_policy(&admin, &group_id, &86400, &1000);
+
+    let policy = client.get_policy(&group_id);
+    assert_eq!(policy.grace_period, 86400);
+    assert_eq!(policy.penalty_percent, 1000);
+}
+
+#[test]
+fn test_invalid_penalty_percent() {
+    let (env, admin, client) = setup();
+    let group_id = String::from_str(&env, "group-1");
+
+    let result = client.try_set_penalty_policy(&admin, &group_id, &259_200, &6000);
+    assert!(result.is_err());
+}

--- a/contracts/migration_coordinator/Cargo.toml
+++ b/contracts/migration_coordinator/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "migration-coordinator"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true

--- a/contracts/migration_coordinator/Makefile
+++ b/contracts/migration_coordinator/Makefile
@@ -1,0 +1,16 @@
+default: build
+
+all: test
+
+test: build
+	cargo test
+
+build:
+	stellar contract build
+	@ls -l target/wasm32v1-none/release/*.wasm
+
+fmt:
+	cargo fmt --all
+
+clean:
+	cargo clean

--- a/contracts/migration_coordinator/src/lib.rs
+++ b/contracts/migration_coordinator/src/lib.rs
@@ -1,0 +1,171 @@
+#![no_std]
+
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, String, Vec};
+
+pub const CONTRACT_VERSION: &str = "0.1.0";
+const GROUP_TTL_EXTEND: u32 = 6_312_000;
+
+#[cfg(test)]
+mod tests;
+
+// #696: Error codes start at 800 to avoid overlap.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    NotAdmin = 800,
+    VersionNotFound = 801,
+    AlreadyDeprecated = 802,
+    NoVersionsRegistered = 803,
+    AlreadyInitialized = 804,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct VersionInfo {
+    pub address: Address,
+    pub version: String,
+    pub is_deprecated: bool,
+    pub registered_at: u64,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    CurrentVersion(String),          // contract_name -> Address
+    VersionInfo(String, String),     // (contract_name, version) -> VersionInfo
+    AllVersions(String),             // contract_name -> Vec<String>
+    Initialized,
+    Admin,
+}
+
+/// MigrationCoordinator is a version registry/pointer contract.
+/// It does NOT attempt actual state migration (out of scope).
+/// It tracks which contract addresses are "current" per version and
+/// signals deprecation to frontends/indexers.
+#[contract]
+pub struct MigrationCoordinator;
+
+#[contractimpl]
+impl MigrationCoordinator {
+    pub fn initialize(env: Env, admin: Address) -> Result<(), Error> {
+        if env.storage().persistent().has(&DataKey::Initialized) {
+            return Err(Error::AlreadyInitialized);
+        }
+        env.storage().persistent().set(&DataKey::Initialized, &true);
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+        Ok(())
+    }
+
+    /// Register a new version of a contract.
+    /// Automatically sets this version as the current one.
+    pub fn register_version(
+        env: Env,
+        admin: Address,
+        contract_name: String,
+        version: String,
+        address: Address,
+    ) -> Result<VersionInfo, Error> {
+        admin.require_auth();
+
+        let stored_admin: Address = env
+            .storage().persistent().get(&DataKey::Admin)
+            .ok_or(Error::NotAdmin)?;
+        if admin != stored_admin {
+            return Err(Error::NotAdmin);
+        }
+
+        let now = env.ledger().timestamp();
+
+        let info = VersionInfo {
+            address: address.clone(),
+            version: version.clone(),
+            is_deprecated: false,
+            registered_at: now,
+        };
+
+        // Store version info
+        let info_key = DataKey::VersionInfo(contract_name.clone(), version.clone());
+        env.storage().persistent().set(&info_key, &info);
+        env.storage().persistent().extend_ttl(&info_key, GROUP_TTL_EXTEND, GROUP_TTL_EXTEND);
+
+        // Update current version pointer
+        let current_key = DataKey::CurrentVersion(contract_name.clone());
+        env.storage().persistent().set(&current_key, &address);
+        env.storage().persistent().extend_ttl(&current_key, GROUP_TTL_EXTEND, GROUP_TTL_EXTEND);
+
+        // Track all versions
+        let versions_key = DataKey::AllVersions(contract_name.clone());
+        let mut versions: Vec<String> = env
+            .storage().persistent().get(&versions_key)
+            .unwrap_or(Vec::new(&env));
+        versions.push_back(version.clone());
+        env.storage().persistent().set(&versions_key, &versions);
+
+        env.events().publish(
+            (symbol_short!("register"), contract_name),
+            (version, address),
+        );
+
+        Ok(info)
+    }
+
+    /// Deprecate a specific version. It remains queryable but flagged.
+    pub fn deprecate_version(
+        env: Env,
+        admin: Address,
+        contract_name: String,
+        version: String,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+
+        let stored_admin: Address = env
+            .storage().persistent().get(&DataKey::Admin)
+            .ok_or(Error::NotAdmin)?;
+        if admin != stored_admin {
+            return Err(Error::NotAdmin);
+        }
+
+        let info_key = DataKey::VersionInfo(contract_name.clone(), version.clone());
+        let mut info: VersionInfo = env
+            .storage().persistent().get(&info_key)
+            .ok_or(Error::VersionNotFound)?;
+
+        if info.is_deprecated {
+            return Err(Error::AlreadyDeprecated);
+        }
+
+        info.is_deprecated = true;
+        env.storage().persistent().set(&info_key, &info);
+
+        env.events().publish(
+            (symbol_short!("deprecate"), contract_name),
+            (version,),
+        );
+
+        Ok(())
+    }
+
+    /// Get the current (latest non-deprecated) contract address.
+    /// This is the single source of truth frontends should query.
+    pub fn get_current(env: Env, contract_name: String) -> Result<Address, Error> {
+        let current_key = DataKey::CurrentVersion(contract_name);
+        env.storage().persistent().get(&current_key).ok_or(Error::NoVersionsRegistered)
+    }
+
+    /// Get version info for a specific contract version.
+    pub fn get_version_info(
+        env: Env,
+        contract_name: String,
+        version: String,
+    ) -> Result<VersionInfo, Error> {
+        let info_key = DataKey::VersionInfo(contract_name, version);
+        env.storage().persistent().get(&info_key).ok_or(Error::VersionNotFound)
+    }
+
+    /// Get all registered versions for a contract
+    pub fn get_all_versions(env: Env, contract_name: String) -> Vec<String> {
+        let versions_key = DataKey::AllVersions(contract_name);
+        env.storage().persistent().get(&versions_key).unwrap_or(Vec::new(&env))
+    }
+}

--- a/contracts/migration_coordinator/src/tests.rs
+++ b/contracts/migration_coordinator/src/tests.rs
@@ -1,0 +1,124 @@
+use crate::{MigrationCoordinator, MigrationCoordinatorClient};
+use soroban_sdk::{testutils::Address as _, testutils::Ledger, Address, Env, String};
+
+fn setup() -> (Env, Address, MigrationCoordinatorClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| {
+        li.timestamp = 100_000;
+    });
+    let contract_id = env.register(MigrationCoordinator, ());
+    let client = MigrationCoordinatorClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    (env, admin, client)
+}
+
+#[test]
+fn test_register_version() {
+    let (env, admin, client) = setup();
+    let name = String::from_str(&env, "savings");
+    let version = String::from_str(&env, "0.1.0");
+    let addr = Address::generate(&env);
+
+    let info = client.register_version(&admin, &name, &version, &addr);
+    assert_eq!(info.address, addr);
+    assert!(!info.is_deprecated);
+}
+
+#[test]
+fn test_register_updates_current() {
+    let (env, admin, client) = setup();
+    let name = String::from_str(&env, "savings");
+    let v1 = String::from_str(&env, "0.1.0");
+    let v2 = String::from_str(&env, "0.2.0");
+    let addr1 = Address::generate(&env);
+    let addr2 = Address::generate(&env);
+
+    client.register_version(&admin, &name, &v1, &addr1);
+    let current = client.get_current(&name);
+    assert_eq!(current, addr1);
+
+    client.register_version(&admin, &name, &v2, &addr2);
+    let current2 = client.get_current(&name);
+    assert_eq!(current2, addr2);
+}
+
+#[test]
+fn test_deprecate_version() {
+    let (env, admin, client) = setup();
+    let name = String::from_str(&env, "savings");
+    let version = String::from_str(&env, "0.1.0");
+    let addr = Address::generate(&env);
+
+    client.register_version(&admin, &name, &version, &addr);
+    client.deprecate_version(&admin, &name, &version);
+
+    let info = client.get_version_info(&name, &version);
+    assert!(info.is_deprecated);
+}
+
+#[test]
+fn test_deprecated_still_queryable() {
+    let (env, admin, client) = setup();
+    let name = String::from_str(&env, "savings");
+    let version = String::from_str(&env, "0.1.0");
+    let addr = Address::generate(&env);
+
+    client.register_version(&admin, &name, &version, &addr);
+    client.deprecate_version(&admin, &name, &version);
+
+    // Can still query version info (returns directly, not Result)
+    let info = client.get_version_info(&name, &version);
+    assert!(info.is_deprecated);
+}
+
+#[test]
+fn test_cannot_deprecate_twice() {
+    let (env, admin, client) = setup();
+    let name = String::from_str(&env, "savings");
+    let version = String::from_str(&env, "0.1.0");
+    let addr = Address::generate(&env);
+
+    client.register_version(&admin, &name, &version, &addr);
+    client.deprecate_version(&admin, &name, &version);
+
+    let result = client.try_deprecate_version(&admin, &name, &version);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_admin_only() {
+    let (env, _, client) = setup();
+    let non_admin = Address::generate(&env);
+    let name = String::from_str(&env, "savings");
+    let version = String::from_str(&env, "0.1.0");
+    let addr = Address::generate(&env);
+
+    let result = client.try_register_version(&non_admin, &name, &version, &addr);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_get_all_versions() {
+    let (env, admin, client) = setup();
+    let name = String::from_str(&env, "savings");
+    let v1 = String::from_str(&env, "0.1.0");
+    let v2 = String::from_str(&env, "0.2.0");
+    let addr = Address::generate(&env);
+
+    client.register_version(&admin, &name, &v1, &addr);
+    client.register_version(&admin, &name, &v2, &addr);
+
+    let versions = client.get_all_versions(&name);
+    assert_eq!(versions.len(), 2);
+}
+
+#[test]
+fn test_get_current_no_versions() {
+    let (env, _, client) = setup();
+    let name = String::from_str(&env, "savings");
+
+    let result = client.try_get_current(&name);
+    assert!(result.is_err());
+}

--- a/contracts/oracle_feed/Cargo.toml
+++ b/contracts/oracle_feed/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "oracle-feed"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true

--- a/contracts/oracle_feed/Makefile
+++ b/contracts/oracle_feed/Makefile
@@ -1,0 +1,16 @@
+default: build
+
+all: test
+
+test: build
+	cargo test
+
+build:
+	stellar contract build
+	@ls -l target/wasm32v1-none/release/*.wasm
+
+fmt:
+	cargo fmt --all
+
+clean:
+	cargo clean

--- a/contracts/oracle_feed/src/lib.rs
+++ b/contracts/oracle_feed/src/lib.rs
@@ -1,0 +1,152 @@
+#![no_std]
+
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, String};
+
+pub const CONTRACT_VERSION: &str = "0.1.0";
+const GROUP_TTL_EXTEND: u32 = 6_312_000;
+
+#[cfg(test)]
+mod tests;
+
+// #696: Error codes start at 900 to avoid overlap.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    NotAdmin = 900,
+    NotPublisher = 901,
+    StalePrice = 902,
+    InvalidAsset = 903,
+    AlreadyInitialized = 904,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct PriceData {
+    pub price: i128,
+    pub decimals: u32,
+    pub timestamp: u64,
+    pub publisher: Address,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    IsPublisher(Address),           // address -> bool
+    LatestPrice(String),            // asset -> PriceData
+    Initialized,
+}
+
+/// OracleFeed is an admin-managed publisher allowlist oracle.
+/// Admin adds/removes publishers via add_publisher/remove_publisher.
+/// Publishers push signed price data. Consumers read latest_price.
+/// NOT integration-tested with real oracles (TODO).
+/// Partially implemented — existing integration test framework can be extended.
+#[contract]
+pub struct OracleFeed;
+
+#[contractimpl]
+impl OracleFeed {
+    pub fn initialize(env: Env, admin: Address) -> Result<(), Error> {
+        if env.storage().persistent().has(&DataKey::Initialized) {
+            return Err(Error::AlreadyInitialized);
+        }
+        env.storage().persistent().set(&DataKey::Initialized, &true);
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+        Ok(())
+    }
+
+    /// Add a publisher to the allowlist. Admin only.
+    pub fn add_publisher(
+        env: Env,
+        admin: Address,
+        publisher: Address,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+
+        let stored_admin: Address = env
+            .storage().persistent().get(&DataKey::Admin)
+            .ok_or(Error::NotAdmin)?;
+        if admin != stored_admin {
+            return Err(Error::NotAdmin);
+        }
+
+        let key = DataKey::IsPublisher(publisher.clone());
+        env.storage().persistent().set(&key, &true);
+        env.storage().persistent().extend_ttl(&key, GROUP_TTL_EXTEND, GROUP_TTL_EXTEND);
+
+        env.events().publish(
+            (symbol_short!("add_pub"), admin),
+            (publisher,),
+        );
+
+        Ok(())
+    }
+
+    /// Remove a publisher from the allowlist. Admin only.
+    pub fn remove_publisher(
+        env: Env,
+        admin: Address,
+        publisher: Address,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+
+        let stored_admin: Address = env
+            .storage().persistent().get(&DataKey::Admin)
+            .ok_or(Error::NotAdmin)?;
+        if admin != stored_admin {
+            return Err(Error::NotAdmin);
+        }
+
+        let key = DataKey::IsPublisher(publisher.clone());
+        env.storage().persistent().remove(&key);
+
+        env.events().publish(
+            (symbol_short!("rm_pub"), admin),
+            (publisher,),
+        );
+
+        Ok(())
+    }
+
+    /// Publish a price update for an asset. Only allowlisted publishers.
+    pub fn publish_price(
+        env: Env,
+        publisher: Address,
+        asset: String,
+        price: i128,
+        decimals: u32,
+    ) -> Result<(), Error> {
+        publisher.require_auth();
+
+        let pub_key = DataKey::IsPublisher(publisher.clone());
+        if !env.storage().persistent().has(&pub_key) {
+            return Err(Error::NotPublisher);
+        }
+
+        let data = PriceData {
+            price,
+            decimals,
+            timestamp: env.ledger().timestamp(),
+            publisher: publisher.clone(),
+        };
+
+        let price_key = DataKey::LatestPrice(asset.clone());
+        env.storage().persistent().set(&price_key, &data);
+        env.storage().persistent().extend_ttl(&price_key, GROUP_TTL_EXTEND, GROUP_TTL_EXTEND);
+
+        env.events().publish(
+            (symbol_short!("price"), asset),
+            (price, decimals, publisher),
+        );
+
+        Ok(())
+    }
+
+    /// Get the latest price for an asset.
+    pub fn latest_price(env: Env, asset: String) -> Result<PriceData, Error> {
+        let price_key = DataKey::LatestPrice(asset);
+        env.storage().persistent().get(&price_key).ok_or(Error::InvalidAsset)
+    }
+}

--- a/contracts/oracle_feed/src/tests.rs
+++ b/contracts/oracle_feed/src/tests.rs
@@ -1,0 +1,96 @@
+use crate::{OracleFeed, OracleFeedClient};
+use soroban_sdk::{testutils::Address as _, testutils::Ledger, Address, Env, String};
+
+fn setup() -> (Env, Address, OracleFeedClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| {
+        li.timestamp = 100_000;
+    });
+    let contract_id = env.register(OracleFeed, ());
+    let client = OracleFeedClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    (env, admin, client)
+}
+
+#[test]
+fn test_add_publisher_and_publish() {
+    let (env, admin, client) = setup();
+    let publisher = Address::generate(&env);
+
+    client.add_publisher(&admin, &publisher);
+
+    let asset = String::from_str(&env, "USDC");
+    client.publish_price(&publisher, &asset, &100_000_000, &8);
+
+    let price = client.latest_price(&asset);
+    assert_eq!(price.price, 100_000_000);
+    assert_eq!(price.decimals, 8);
+}
+
+#[test]
+fn test_not_publisher_rejected() {
+    let (env, _, client) = setup();
+    let publisher = Address::generate(&env);
+    let asset = String::from_str(&env, "USDC");
+
+    let result = client.try_publish_price(&publisher, &asset, &100, &8);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_admin_only() {
+    let (env, _, client) = setup();
+    let non_admin = Address::generate(&env);
+    let publisher = Address::generate(&env);
+
+    let result = client.try_add_publisher(&non_admin, &publisher);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_remove_publisher() {
+    let (env, admin, client) = setup();
+    let publisher = Address::generate(&env);
+
+    client.add_publisher(&admin, &publisher);
+    let asset = String::from_str(&env, "USDC");
+    client.publish_price(&publisher, &asset, &100, &8);
+
+    client.remove_publisher(&admin, &publisher);
+
+    // Can no longer publish new prices
+    let result = client.try_publish_price(&publisher, &asset, &200, &8);
+    assert!(result.is_err());
+
+    // Old prices still queryable
+    let price = client.latest_price(&asset);
+    assert_eq!(price.price, 100);
+}
+
+#[test]
+fn test_latest_price_no_data() {
+    let (env, _, client) = setup();
+    let asset = String::from_str(&env, "USDC");
+
+    let result = client.try_latest_price(&asset);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_publish_updates_price() {
+    let (env, admin, client) = setup();
+    let publisher = Address::generate(&env);
+    let asset = String::from_str(&env, "USDC");
+
+    client.add_publisher(&admin, &publisher);
+
+    client.publish_price(&publisher, &asset, &100, &8);
+    let p1 = client.latest_price(&asset);
+    assert_eq!(p1.price, 100);
+
+    client.publish_price(&publisher, &asset, &200, &8);
+    let p2 = client.latest_price(&asset);
+    assert_eq!(p2.price, 200);
+}

--- a/contracts/social_vouching/Cargo.toml
+++ b/contracts/social_vouching/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "social-vouching"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true

--- a/contracts/social_vouching/Makefile
+++ b/contracts/social_vouching/Makefile
@@ -1,0 +1,16 @@
+default: build
+
+all: test
+
+test: build
+	cargo test
+
+build:
+	stellar contract build
+	@ls -l target/wasm32v1-none/release/*.wasm
+
+fmt:
+	cargo fmt --all
+
+clean:
+	cargo clean

--- a/contracts/social_vouching/src/lib.rs
+++ b/contracts/social_vouching/src/lib.rs
@@ -1,0 +1,132 @@
+#![no_std]
+
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, Vec};
+
+pub const CONTRACT_VERSION: &str = "0.1.0";
+const GROUP_TTL_EXTEND: u32 = 6_312_000;
+
+#[cfg(test)]
+mod tests;
+
+// #696: Error codes start at 700 to avoid overlap.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    AlreadyVouched = 700,
+    NotVouched = 701,
+    CannotVouchForSelf = 702,
+    AlreadyInitialized = 703,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    VouchCount(Address),            // subject -> u32
+    HasVouched(Address, Address),   // (voucher, subject) -> bool
+    VoucherList(Address),           // subject -> Vec<Address>
+    Initialized,
+    Admin,
+}
+
+/// SocialVouching is a permissionless contract for community-based trust attestation.
+/// Any address can vouch for any other address, once per pair.
+/// Vouch count is a public, cheap read for frontend display alongside ReputationScore.
+#[contract]
+pub struct SocialVouching;
+
+#[contractimpl]
+impl SocialVouching {
+    pub fn initialize(env: Env, admin: Address) -> Result<(), Error> {
+        if env.storage().persistent().has(&DataKey::Initialized) {
+            return Err(Error::AlreadyInitialized);
+        }
+        env.storage().persistent().set(&DataKey::Initialized, &true);
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+        Ok(())
+    }
+
+    /// Vouch for another address. Permissionless — any address can vouch.
+    /// One vouch per (voucher, subject) pair.
+    pub fn vouch(
+        env: Env,
+        voucher: Address,
+        subject: Address,
+    ) -> Result<u32, Error> {
+        voucher.require_auth();
+
+        if voucher == subject {
+            return Err(Error::CannotVouchForSelf);
+        }
+
+        let vouch_key = DataKey::HasVouched(voucher.clone(), subject.clone());
+        if env.storage().persistent().has(&vouch_key) {
+            return Err(Error::AlreadyVouched);
+        }
+
+        // Record the vouch
+        env.storage().persistent().set(&vouch_key, &true);
+        env.storage().persistent().extend_ttl(&vouch_key, GROUP_TTL_EXTEND, GROUP_TTL_EXTEND);
+
+        // Increment count
+        let count_key = DataKey::VouchCount(subject.clone());
+        let current: u32 = env.storage().persistent().get(&count_key).unwrap_or(0);
+        let new_count = current + 1;
+        env.storage().persistent().set(&count_key, &new_count);
+        env.storage().persistent().extend_ttl(&count_key, GROUP_TTL_EXTEND, GROUP_TTL_EXTEND);
+
+        // Track voucher list for the subject
+        let list_key = DataKey::VoucherList(subject.clone());
+        let mut list: Vec<Address> = env.storage().persistent().get(&list_key).unwrap_or(Vec::new(&env));
+        list.push_back(voucher.clone());
+        env.storage().persistent().set(&list_key, &list);
+
+        env.events().publish(
+            (symbol_short!("vouch"), subject.clone()),
+            (voucher, new_count),
+        );
+
+        Ok(new_count)
+    }
+
+    /// Revoke a vouch. Takes effect immediately.
+    pub fn revoke_vouch(
+        env: Env,
+        voucher: Address,
+        subject: Address,
+    ) -> Result<u32, Error> {
+        voucher.require_auth();
+
+        let vouch_key = DataKey::HasVouched(voucher.clone(), subject.clone());
+        if !env.storage().persistent().has(&vouch_key) {
+            return Err(Error::NotVouched);
+        }
+
+        env.storage().persistent().remove(&vouch_key);
+
+        // Decrement count
+        let count_key = DataKey::VouchCount(subject.clone());
+        let current: u32 = env.storage().persistent().get(&count_key).unwrap_or(0);
+        let new_count = current.saturating_sub(1);
+        env.storage().persistent().set(&count_key, &new_count);
+
+        env.events().publish(
+            (symbol_short!("revoke"), subject.clone()),
+            (voucher, new_count),
+        );
+
+        Ok(new_count)
+    }
+
+    /// Get vouch count for a subject. Cheap read for frontend display.
+    pub fn vouch_count(env: Env, subject: Address) -> u32 {
+        let count_key = DataKey::VouchCount(subject);
+        env.storage().persistent().get(&count_key).unwrap_or(0)
+    }
+
+    /// Check if a voucher has vouched for a subject
+    pub fn has_vouched(env: Env, voucher: Address, subject: Address) -> bool {
+        let vouch_key = DataKey::HasVouched(voucher, subject);
+        env.storage().persistent().has(&vouch_key)
+    }
+}

--- a/contracts/social_vouching/src/tests.rs
+++ b/contracts/social_vouching/src/tests.rs
@@ -1,0 +1,113 @@
+use crate::{SocialVouching, SocialVouchingClient};
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+fn setup() -> (Env, SocialVouchingClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(SocialVouching, ());
+    let client = SocialVouchingClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    (env, client)
+}
+
+#[test]
+fn test_vouch() {
+    let (env, client) = setup();
+    let voucher = Address::generate(&env);
+    let subject = Address::generate(&env);
+
+    let count = client.vouch(&voucher, &subject);
+    assert_eq!(count, 1);
+    assert!(client.has_vouched(&voucher, &subject));
+}
+
+#[test]
+fn test_cannot_vouch_for_self() {
+    let (env, client) = setup();
+    let addr = Address::generate(&env);
+
+    let result = client.try_vouch(&addr, &addr);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_cannot_vouch_twice() {
+    let (env, client) = setup();
+    let voucher = Address::generate(&env);
+    let subject = Address::generate(&env);
+
+    client.vouch(&voucher, &subject);
+    let result = client.try_vouch(&voucher, &subject);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_revoke_vouch() {
+    let (env, client) = setup();
+    let voucher = Address::generate(&env);
+    let subject = Address::generate(&env);
+
+    client.vouch(&voucher, &subject);
+    assert!(client.has_vouched(&voucher, &subject));
+
+    let count = client.revoke_vouch(&voucher, &subject);
+    assert_eq!(count, 0);
+    assert!(!client.has_vouched(&voucher, &subject));
+}
+
+#[test]
+fn test_revoke_nonexistent_fails() {
+    let (env, client) = setup();
+    let voucher = Address::generate(&env);
+    let subject = Address::generate(&env);
+
+    let result = client.try_revoke_vouch(&voucher, &subject);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_vouch_count() {
+    let (env, client) = setup();
+    let subject = Address::generate(&env);
+
+    assert_eq!(client.vouch_count(&subject), 0);
+
+    let v1 = Address::generate(&env);
+    let v2 = Address::generate(&env);
+    client.vouch(&v1, &subject);
+    client.vouch(&v2, &subject);
+
+    assert_eq!(client.vouch_count(&subject), 2);
+}
+
+#[test]
+fn test_permissionless() {
+    let (env, client) = setup();
+    // Anyone can vouch — no admin gating
+    let v1 = Address::generate(&env);
+    let v2 = Address::generate(&env);
+    let subject = Address::generate(&env);
+
+    client.vouch(&v1, &subject);
+    client.vouch(&v2, &subject);
+
+    assert_eq!(client.vouch_count(&subject), 2);
+    assert!(client.has_vouched(&v1, &subject));
+    assert!(client.has_vouched(&v2, &subject));
+}
+
+#[test]
+fn test_vouch_count_decrements_on_revoke() {
+    let (env, client) = setup();
+    let v1 = Address::generate(&env);
+    let v2 = Address::generate(&env);
+    let subject = Address::generate(&env);
+
+    client.vouch(&v1, &subject);
+    client.vouch(&v2, &subject);
+    assert_eq!(client.vouch_count(&subject), 2);
+
+    client.revoke_vouch(&v1, &subject);
+    assert_eq!(client.vouch_count(&subject), 1);
+}


### PR DESCRIPTION
Closes #844, 
closes #845, 
closes #846, 
closes #847

## Summary
Implements four new Soroban smart contracts with non-overlapping error code ranges:

### late_payment_penalty (errors 600-605)
- Admin-configurable grace periods and penalty logic for late group contributions
- Penalty funds route to group pool (not FeeTreasury) to benefit remaining members
- set_penalty_policy, pply_penalty, penalty_pool_balance, get_policy
- 8 tests

### social_vouching (errors 700-702)
- Permissionless vouch/revoke system for community trust attestation
- One vouch per (voucher, subject) pair, public vouch count for frontend display
- ouch, 
evoke_vouch, ouch_count, has_vouched
- 8 tests

### migration_coordinator (errors 800-804)
- Version registry/pointer contract tracking which contract addresses are current
- Admin-managed register/deprecate, frontend single source of truth for version
- 
egister_version, deprecate_version, get_current, get_version_info, get_all_versions
- 8 tests

### oracle_feed (errors 900-904)
- Admin-managed publisher allowlist oracle for price data
- Publishers push signed prices, consumers read latest price
- dd_publisher, 
emove_publisher, publish_price, latest_price
- 6 tests

## Implementation details
- All contracts: \#![no_std]\, persistent storage with TTL extension (\GROUP_TTL_EXTEND = 6_312_000\), checked arithmetic
- Error codes non-overlapping with all existing contracts per #696
- 30 tests total, all passing
- Existing workspace Cargo.toml already includes \contracts/*\, so new contracts auto-included